### PR TITLE
Remove unused Resend mail dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,6 @@
         "livewire/flux-pro": "^2.6.1",
         "livewire/livewire": "^4.0",
         "mews/purifier": "^3.4",
-        "resend/resend-laravel": "^0.21.0",
         "spatie/laravel-comments": "^2.1",
         "symfony/http-client": "^7.3",
         "symfony/postmark-mailer": "^7.3"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8f3ffe1c51573ff6879d0f829d39a0ff",
+    "content-hash": "ad5ee70ab32f79e59f62bbaca322df39",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -4072,132 +4072,6 @@
                 "source": "https://github.com/ramsey/uuid/tree/4.9.2"
             },
             "time": "2025-12-14T04:43:48+00:00"
-        },
-        {
-            "name": "resend/resend-laravel",
-            "version": "v0.21.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/resend/resend-laravel.git",
-                "reference": "72deb3fe044a5a0e68e220d86908eeaaa8ecf5db"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/resend/resend-laravel/zipball/72deb3fe044a5a0e68e220d86908eeaaa8ecf5db",
-                "reference": "72deb3fe044a5a0e68e220d86908eeaaa8ecf5db",
-                "shasum": ""
-            },
-            "require": {
-                "illuminate/http": "^10.0|^11.0|^12.0",
-                "illuminate/support": "^10.0|^11.0|^12.0",
-                "php": "^8.1",
-                "resend/resend-php": "^0.19.0",
-                "symfony/mailer": "^6.2|^7.0"
-            },
-            "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.14",
-                "mockery/mockery": "^1.5",
-                "orchestra/testbench": "^8.17|^9.0|^10.0",
-                "pestphp/pest": "^2.0|^3.7"
-            },
-            "type": "library",
-            "extra": {
-                "laravel": {
-                    "providers": [
-                        "Resend\\Laravel\\ResendServiceProvider"
-                    ]
-                },
-                "branch-alias": {
-                    "dev-main": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Resend\\Laravel\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Resend and contributors",
-                    "homepage": "https://github.com/resend/resend-laravel/contributors"
-                }
-            ],
-            "description": "Resend for Laravel",
-            "homepage": "https://resend.com/",
-            "keywords": [
-                "api",
-                "client",
-                "laravel",
-                "php",
-                "resend",
-                "sdk"
-            ],
-            "support": {
-                "issues": "https://github.com/resend/resend-laravel/issues",
-                "source": "https://github.com/resend/resend-laravel/tree/v0.21.0"
-            },
-            "time": "2025-08-13T04:57:39+00:00"
-        },
-        {
-            "name": "resend/resend-php",
-            "version": "v0.19.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/resend/resend-php.git",
-                "reference": "b2fc34593c7b8ff7b202f3fcc20f33ce55dde424"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/resend/resend-php/zipball/b2fc34593c7b8ff7b202f3fcc20f33ce55dde424",
-                "reference": "b2fc34593c7b8ff7b202f3fcc20f33ce55dde424",
-                "shasum": ""
-            },
-            "require": {
-                "guzzlehttp/guzzle": "^7.5",
-                "php": "^8.1.0"
-            },
-            "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.13",
-                "mockery/mockery": "^1.6",
-                "pestphp/pest": "^2.0"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "src/Resend.php"
-                ],
-                "psr-4": {
-                    "Resend\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Resend and contributors",
-                    "homepage": "https://github.com/resend/resend-php/contributors"
-                }
-            ],
-            "description": "Resend PHP library.",
-            "homepage": "https://resend.com/",
-            "keywords": [
-                "api",
-                "client",
-                "php",
-                "resend",
-                "sdk"
-            ],
-            "support": {
-                "issues": "https://github.com/resend/resend-php/issues",
-                "source": "https://github.com/resend/resend-php/tree/v0.19.1"
-            },
-            "time": "2025-08-06T04:57:27+00:00"
         },
         {
             "name": "spatie/laravel-comments",

--- a/config/mail.php
+++ b/config/mail.php
@@ -30,7 +30,7 @@ return [
     | your mailers below. You may also add additional mailers if needed.
     |
     | Supported: "smtp", "sendmail", "mailgun", "ses", "ses-v2",
-    |            "postmark", "resend", "log", "array",
+    |            "postmark", "log", "array",
     |            "failover", "roundrobin"
     |
     */
@@ -59,10 +59,6 @@ return [
             // 'client' => [
             //     'timeout' => 5,
             // ],
-        ],
-
-        'resend' => [
-            'transport' => 'resend',
         ],
 
         'sendmail' => [

--- a/config/services.php
+++ b/config/services.php
@@ -24,10 +24,6 @@ return [
         'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
     ],
 
-    'resend' => [
-        'key' => env('RESEND_KEY'),
-    ],
-
     'slack' => [
         'notifications' => [
             'bot_user_oauth_token' => env('SLACK_BOT_USER_OAUTH_TOKEN'),


### PR DESCRIPTION
## Summary
- Drops `resend/resend-laravel` (and the transitive `resend/resend-php`) from `composer.json` / `composer.lock`. Resend was only present as default Laravel scaffolding — production mail goes through Postmark and `MAIL_MAILER` defaults to `log`.
- Removes the corresponding dead config: the `'resend'` block in `config/services.php` and the `'resend'` mailer in `config/mail.php` (with a matching update to the supported-transports comment).
- This is the first step of a staged Laravel 13 upgrade; landing it independently shrinks the dependency surface before the framework bump.

## Test plan
- [x] `npm run pest` — 207 passed, 2 skipped
- [x] `npm run larastan` — no errors
- [x] `vendor/bin/pint --dirty` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed Resend email service integration from the project, including its dependency package, mailer configuration, and service settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->