### PR TITLE
Lift assignee user list to parent element components

### DIFF
--- a/resources/views/livewire/elements/reading.blade.php
+++ b/resources/views/livewire/elements/reading.blade.php
@@ -2,18 +2,23 @@
 
 use App\Models\LiturgyElement;
 use App\Models\Reading;
-use App\Models\User;
+use Illuminate\Support\Collection;
 use Livewire\Attributes\Computed;
+use Livewire\Attributes\Locked;
 use Livewire\Component;
 
 new class extends Component {
     public LiturgyElement $element;
 
+    #[Locked]
+    public Collection $users;
+
     public $selectedContent;
     public $assigneeId;
 
-    public function mount(): void
+    public function mount(?Collection $users = null): void
     {
+        $this->users = $users ?? collect();
         $this->selectedContent = $this->element->content_id;
         $this->assigneeId = $this->element->assignee_id;
     }
@@ -56,12 +61,6 @@ new class extends Component {
             ? Reading::where('type', $this->element->reading_type)->orderBy('title')->get()
             : Reading::orderBy('title')->get();
     }
-
-    #[Computed]
-    public function users()
-    {
-        return User::all();
-    }
 };
 ?>
 
@@ -84,7 +83,7 @@ new class extends Component {
             </div>
             <div>
                 <flux:select variant="combobox" size="sm" wire:model.live="assigneeId" placeholder="Assign element...">
-                    @foreach($this->users as $user)
+                    @foreach($users as $user)
                         <flux:select.option value="{{ $user->id }}">{{ $user->name }}</flux:select.option>
                     @endforeach
                 </flux:select>

--- a/resources/views/livewire/elements/sermon.blade.php
+++ b/resources/views/livewire/elements/sermon.blade.php
@@ -1,18 +1,22 @@
 <?php
 
 use App\Models\LiturgyElement;
-use App\Models\User;
-use Livewire\Attributes\Computed;
+use Illuminate\Support\Collection;
+use Livewire\Attributes\Locked;
 use Livewire\Component;
 
 new class extends Component {
     public LiturgyElement $element;
 
+    #[Locked]
+    public Collection $users;
+
     public $description;
     public $assigneeId;
 
-    public function mount(): void
+    public function mount(?Collection $users = null): void
     {
+        $this->users = $users ?? collect();
         $this->description = $this->element->description;
         $this->assigneeId = $this->element->assignee_id;
     }
@@ -42,12 +46,6 @@ new class extends Component {
     {
         $this->modal("delete-element")->show();
     }
-
-    #[Computed]
-    public function users()
-    {
-        return User::all();
-    }
 };
 ?>
 
@@ -67,8 +65,8 @@ new class extends Component {
             </div>
             <div>
                 <flux:select variant="combobox" size="sm" wire:model.live="assigneeId" placeholder="Assign element...">
-                    @foreach($this->users as $user)
-                        <flux:select.option value="{{ $user->id }}">{{ $user->name }}</flux:option>
+                    @foreach($users as $user)
+                        <flux:select.option value="{{ $user->id }}">{{ $user->name }}</flux:select.option>
                     @endforeach
                 </flux:select>
             </div>

--- a/resources/views/livewire/elements/song.blade.php
+++ b/resources/views/livewire/elements/song.blade.php
@@ -2,18 +2,23 @@
 
 use App\Models\LiturgyElement;
 use App\Models\Song;
-use App\Models\User;
+use Illuminate\Support\Collection;
 use Livewire\Attributes\Computed;
+use Livewire\Attributes\Locked;
 use Livewire\Component;
 
 new class extends Component {
     public LiturgyElement $element;
 
+    #[Locked]
+    public Collection $users;
+
     public $selectedContent;
     public $assigneeId;
 
-    public function mount(): void
+    public function mount(?Collection $users = null): void
     {
+        $this->users = $users ?? collect();
         $this->selectedContent = $this->element->content_id;
         $this->assigneeId = $this->element->assignee_id;
     }
@@ -51,12 +56,6 @@ new class extends Component {
     {
         return Song::all();
     }
-
-    #[Computed]
-    public function users()
-    {
-        return User::all();
-    }
 };
 ?>
 
@@ -79,7 +78,7 @@ new class extends Component {
             </div>
             <div>
                 <flux:select variant="combobox" size="sm" wire:model.live="assigneeId" placeholder="Assign element...">
-                    @foreach($this->users as $user)
+                    @foreach($users as $user)
                         <flux:select.option value="{{ $user->id }}">{{ $user->name }}</flux:select.option>
                     @endforeach
                 </flux:select>

--- a/resources/views/livewire/services/elements.blade.php
+++ b/resources/views/livewire/services/elements.blade.php
@@ -2,7 +2,9 @@
 
 use App\Models\LiturgyElement;
 use App\Models\Service;
+use App\Models\User;
 use Illuminate\Support\Facades\DB;
+use Livewire\Attributes\Computed;
 use Livewire\Attributes\On;
 use Livewire\Attributes\Reactive;
 use Livewire\Component;
@@ -23,6 +25,12 @@ new class extends Component {
         $this->service = Service::with("liturgyElements")->find(
             $this->serviceId,
         );
+    }
+
+    #[Computed]
+    public function users()
+    {
+        return User::orderBy("name")->get();
     }
 
     #[On("service-element-changed")]
@@ -82,7 +90,7 @@ new class extends Component {
             </flux:table.row>
         @else
             @foreach($this->service->liturgyElements as $element)
-                @livewire($element->type->component(), ['element' => $element], key($element->id))
+                @livewire($element->type->component(), ['element' => $element, 'users' => $this->users], key($element->id))
             @endforeach
         @endif
     </flux:table.rows>

--- a/resources/views/livewire/templates/elements.blade.php
+++ b/resources/views/livewire/templates/elements.blade.php
@@ -33,7 +33,7 @@ new class extends Component {
     #[Computed]
     public function users()
     {
-        return User::all();
+        return User::orderBy("name")->get();
     }
 
     #[On("service-element-changed")]
@@ -111,7 +111,7 @@ new class extends Component {
                 </flux:table.row>
             @else
                 @foreach($this->template->liturgyElements as $element)
-                    @livewire($element->type->component(), ['element' => $element], key($element->id))
+                    @livewire($element->type->component(), ['element' => $element, 'users' => $this->users], key($element->id))
                 @endforeach
             @endif
         </flux:table.rows>


### PR DESCRIPTION
## Summary
- Hoist the `User::all()` lookup out of each per-element Livewire component (`song`/`reading`/`sermon`) into the `services/elements` and `templates/elements` parents, then pass the collection down via a `#[Locked]` property so users are loaded once per page instead of once per element.
- Order users by name for a stable, alphabetized assignee dropdown.
- Fix a stray `</flux:option>` closing tag in the sermon view (should be `</flux:select.option>`).

## Test plan
- [ ] Open a service and confirm the assignee dropdown on each element is populated and alphabetized.
- [ ] Open a template and confirm the same.
- [ ] Verify selecting an assignee on a song/reading/sermon element saves correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized user data fetching for assignee selection components by centralizing the retrieval at the parent level and passing pre-sorted data to child components.

* **New Features**
  * Users in assignee dropdowns are now consistently sorted alphabetically by name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->