### PR TITLE
Fix sermon description not saving on blur

### DIFF
--- a/resources/views/livewire/elements/sermon.blade.php
+++ b/resources/views/livewire/elements/sermon.blade.php
@@ -73,7 +73,7 @@ new class extends Component {
                 </flux:select>
             </div>
             <div class="md:w-[226px]">
-                <flux:input size="sm" placeholder="Enter title or reference" wire:model.blur="description" />
+                <flux:input size="sm" placeholder="Enter title or reference" wire:model.live.blur="description" />
             </div>
             <div class="hidden md:block md:pr-2">
                 <flux:dropdown align="end" offset="-15">


### PR DESCRIPTION
## Summary
- Livewire 4.1 changed `wire:model.blur` so it only syncs client-side state on blur and no longer issues a network request, which silently broke the sermon element: typing a description and tabbing away never reached the server, so the `updated()` hook never fired and the value was never persisted.
- Restore the prior save-on-blur behavior by binding the input with `wire:model.live.blur="description"` in `resources/views/livewire/elements/sermon.blade.php`. This is the only `wire:model.blur` binding in the project, so the fix is self-contained.

## Test plan
- [ ] Open a service that includes a sermon element on `https://stave.test`, type a description, tab/click away, and confirm the "Sermon description saved." toast appears and the value persists after reload.
- [ ] Clear the description, blur, and confirm the empty value also persists.
- [ ] Sanity-check the assignee dropdown on the same row still saves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)