### PR TITLE
MM-64 - Template Element Editing

### DIFF
--- a/app/Livewire/Forms/LiturgyElementForm.php
+++ b/app/Livewire/Forms/LiturgyElementForm.php
@@ -102,15 +102,19 @@ class LiturgyElementForm extends Form
     {
         $this->validate();
 
-        $this->element->update(
-            $this->only([
-                'name',
-                'description',
-                'type',
-                'reading_type',
-                'assignee_id',
-                'order',
-            ])
-        );
+        $data = $this->only([
+            'name',
+            'description',
+            'type',
+            'reading_type',
+            'assignee_id',
+            'order',
+        ]);
+
+        if (($data['type'] ?? null) !== LiturgyElementType::READING->value) {
+            $data['reading_type'] = null;
+        }
+
+        $this->element->update($data);
     }
 }

--- a/app/Livewire/Forms/LiturgyElementForm.php
+++ b/app/Livewire/Forms/LiturgyElementForm.php
@@ -55,6 +55,7 @@ class LiturgyElementForm extends Form
                 'string',
                 new Enum(ReadingType::class),
             ],
+            'assignee_id' => 'nullable|integer|exists:users,id',
             'order' => 'integer|min:0|max:1000',
         ];
     }

--- a/app/Livewire/Forms/LiturgyElementForm.php
+++ b/app/Livewire/Forms/LiturgyElementForm.php
@@ -61,13 +61,14 @@ class LiturgyElementForm extends Form
     public function setLiturgyElement(LiturgyElement $element): void
     {
         $this->element = $element;
-        $this->parent = $element->parent;
+        $this->parent = $element->liturgy;
 
         $this->name = $element->name;
         $this->description = $element->description;
         $this->type = $element?->type?->value ?? '';
-        $this->reading_type = $element?->reading_type?->value ?? '';
+        $this->reading_type = $element?->reading_type?->value ?? null;
         $this->order = $element->order;
+        $this->assignee_id = $element->assignee_id;
     }
 
     public function setParent(Template|Service $parent): void

--- a/app/Livewire/Forms/LiturgyElementForm.php
+++ b/app/Livewire/Forms/LiturgyElementForm.php
@@ -50,7 +50,8 @@ class LiturgyElementForm extends Form
                 new Enum(LiturgyElementType::class),
             ],
             'reading_type' => [
-                'nullable',
+                'exclude_unless:type,' . LiturgyElementType::READING->value,
+                'required',
                 'string',
                 new Enum(ReadingType::class),
             ],

--- a/resources/views/livewire/elements/other.blade.php
+++ b/resources/views/livewire/elements/other.blade.php
@@ -33,7 +33,7 @@ new class extends Component {
                     <flux:button variant="ghost" size="sm" icon="ellipsis-horizontal" inset="bottom" />
 
                     <flux:menu class="min-w-32">
-                        <flux:menu.item wire:click="editElement({{ $element->id }})" icon="pencil-square"  class="cursor-default">Edit</flux:menu.item>
+                        <flux:menu.item wire:click="$dispatch('edit-element', { id: {{ $element->id }} })" icon="pencil-square"  class="cursor-default">Edit</flux:menu.item>
                         <flux:menu.item wire:click="delete" icon="trash" variant="danger">Delete</flux:menu.item>
                     </flux:menu>
                 </flux:dropdown>

--- a/resources/views/livewire/elements/other.blade.php
+++ b/resources/views/livewire/elements/other.blade.php
@@ -43,7 +43,7 @@ new class extends Component {
         <flux:modal name="delete-element" class="min-w-[22rem]">
             <form wire:submit="$parent.delete({{ $element->id }})" class="space-y-6">
                 <div>
-                    <flux:heading size="lg">Delete song?</flux:heading>
+                    <flux:heading size="lg">Delete liturgy element?</flux:heading>
 
                     <flux:subheading>
                         <p>This will permanently delete the liturgy element.</p>

--- a/resources/views/livewire/elements/reading.blade.php
+++ b/resources/views/livewire/elements/reading.blade.php
@@ -105,7 +105,7 @@ new class extends Component {
         <flux:modal name="delete-element" class="min-w-[22rem]">
             <form wire:submit="$parent.delete({{ $element->id }})" class="space-y-6">
                 <div>
-                    <flux:heading size="lg">Delete song?</flux:heading>
+                    <flux:heading size="lg">Delete liturgy element?</flux:heading>
 
                     <flux:subheading>
                         <p>This will permanently delete the liturgy element.</p>

--- a/resources/views/livewire/elements/reading.blade.php
+++ b/resources/views/livewire/elements/reading.blade.php
@@ -95,7 +95,7 @@ new class extends Component {
 
                     <flux:menu class="min-w-32">
                         <flux:menu.item href="{{ route('readings.create') }}" icon="plus-circle">New Reading</flux:menu.item>
-                        <flux:menu.item wire:click="editElement({{ $element->id }})" icon="pencil-square"  class="cursor-default">Edit</flux:menu.item>
+                        <flux:menu.item wire:click="$dispatch('edit-element', { id: {{ $element->id }} })" icon="pencil-square"  class="cursor-default">Edit</flux:menu.item>
                         <flux:menu.item wire:click="delete" icon="trash" variant="danger">Delete</flux:menu.item>
                     </flux:menu>
                 </flux:dropdown>

--- a/resources/views/livewire/elements/section.blade.php
+++ b/resources/views/livewire/elements/section.blade.php
@@ -39,7 +39,7 @@ new class extends Component {
         <flux:modal name="delete-element" class="min-w-[22rem]">
             <form wire:submit="$parent.delete({{ $element->id }})" class="space-y-6">
                 <div>
-                    <flux:heading size="lg">Delete song?</flux:heading>
+                    <flux:heading size="lg">Delete liturgy element?</flux:heading>
 
                     <flux:subheading>
                         <p>This will permanently delete the liturgy element.</p>

--- a/resources/views/livewire/elements/section.blade.php
+++ b/resources/views/livewire/elements/section.blade.php
@@ -29,7 +29,7 @@ new class extends Component {
                     <flux:button variant="ghost" size="sm" icon="ellipsis-horizontal" inset="bottom" />
 
                     <flux:menu class="min-w-32">
-                        <flux:menu.item wire:click="editElement({{ $element->id }})" icon="pencil-square"  class="cursor-default">Edit</flux:menu.item>
+                        <flux:menu.item wire:click="$dispatch('edit-element', { id: {{ $element->id }} })" icon="pencil-square"  class="cursor-default">Edit</flux:menu.item>
                         <flux:menu.item wire:click="delete" icon="trash" variant="danger">Delete</flux:menu.item>
                     </flux:menu>
                 </flux:dropdown>

--- a/resources/views/livewire/elements/sermon.blade.php
+++ b/resources/views/livewire/elements/sermon.blade.php
@@ -77,7 +77,7 @@ new class extends Component {
                     <flux:button variant="ghost" size="sm" icon="ellipsis-horizontal" inset="bottom" />
 
                     <flux:menu class="min-w-32">
-                        <flux:menu.item wire:click="editElement({{ $element->id }})" icon="pencil-square"  class="cursor-default">Edit</flux:menu.item>
+                        <flux:menu.item wire:click="$dispatch('edit-element', { id: {{ $element->id }} })" icon="pencil-square"  class="cursor-default">Edit</flux:menu.item>
                         <flux:menu.item wire:click="delete" icon="trash" variant="danger">Delete</flux:menu.item>
                     </flux:menu>
                 </flux:dropdown>

--- a/resources/views/livewire/elements/sermon.blade.php
+++ b/resources/views/livewire/elements/sermon.blade.php
@@ -87,7 +87,7 @@ new class extends Component {
         <flux:modal name="delete-element" class="min-w-[22rem]">
             <form wire:submit="$parent.delete({{ $element->id }})" class="space-y-6">
                 <div>
-                    <flux:heading size="lg">Delete song?</flux:heading>
+                    <flux:heading size="lg">Delete liturgy element?</flux:heading>
 
                     <flux:subheading>
                         <p>This will permanently delete the liturgy element.</p>

--- a/resources/views/livewire/elements/song.blade.php
+++ b/resources/views/livewire/elements/song.blade.php
@@ -89,7 +89,7 @@ new class extends Component {
                     <flux:button variant="ghost" size="sm" icon="ellipsis-horizontal" inset="bottom" />
 
                     <flux:menu class="min-w-32">
-                        <flux:menu.item wire:click="editElement({{ $element->id }})" icon="pencil-square"  class="cursor-default">Edit</flux:menu.item>
+                        <flux:menu.item wire:click="$dispatch('edit-element', { id: {{ $element->id }} })" icon="pencil-square"  class="cursor-default">Edit</flux:menu.item>
                         <flux:menu.item wire:click="delete" icon="trash" variant="danger">Delete</flux:menu.item>
                     </flux:menu>
                 </flux:dropdown>

--- a/resources/views/livewire/templates/elements.blade.php
+++ b/resources/views/livewire/templates/elements.blade.php
@@ -1,7 +1,10 @@
 <?php
 
+use App\Livewire\Forms\LiturgyElementForm;
 use App\Models\LiturgyElement;
 use App\Models\Template;
+use App\Models\User;
+use Livewire\Attributes\Computed;
 use Livewire\Attributes\On;
 use Livewire\Attributes\Reactive;
 use Livewire\Volt\Component;
@@ -11,6 +14,7 @@ new class extends Component {
     public int $templateId;
 
     public Template $template;
+    public LiturgyElementForm $elementForm;
 
     public function mount()
     {
@@ -22,6 +26,12 @@ new class extends Component {
         $this->template = Template::with("liturgyElements")->find(
             $this->templateId,
         );
+    }
+
+    #[Computed]
+    public function users()
+    {
+        return User::all();
     }
 
     #[On("related-model-changed")]
@@ -70,19 +80,87 @@ new class extends Component {
         Flux::modal("delete-element")->close();
         Flux::toast(variant: "danger", text: "Liturgy element deleted.");
     }
+
+    #[On('edit-element')]
+    public function editElement($id): void
+    {
+        $element = LiturgyElement::findOrFail($id);
+        $this->elementForm->setLiturgyElement($element);
+        Flux::modal("edit-element")->show();
+    }
+
+    public function updateElement(): void
+    {
+        $this->elementForm->update();
+        $this->reset("elementForm");
+        $this->loadTemplate();
+        Flux::modal("edit-element")->close();
+        Flux::toast(variant: "success", text: "Element updated.");
+    }
 };
 ?>
 
-<flux:table class="w-full">
-    <flux:table.rows x-sort="$wire.sort($item, $position)">
-        @if($this->template->liturgyElements->isEmpty())
-            <flux:table.row>
-                <flux:table.cell align="center">No Service Elements</flux:table.cell>
-            </flux:table.row>
-        @else
-            @foreach($this->template->liturgyElements as $element)
-                @livewire($element->type->component(), ['element' => $element], key($element->id))
+<div>
+    <flux:table class="w-full">
+        <flux:table.rows x-sort="$wire.sort($item, $position)">
+            @if($this->template->liturgyElements->isEmpty())
+                <flux:table.row>
+                    <flux:table.cell align="center">No Service Elements</flux:table.cell>
+                </flux:table.row>
+            @else
+                @foreach($this->template->liturgyElements as $element)
+                    @livewire($element->type->component(), ['element' => $element], key($element->id))
+                @endforeach
+            @endif
+        </flux:table.rows>
+    </flux:table>
+
+    <flux:modal variant="flyout" name="edit-element">
+    <form wire:submit="updateElement" class="space-y-6">
+        <div>
+            <flux:heading size="lg">Edit Liturgy Element</flux:heading>
+        </div>
+
+        <flux:select label="Type" variant="listbox" wire:model="elementForm.type">
+            @foreach(App\Enums\LiturgyElementType::cases() as $element)
+                <flux:select.option value="{{ $element->value }}">
+                    <div class="flex items-center gap-x-2">
+                        <flux:icon name="{{ $element->icon() }}" />{{ $element->label() }}
+                    </div>
+                </flux:select.option>
             @endforeach
+        </flux:select>
+
+        @if(isset($elementForm->type) && $elementForm->type === App\Enums\LiturgyElementType::READING->value)
+        <flux:select label="Reading Type" variant="listbox" wire:model="elementForm.reading_type">
+            @foreach(App\Enums\ReadingType::cases() as $reading_type)
+                <flux:select.option value="{{ $reading_type->value }}">{{ $reading_type->label() }}</flux:select.option>
+            @endforeach
+        </flux:select>
         @endif
-    </flux:table.rows>
-</flux:table>
+
+        <flux:field>
+            <flux:label for="element_name">Name</flux:label>
+            <flux:input id="element_name" placeholder="Enter a name..." wire:model="elementForm.name" />
+            <flux:error name="elementForm.name" />
+        </flux:field>
+
+        <flux:field>
+            <flux:label for="element_description">Description</flux:label>
+            <flux:input id="element_description" wire:model="elementForm.description" />
+            <flux:error name="elementForm.description" />
+        </flux:field>
+
+        <flux:select label="Assignee" variant="listbox" wire:model="elementForm.assignee_id" placeholder="Select an assignee...">
+            @foreach($this->users as $user)
+                <flux:select.option value="{{ $user->id }}">{{ $user->name }}</flux:select.option>
+            @endforeach
+        </flux:select>
+
+        <div class="flex">
+            <flux:spacer />
+            <flux:button type="submit" variant="primary">Update Element</flux:button>
+        </div>
+    </form>
+    </flux:modal>
+</div>

--- a/resources/views/livewire/templates/elements.blade.php
+++ b/resources/views/livewire/templates/elements.blade.php
@@ -76,7 +76,7 @@ new class extends Component {
 
     public function delete($id): void
     {
-        LiturgyElement::findOrFail($id)->delete();
+        $this->template->liturgyElements()->findOrFail($id)->delete();
         Flux::modal("delete-element")->close();
         Flux::toast(variant: "danger", text: "Liturgy element deleted.");
     }

--- a/resources/views/livewire/templates/elements.blade.php
+++ b/resources/views/livewire/templates/elements.blade.php
@@ -84,7 +84,7 @@ new class extends Component {
     #[On('edit-element')]
     public function editElement($id): void
     {
-        $element = LiturgyElement::findOrFail($id);
+        $element = $this->template->liturgyElements()->findOrFail($id);
         $this->elementForm->setLiturgyElement($element);
         Flux::modal("edit-element")->show();
     }

--- a/tests/Feature/TemplateElementEditTest.php
+++ b/tests/Feature/TemplateElementEditTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\LiturgyElementType;
+use App\Models\LiturgyElement;
+use App\Models\Template;
+use App\Models\User;
+use Livewire\Volt\Volt as LivewireVolt;
+
+uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+test('authenticated users can edit template elements', function (): void {
+    $user = User::factory()->create();
+    $template = Template::factory()->create(['name' => 'Test Template']);
+
+    // Create a liturgy element for the template
+    $element = LiturgyElement::factory()->create([
+        'liturgy_type' => Template::class,
+        'liturgy_id' => $template->id,
+        'type' => LiturgyElementType::SECTION,
+        'name' => 'Original Name',
+        'description' => 'Original Description',
+        'order' => 1,
+    ]);
+
+    $this->actingAs($user);
+
+    // Test editing the element
+    LivewireVolt::test('templates.elements', ['templateId' => $template->id])
+        ->call('editElement', $element->id)
+        ->assertSet('elementForm.name', 'Original Name')
+        ->assertSet('elementForm.description', 'Original Description')
+        ->assertSet('elementForm.type', LiturgyElementType::SECTION->value)
+        ->set('elementForm.name', 'Updated Name')
+        ->set('elementForm.description', 'Updated Description')
+        ->set('elementForm.type', LiturgyElementType::SONG->value)
+        ->call('updateElement')
+        ->assertHasNoErrors();
+
+    // Verify the element was updated in the database
+    $element->refresh();
+    expect($element->name)->toBe('Updated Name');
+    expect($element->description)->toBe('Updated Description');
+    expect($element->type)->toBe(LiturgyElementType::SONG);
+});
+
+test('editing template elements validates required fields', function (): void {
+    $user = User::factory()->create();
+    $template = Template::factory()->create(['name' => 'Test Template']);
+
+    $element = LiturgyElement::factory()->create([
+        'liturgy_type' => Template::class,
+        'liturgy_id' => $template->id,
+        'type' => LiturgyElementType::SECTION,
+        'name' => 'Original Name',
+        'order' => 1,
+    ]);
+
+    $this->actingAs($user);
+
+    // Test validation by setting empty name
+    LivewireVolt::test('templates.elements', ['templateId' => $template->id])
+        ->call('editElement', $element->id)
+        ->set('elementForm.name', '')
+        ->call('updateElement')
+        ->assertHasErrors(['elementForm.name']);
+});
+
+test('editing reading elements shows reading type field', function (): void {
+    $user = User::factory()->create();
+    $template = Template::factory()->create(['name' => 'Test Template']);
+
+    $element = LiturgyElement::factory()->create([
+        'liturgy_type' => Template::class,
+        'liturgy_id' => $template->id,
+        'type' => LiturgyElementType::SECTION,
+        'name' => 'Original Name',
+        'order' => 1,
+    ]);
+
+    $this->actingAs($user);
+
+    // Test that changing to reading type shows reading_type field
+    LivewireVolt::test('templates.elements', ['templateId' => $template->id])
+        ->call('editElement', $element->id)
+        ->set('elementForm.type', LiturgyElementType::READING->value)
+        ->call('$refresh')
+        ->assertSeeHtml('Reading Type');
+});


### PR DESCRIPTION
- Add edit functionality to template elements using flyout modal
- Implement event system for child-parent component communication
- Fix LiturgyElementForm bugs (liturgy relationship, null handling)
- Add comprehensive tests for edit functionality
- Update all element components to dispatch 'edit-element' events
- Support editing name, description, type, reading type, and assignee

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Edit modal for Liturgy Elements with Type, conditional Reading Type, Name, Description, and Assignee; assignee dropdown populated from users; in-place flyout editing with success toast.

* **Bug Fixes**
  * Preserve assignee when loading an element and clear Reading Type automatically when element type is not a reading; Reading Type now defaults to null when appropriate.

* **Refactor**
  * Edit triggers changed to browser events for smoother UI responsiveness.

* **Tests**
  * Added feature tests for editing, validation, and Reading Type behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->