### PR TITLE
MM-54 - Reading Type for Template Elements

### DIFF
--- a/app/Livewire/Actions/CreateServiceFromTemplate.php
+++ b/app/Livewire/Actions/CreateServiceFromTemplate.php
@@ -23,6 +23,7 @@ class CreateServiceFromTemplate
             foreach ($template->liturgyElements as $element) {
                 $service->liturgyElements()->create([
                     'type' => $element->type,
+                    'reading_type' => $element->reading_type,
                     'order' => $element->order,
                     'name' => $element->name,
                     'description' => $element->description,

--- a/app/Models/LiturgyElement.php
+++ b/app/Models/LiturgyElement.php
@@ -16,6 +16,7 @@ class LiturgyElement extends Model
 
     protected $fillable = [
         'type',
+        'reading_type',
         'order',
         'name',
         'assignee_id',

--- a/resources/views/livewire/elements/reading.blade.php
+++ b/resources/views/livewire/elements/reading.blade.php
@@ -46,7 +46,9 @@ new class extends Component {
     #[Computed]
     public function readings()
     {
-        return Reading::all();
+        return $this->element->reading_type
+            ? Reading::where('type', $this->element->reading_type->value)->get()
+            : Reading::all();
     }
 
     #[Computed]

--- a/resources/views/livewire/templates/edit.blade.php
+++ b/resources/views/livewire/templates/edit.blade.php
@@ -56,7 +56,7 @@ new class extends Component {
         $elements = $this->form->template->liturgyElements();
 
         $this->elementForm->order =
-            $elements->count() === 0 ? 0 : $elements->max("order")->increment();
+            $elements->count() === 0 ? 0 : $elements->max("order") + 1;
 
         $this->elementForm->parent = $this->form->template;
 

--- a/tests/Feature/ReadingTypeFilteringTest.php
+++ b/tests/Feature/ReadingTypeFilteringTest.php
@@ -1,0 +1,71 @@
+<?php
+
+use App\Enums\LiturgyElementType;
+use App\Enums\ReadingType;
+use App\Models\LiturgyElement;
+use App\Models\Reading;
+use App\Models\Service;
+use Livewire\Volt\Volt;
+
+uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+it('filters readings by reading_type when element has reading_type specified', function () {
+    // Create readings of different types
+    $callToWorshipReading = Reading::factory()->create([
+        'title' => 'Call to Worship Reading',
+        'type' => ReadingType::WORSHIP_CALL,
+    ]);
+
+    $lawReading = Reading::factory()->create([
+        'title' => 'Law Reading',
+        'type' => ReadingType::LAW,
+    ]);
+
+    $otherReading = Reading::factory()->create([
+        'title' => 'Other Reading',
+        'type' => ReadingType::CREED,
+    ]);
+
+    // Create a service with a reading element that has a specific reading_type
+    $service = Service::factory()->create();
+    $readingElement = LiturgyElement::factory()->create([
+        'liturgy_type' => Service::class,
+        'liturgy_id' => $service->id,
+        'type' => LiturgyElementType::READING,
+        'reading_type' => ReadingType::WORSHIP_CALL,
+    ]);
+
+    // Test the reading element component
+    $component = Volt::test('elements.reading', ['element' => $readingElement]);
+
+    // The computed readings property should only return readings that match the reading_type
+    $readings = $component->readings;
+
+    expect($readings)->toHaveCount(1);
+    expect($readings->first()->id)->toBe($callToWorshipReading->id);
+    expect($readings->first()->title)->toBe('Call to Worship Reading');
+});
+
+it('returns all readings when element has no reading_type specified', function () {
+    // Create readings of different types
+    Reading::factory()->create(['type' => ReadingType::WORSHIP_CALL]);
+    Reading::factory()->create(['type' => ReadingType::LAW]);
+    Reading::factory()->create(['type' => ReadingType::CREED]);
+
+    // Create a service with a reading element that has no reading_type
+    $service = Service::factory()->create();
+    $readingElement = LiturgyElement::factory()->create([
+        'liturgy_type' => Service::class,
+        'liturgy_id' => $service->id,
+        'type' => LiturgyElementType::READING,
+        'reading_type' => null,
+    ]);
+
+    // Test the reading element component
+    $component = Volt::test('elements.reading', ['element' => $readingElement]);
+
+    // The computed readings property should return all readings
+    $readings = $component->readings;
+
+    expect($readings)->toHaveCount(3);
+});


### PR DESCRIPTION
- Add reading_type to LiturgyElement fillable fields
- Filter reading selection by reading_type in service elements
- Copy reading_type when creating services from templates
- Fix template element ordering logic
- Add comprehensive tests for reading type functionality

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
