### PR TITLE
MM-36 - Add Authors to Songs

### DIFF
--- a/app/Livewire/Forms/SongForm.php
+++ b/app/Livewire/Forms/SongForm.php
@@ -13,6 +13,8 @@ class SongForm extends Form
     #[Validate('required|string')]
     public string $name;
 
+    public ?string $authors = null;
+
     public ?string $ccli_number = null;
 
     public ?string $copyright = null;
@@ -24,6 +26,7 @@ class SongForm extends Form
         $this->song = $song;
 
         $this->name = $song->name;
+        $this->authors = $song->authors;
         $this->ccli_number = $song->ccli_number;
         $this->copyright = $song->copyright;
         $this->lyrics = $song->lyrics;
@@ -34,7 +37,7 @@ class SongForm extends Form
         $this->validate();
 
         Song::create(
-            $this->only(['name', 'ccli_number', 'copyright', 'lyrics'])
+            $this->only(['name', 'authors', 'ccli_number', 'copyright', 'lyrics'])
         );
     }
 
@@ -43,7 +46,7 @@ class SongForm extends Form
         $this->validate();
 
         $this->song->update(
-            $this->only(['name', 'ccli_number', 'copyright', 'lyrics'])
+            $this->only(['name', 'authors', 'ccli_number', 'copyright', 'lyrics'])
         );
     }
 }

--- a/app/Models/Song.php
+++ b/app/Models/Song.php
@@ -12,7 +12,7 @@ class Song extends Model
     /** @use HasFactory<\Database\Factories\SongFactory> */
     use HasFactory;
 
-    protected $fillable = ['name', 'ccli_number', 'copyright', 'lyrics'];
+    protected $fillable = ['name', 'authors', 'ccli_number', 'copyright', 'lyrics'];
 
     /**
      * @return HasMany<Recording,Song>

--- a/database/migrations/2025_09_06_025117_add_authors_to_songs_table.php
+++ b/database/migrations/2025_09_06_025117_add_authors_to_songs_table.php
@@ -12,7 +12,7 @@ return new class() extends Migration
     public function up(): void
     {
         Schema::table('songs', function (Blueprint $table) {
-            $table->text('authors')->nullable()->after('title');
+            $table->text('authors')->nullable()->after('name');
         });
     }
 

--- a/database/migrations/2025_09_06_025117_add_authors_to_songs_table.php
+++ b/database/migrations/2025_09_06_025117_add_authors_to_songs_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('songs', function (Blueprint $table) {
+            $table->text('authors')->nullable()->after('title');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('songs', function (Blueprint $table) {
+            $table->dropColumn('authors');
+        });
+    }
+};

--- a/resources/views/livewire/songs/create.blade.php
+++ b/resources/views/livewire/songs/create.blade.php
@@ -35,6 +35,13 @@ new class extends Component {
                 </flux:field>
 
                 <flux:field>
+                    <flux:label>Authors</flux:label>
+                    <flux:input type="text" name="authors" wire:model="form.authors" placeholder="e.g., John Smith, Jane Doe" />
+                    <flux:description>Separate multiple authors with commas</flux:description>
+                    <flux:error name="form.authors" />
+                </flux:field>
+
+                <flux:field>
                     <flux:label>CCLI Number</flux:label>
                     <flux:input type="text" name="ccli_number" wire:model="form.ccli_number" />
                     <flux:error name="form.ccli_number" />

--- a/resources/views/livewire/songs/edit.blade.php
+++ b/resources/views/livewire/songs/edit.blade.php
@@ -63,6 +63,13 @@ new class extends Component {
                     </flux:field>
 
                     <flux:field>
+                        <flux:label>Authors</flux:label>
+                        <flux:input type="text" name="authors" wire:model="form.authors" placeholder="e.g., John Smith, Jane Doe" />
+                        <flux:description>Separate multiple authors with commas</flux:description>
+                        <flux:error name="form.authors" />
+                    </flux:field>
+
+                    <flux:field>
                         <flux:label>CCLI Number</flux:label>
                         <flux:input type="text" name="ccli_number" wire:model="form.ccli_number" />
                         <flux:error name="form.ccli_number" />

--- a/resources/views/livewire/songs/show.blade.php
+++ b/resources/views/livewire/songs/show.blade.php
@@ -50,6 +50,12 @@ new class extends Component {
                     </flux:field>
 
                     <flux:field>
+                        <flux:label>Authors</flux:label>
+                        <flux:input type="text" name="authors" wire:model="form.authors" variant="filled" readonly copyable/>
+                        <flux:error name="form.authors" />
+                    </flux:field>
+
+                    <flux:field>
                         <flux:label>CCLI Number</flux:label>
                         <flux:input type="text" name="ccli_number" wire:model="form.ccli_number" variant="filled" readonly copyable />
                         <flux:error name="form.ccli_number" />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Authors field for songs across create, edit, and details views.
  * Form now loads and persists authors on create and update; authors are optional and support multiple entries (comma-separated).
  * Read-only, copyable display on the details page.

* **Chores**
  * Database schema updated to store authors for songs.

* **Tests**
  * Added tests for creating, updating, optional authors, and details display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->