### PR TITLE
Require and normalize series order on readings

### DIFF
--- a/app/Livewire/Forms/ReadingForm.php
+++ b/app/Livewire/Forms/ReadingForm.php
@@ -45,6 +45,7 @@ class ReadingForm extends Form
 
     public function store(): void
     {
+        $this->normalizeSeries();
         $this->validate();
 
         Reading::create($this->only(['title', 'type', 'text', 'series_id', 'series_order']));
@@ -52,10 +53,18 @@ class ReadingForm extends Form
 
     public function update(): void
     {
+        $this->normalizeSeries();
         $this->validate();
 
         $this->reading->update(
             $this->only(['title', 'type', 'text', 'series_id', 'series_order'])
         );
+    }
+
+    private function normalizeSeries(): void
+    {
+        if ($this->series_id === null) {
+            $this->series_order = null;
+        }
     }
 }

--- a/resources/views/pages/readings/create.blade.php
+++ b/resources/views/pages/readings/create.blade.php
@@ -48,19 +48,18 @@ new class extends Component {
                     @endforeach
                 </flux:select>
 
-                <flux:select variant="listbox" label="Series" wire:model="form.series_id" placeholder="No series" clearable>
+                <flux:select variant="listbox" label="Series" wire:model.live="form.series_id" placeholder="No series" clearable>
                     @foreach($this->seriesList as $seriesItem)
                         <flux:select.option value="{{ $seriesItem->id }}">{{ $seriesItem->name }}</flux:select.option>
                     @endforeach
                 </flux:select>
 
-                @if($form->series_id)
-                    <flux:field>
-                        <flux:label>Order in Series</flux:label>
-                        <flux:input type="number" wire:model="form.series_order" min="1" />
-                        <flux:description>Position of this reading in the series</flux:description>
-                    </flux:field>
-                @endif
+                <flux:field>
+                    <flux:label :badge="$form->series_id ? 'Required' : null">Order in Series</flux:label>
+                    <flux:input type="number" wire:model="form.series_order" min="1" :disabled="! $form->series_id" />
+                    <flux:description>Position of this reading in the series</flux:description>
+                    <flux:error name="form.series_order" />
+                </flux:field>
 
                 <flux:editor label="Text" wire:model="form.text" toolbar="heading | bold italic underline ~ undo redo" class="**:data-[slot=content]:min-h-[400px]" />
 

--- a/resources/views/pages/readings/edit.blade.php
+++ b/resources/views/pages/readings/edit.blade.php
@@ -82,13 +82,12 @@ new class extends Component {
                         @endforeach
                     </flux:select>
 
-                    @if($form->series_id)
-                        <flux:field>
-                            <flux:label>Order in Series</flux:label>
-                            <flux:input type="number" wire:model="form.series_order" min="1" />
-                            <flux:description>Position of this reading in the series</flux:description>
-                        </flux:field>
-                    @endif
+                    <flux:field>
+                        <flux:label :badge="$form->series_id ? 'Required' : null">Order in Series</flux:label>
+                        <flux:input type="number" wire:model="form.series_order" min="1" :disabled="! $form->series_id" />
+                        <flux:description>Position of this reading in the series</flux:description>
+                        <flux:error name="form.series_order" />
+                    </flux:field>
 
                     <div class="flex space-x-2">
                         <flux:button type="submit" variant="primary">Save</flux:button>

--- a/tests/Feature/ReadingsTest.php
+++ b/tests/Feature/ReadingsTest.php
@@ -73,6 +73,61 @@ test('authenticated users can create a reading', function (): void {
     $this->assertDatabaseHas('readings', ['title' => 'Test Reading']);
 });
 
+test('authenticated users can create a reading within a series', function (): void {
+    $user = User::factory()->create();
+    $series = Series::factory()->create(['name' => 'Advent Series']);
+    $this->actingAs($user);
+
+    Livewire::test('pages::readings.create')
+        ->set('form.title', 'Week One')
+        ->set('form.type', ReadingType::CREED->value)
+        ->set('form.series_id', $series->id)
+        ->set('form.series_order', 1)
+        ->call('save')
+        ->assertHasNoErrors()
+        ->assertRedirect('/readings');
+
+    $this->assertDatabaseHas('readings', [
+        'title' => 'Week One',
+        'series_id' => $series->id,
+        'series_order' => 1,
+    ]);
+});
+
+test('series_order is required when a series is selected', function (): void {
+    $user = User::factory()->create();
+    $series = Series::factory()->create();
+    $this->actingAs($user);
+
+    Livewire::test('pages::readings.create')
+        ->set('form.title', 'Week One')
+        ->set('form.type', ReadingType::CREED->value)
+        ->set('form.series_id', $series->id)
+        ->call('save')
+        ->assertHasErrors(['form.series_order' => 'required_with']);
+});
+
+test('series_order is cleared when series_id is cleared on save', function (): void {
+    $user = User::factory()->create();
+    $series = Series::factory()->create();
+    $reading = Reading::factory()->create([
+        'title' => 'Existing Reading',
+        'series_id' => $series->id,
+        'series_order' => 3,
+    ]);
+    $this->actingAs($user);
+
+    Livewire::test('pages::readings.edit', ['reading' => $reading->id])
+        ->set('form.series_id', null)
+        ->call('save')
+        ->assertHasNoErrors()
+        ->assertRedirect('/readings');
+
+    $reading->refresh();
+    expect($reading->series_id)->toBeNull();
+    expect($reading->series_order)->toBeNull();
+});
+
 test('guests are redirected from the reading show page', function (): void {
     $reading = Reading::create([
         'title' => 'Test Reading',


### PR DESCRIPTION
## Summary
- Require an order value when a reading is assigned to a series, with server-side normalization that nulls `series_order` whenever `series_id` is cleared.
- Replace the conditional order-in-series field with an always-rendered `flux:field` whose `Required` badge and disabled state react to the selected series via `wire:model.live`.
- Add tests covering the create-with-series path, the `required_with` validation, and the clear-on-edit normalization.

## Test plan
- [x] `php artisan test --compact tests/Feature/ReadingsTest.php`
- [x] `vendor/bin/pint --dirty --format agent`

🤖 Generated with [Claude Code](https://claude.com/claude-code)