### PR TITLE
Add server-side search to song and reading element selectors

### DIFF
--- a/resources/views/livewire/elements/reading.blade.php
+++ b/resources/views/livewire/elements/reading.blade.php
@@ -15,6 +15,7 @@ new class extends Component {
 
     public $selectedContent;
     public $assigneeId;
+    public string $search = '';
 
     public function mount(?Collection $users = null): void
     {
@@ -55,11 +56,29 @@ new class extends Component {
     }
 
     #[Computed]
-    public function readings()
+    public function readings(): Collection
     {
-        return $this->element->reading_type
-            ? Reading::where('type', $this->element->reading_type)->orderBy('title')->get()
-            : Reading::orderBy('title')->get();
+        $query = Reading::query()->orderBy('title');
+
+        if ($this->element->reading_type) {
+            $query->where('type', $this->element->reading_type);
+        }
+
+        if ($this->search !== '') {
+            $query->where('title', 'like', '%' . $this->search . '%');
+        }
+
+        $readings = $query->limit(50)->get();
+
+        if ($this->selectedContent && ! $readings->contains('id', $this->selectedContent)) {
+            $selected = Reading::find($this->selectedContent);
+
+            if ($selected) {
+                $readings = $readings->prepend($selected);
+            }
+        }
+
+        return $readings;
     }
 };
 ?>
@@ -89,9 +108,20 @@ new class extends Component {
                 </flux:select>
             </div>
             <div>
-                <flux:select variant="combobox" size="sm" wire:model.live="selectedContent" placeholder="Select a reading...">
+                <flux:select
+                    variant="listbox"
+                    searchable
+                    :filter="false"
+                    size="sm"
+                    wire:model.live="selectedContent"
+                    placeholder="Select a reading..."
+                >
+                    <x-slot:search>
+                        <flux:select.search wire:model.live.debounce.300ms="search" placeholder="Search readings..." />
+                    </x-slot:search>
+
                     @foreach($this->readings as $reading)
-                        <flux:select.option value="{{ $reading->id }}">{{ $reading->title }}</flux:select.option>
+                        <flux:select.option :value="$reading->id" wire:key="reading-option-{{ $reading->id }}">{{ $reading->title }}</flux:select.option>
                     @endforeach
                 </flux:select>
             </div>

--- a/resources/views/livewire/elements/song.blade.php
+++ b/resources/views/livewire/elements/song.blade.php
@@ -15,6 +15,7 @@ new class extends Component {
 
     public $selectedContent;
     public $assigneeId;
+    public string $search = '';
 
     public function mount(?Collection $users = null): void
     {
@@ -52,9 +53,25 @@ new class extends Component {
     }
 
     #[Computed]
-    public function songs()
+    public function songs(): Collection
     {
-        return Song::all();
+        $query = Song::query()->orderBy('name');
+
+        if ($this->search !== '') {
+            $query->where('name', 'like', '%' . $this->search . '%');
+        }
+
+        $songs = $query->limit(50)->get();
+
+        if ($this->selectedContent && ! $songs->contains('id', $this->selectedContent)) {
+            $selected = Song::find($this->selectedContent);
+
+            if ($selected) {
+                $songs = $songs->prepend($selected);
+            }
+        }
+
+        return $songs;
     }
 };
 ?>
@@ -84,9 +101,20 @@ new class extends Component {
                 </flux:select>
             </div>
             <div>
-                <flux:select variant="combobox" size="sm" wire:model.live="selectedContent" placeholder="Select a song...">
+                <flux:select
+                    variant="listbox"
+                    searchable
+                    :filter="false"
+                    size="sm"
+                    wire:model.live="selectedContent"
+                    placeholder="Select a song..."
+                >
+                    <x-slot:search>
+                        <flux:select.search wire:model.live.debounce.300ms="search" placeholder="Search songs..." />
+                    </x-slot:search>
+
                     @foreach($this->songs as $song)
-                        <flux:select.option value="{{ $song->id }}">{{ $song->name }}</flux:select.option>
+                        <flux:select.option :value="$song->id" wire:key="song-option-{{ $song->id }}">{{ $song->name }}</flux:select.option>
                     @endforeach
                 </flux:select>
             </div>

--- a/tests/Feature/ElementSearchTest.php
+++ b/tests/Feature/ElementSearchTest.php
@@ -1,0 +1,143 @@
+<?php
+
+use App\Enums\LiturgyElementType;
+use App\Enums\ReadingType;
+use App\Models\LiturgyElement;
+use App\Models\Reading;
+use App\Models\Service;
+use App\Models\Song;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+it('filters songs by search term', function (): void {
+    Song::factory()->create(['name' => 'Amazing Grace']);
+    Song::factory()->create(['name' => 'How Great Thou Art']);
+    Song::factory()->create(['name' => 'Be Thou My Vision']);
+
+    $service = Service::factory()->create();
+    $element = LiturgyElement::factory()->create([
+        'liturgy_type' => Service::class,
+        'liturgy_id' => $service->id,
+        'type' => LiturgyElementType::SONG,
+    ]);
+
+    $songs = Livewire::test('elements.song', ['element' => $element])
+        ->set('search', 'Grace')
+        ->get('songs');
+
+    expect($songs)->toHaveCount(1);
+    expect($songs->first()->name)->toBe('Amazing Grace');
+});
+
+it('limits song results to 50', function (): void {
+    Song::factory()->count(60)->create();
+
+    $service = Service::factory()->create();
+    $element = LiturgyElement::factory()->create([
+        'liturgy_type' => Service::class,
+        'liturgy_id' => $service->id,
+        'type' => LiturgyElementType::SONG,
+    ]);
+
+    $songs = Livewire::test('elements.song', ['element' => $element])->get('songs');
+
+    expect($songs)->toHaveCount(50);
+});
+
+it('keeps the selected song in the list when the search would exclude it', function (): void {
+    $selected = Song::factory()->create(['name' => 'Selected Song']);
+    Song::factory()->create(['name' => 'Other Song']);
+
+    $service = Service::factory()->create();
+    $element = LiturgyElement::factory()->create([
+        'liturgy_type' => Service::class,
+        'liturgy_id' => $service->id,
+        'type' => LiturgyElementType::SONG,
+        'content_type' => Song::class,
+        'content_id' => $selected->id,
+    ]);
+
+    $songs = Livewire::test('elements.song', ['element' => $element])
+        ->set('search', 'Other')
+        ->get('songs');
+
+    expect($songs->pluck('id'))->toContain($selected->id);
+});
+
+it('filters readings by search term', function (): void {
+    Reading::factory()->create(['title' => 'Psalm 23', 'type' => ReadingType::PRAISE]);
+    Reading::factory()->create(['title' => 'Psalm 100', 'type' => ReadingType::PRAISE]);
+    Reading::factory()->create(['title' => 'Romans 8', 'type' => ReadingType::PRAISE]);
+
+    $service = Service::factory()->create();
+    $element = LiturgyElement::factory()->create([
+        'liturgy_type' => Service::class,
+        'liturgy_id' => $service->id,
+        'type' => LiturgyElementType::READING,
+    ]);
+
+    $readings = Livewire::test('elements.reading', ['element' => $element])
+        ->set('search', 'Psalm')
+        ->get('readings');
+
+    expect($readings)->toHaveCount(2);
+    expect($readings->pluck('title')->all())->toEqualCanonicalizing(['Psalm 23', 'Psalm 100']);
+});
+
+it('combines reading_type filter with search term', function (): void {
+    $match = Reading::factory()->create([
+        'title' => 'Benediction Verse',
+        'type' => ReadingType::BENEDICTION,
+    ]);
+    Reading::factory()->create([
+        'title' => 'Benediction Other',
+        'type' => ReadingType::CREED,
+    ]);
+    Reading::factory()->create([
+        'title' => 'Different Title',
+        'type' => ReadingType::BENEDICTION,
+    ]);
+
+    $service = Service::factory()->create();
+    $element = LiturgyElement::factory()->create([
+        'liturgy_type' => Service::class,
+        'liturgy_id' => $service->id,
+        'type' => LiturgyElementType::READING,
+        'reading_type' => ReadingType::BENEDICTION,
+    ]);
+
+    $readings = Livewire::test('elements.reading', ['element' => $element])
+        ->set('search', 'Benediction')
+        ->get('readings');
+
+    expect($readings)->toHaveCount(1);
+    expect($readings->first()->id)->toBe($match->id);
+});
+
+it('keeps the selected reading in the list when the search would exclude it', function (): void {
+    $selected = Reading::factory()->create([
+        'title' => 'Selected Reading',
+        'type' => ReadingType::PRAYER,
+    ]);
+    Reading::factory()->create([
+        'title' => 'Other Reading',
+        'type' => ReadingType::PRAYER,
+    ]);
+
+    $service = Service::factory()->create();
+    $element = LiturgyElement::factory()->create([
+        'liturgy_type' => Service::class,
+        'liturgy_id' => $service->id,
+        'type' => LiturgyElementType::READING,
+        'content_type' => Reading::class,
+        'content_id' => $selected->id,
+    ]);
+
+    $readings = Livewire::test('elements.reading', ['element' => $element])
+        ->set('search', 'Other')
+        ->get('readings');
+
+    expect($readings->pluck('id'))->toContain($selected->id);
+});


### PR DESCRIPTION
## Summary
- Replace the per-element song/reading combobox (which loaded every record) with a searchable Flux listbox backed by a server-side query capped at 50 rows.
- Preserve the active selection by prepending the currently selected song/reading when the search would otherwise exclude it, and set `:filter=\"false\"` so Flux's client-side filter doesn't hide it.
- Add feature tests covering search filtering, the 50-row cap, the reading_type + search combination, and selection preservation.

## Test plan
- [x] `php artisan test tests/Feature/ElementSearchTest.php tests/Feature/ReadingTypeFilteringTest.php --compact`
- [ ] Manually verify that opening a service with >50 songs/readings loads quickly and that the selected item remains visible after typing an unrelated search term.

🤖 Generated with [Claude Code](https://claude.com/claude-code)