### PR TITLE
Fix listbox layout and skip preloading element selectors

### DIFF
--- a/resources/views/livewire/elements/reading.blade.php
+++ b/resources/views/livewire/elements/reading.blade.php
@@ -58,17 +58,19 @@ new class extends Component {
     #[Computed]
     public function readings(): Collection
     {
-        $query = Reading::query()->orderBy('title');
-
-        if ($this->element->reading_type) {
-            $query->where('type', $this->element->reading_type);
-        }
+        $readings = collect();
 
         if ($this->search !== '') {
-            $query->where('title', 'like', '%' . $this->search . '%');
-        }
+            $query = Reading::query()
+                ->where('title', 'like', '%' . $this->search . '%')
+                ->orderBy('title');
 
-        $readings = $query->limit(50)->get();
+            if ($this->element->reading_type) {
+                $query->where('type', $this->element->reading_type);
+            }
+
+            $readings = $query->limit(50)->get();
+        }
 
         if ($this->selectedContent && ! $readings->contains('id', $this->selectedContent)) {
             $selected = Reading::find($this->selectedContent);
@@ -107,7 +109,7 @@ new class extends Component {
                     @endforeach
                 </flux:select>
             </div>
-            <div>
+            <div class="md:w-[226px]">
                 <flux:select
                     variant="listbox"
                     searchable

--- a/resources/views/livewire/elements/song.blade.php
+++ b/resources/views/livewire/elements/song.blade.php
@@ -55,13 +55,15 @@ new class extends Component {
     #[Computed]
     public function songs(): Collection
     {
-        $query = Song::query()->orderBy('name');
+        $songs = collect();
 
         if ($this->search !== '') {
-            $query->where('name', 'like', '%' . $this->search . '%');
+            $songs = Song::query()
+                ->where('name', 'like', '%' . $this->search . '%')
+                ->orderBy('name')
+                ->limit(50)
+                ->get();
         }
-
-        $songs = $query->limit(50)->get();
 
         if ($this->selectedContent && ! $songs->contains('id', $this->selectedContent)) {
             $selected = Song::find($this->selectedContent);
@@ -100,7 +102,7 @@ new class extends Component {
                     @endforeach
                 </flux:select>
             </div>
-            <div>
+            <div class="md:w-[226px]">
                 <flux:select
                     variant="listbox"
                     searchable

--- a/tests/Feature/ElementSearchTest.php
+++ b/tests/Feature/ElementSearchTest.php
@@ -32,7 +32,27 @@ it('filters songs by search term', function (): void {
 });
 
 it('limits song results to 50', function (): void {
-    Song::factory()->count(60)->create();
+    Song::factory()
+        ->count(60)
+        ->sequence(fn ($sequence) => ['name' => "Hymn {$sequence->index}"])
+        ->create();
+
+    $service = Service::factory()->create();
+    $element = LiturgyElement::factory()->create([
+        'liturgy_type' => Service::class,
+        'liturgy_id' => $service->id,
+        'type' => LiturgyElementType::SONG,
+    ]);
+
+    $songs = Livewire::test('elements.song', ['element' => $element])
+        ->set('search', 'Hymn')
+        ->get('songs');
+
+    expect($songs)->toHaveCount(50);
+});
+
+it('does not preload songs when no search term is entered', function (): void {
+    Song::factory()->count(10)->create();
 
     $service = Service::factory()->create();
     $element = LiturgyElement::factory()->create([
@@ -43,7 +63,26 @@ it('limits song results to 50', function (): void {
 
     $songs = Livewire::test('elements.song', ['element' => $element])->get('songs');
 
-    expect($songs)->toHaveCount(50);
+    expect($songs)->toBeEmpty();
+});
+
+it('returns only the selected song when no search term is entered', function (): void {
+    $selected = Song::factory()->create(['name' => 'Selected Song']);
+    Song::factory()->count(10)->create();
+
+    $service = Service::factory()->create();
+    $element = LiturgyElement::factory()->create([
+        'liturgy_type' => Service::class,
+        'liturgy_id' => $service->id,
+        'type' => LiturgyElementType::SONG,
+        'content_type' => Song::class,
+        'content_id' => $selected->id,
+    ]);
+
+    $songs = Livewire::test('elements.song', ['element' => $element])->get('songs');
+
+    expect($songs)->toHaveCount(1);
+    expect($songs->first()->id)->toBe($selected->id);
 });
 
 it('keeps the selected song in the list when the search would exclude it', function (): void {
@@ -114,6 +153,43 @@ it('combines reading_type filter with search term', function (): void {
 
     expect($readings)->toHaveCount(1);
     expect($readings->first()->id)->toBe($match->id);
+});
+
+it('does not preload readings when no search term is entered', function (): void {
+    Reading::factory()->count(10)->create();
+
+    $service = Service::factory()->create();
+    $element = LiturgyElement::factory()->create([
+        'liturgy_type' => Service::class,
+        'liturgy_id' => $service->id,
+        'type' => LiturgyElementType::READING,
+    ]);
+
+    $readings = Livewire::test('elements.reading', ['element' => $element])->get('readings');
+
+    expect($readings)->toBeEmpty();
+});
+
+it('returns only the selected reading when no search term is entered', function (): void {
+    $selected = Reading::factory()->create([
+        'title' => 'Selected Reading',
+        'type' => ReadingType::PRAYER,
+    ]);
+    Reading::factory()->count(10)->create();
+
+    $service = Service::factory()->create();
+    $element = LiturgyElement::factory()->create([
+        'liturgy_type' => Service::class,
+        'liturgy_id' => $service->id,
+        'type' => LiturgyElementType::READING,
+        'content_type' => Reading::class,
+        'content_id' => $selected->id,
+    ]);
+
+    $readings = Livewire::test('elements.reading', ['element' => $element])->get('readings');
+
+    expect($readings)->toHaveCount(1);
+    expect($readings->first()->id)->toBe($selected->id);
 });
 
 it('keeps the selected reading in the list when the search would exclude it', function (): void {

--- a/tests/Feature/ReadingTypeFilteringTest.php
+++ b/tests/Feature/ReadingTypeFilteringTest.php
@@ -11,23 +11,21 @@ use Livewire\Livewire;
 uses(RefreshDatabase::class);
 
 it('filters readings by reading_type when element has reading_type specified', function () {
-    // Create readings of different types
     $callToWorshipReading = Reading::factory()->create([
         'title' => 'Call to Worship Reading',
         'type' => ReadingType::WORSHIP_CALL,
     ]);
 
-    $lawReading = Reading::factory()->create([
+    Reading::factory()->create([
         'title' => 'Law Reading',
         'type' => ReadingType::LAW,
     ]);
 
-    $otherReading = Reading::factory()->create([
+    Reading::factory()->create([
         'title' => 'Other Reading',
         'type' => ReadingType::CREED,
     ]);
 
-    // Create a service with a reading element that has a specific reading_type
     $service = Service::factory()->create();
     $readingElement = LiturgyElement::factory()->create([
         'liturgy_type' => Service::class,
@@ -36,24 +34,20 @@ it('filters readings by reading_type when element has reading_type specified', f
         'reading_type' => ReadingType::WORSHIP_CALL,
     ]);
 
-    // Test the reading element component
-    $component = Livewire::test('elements.reading', ['element' => $readingElement]);
-
-    // The computed readings property should only return readings that match the reading_type
-    $readings = $component->readings;
+    $readings = Livewire::test('elements.reading', ['element' => $readingElement])
+        ->set('search', 'Reading')
+        ->get('readings');
 
     expect($readings)->toHaveCount(1);
     expect($readings->first()->id)->toBe($callToWorshipReading->id);
     expect($readings->first()->title)->toBe('Call to Worship Reading');
 });
 
-it('returns all readings when element has no reading_type specified', function () {
-    // Create readings of different types
-    Reading::factory()->create(['type' => ReadingType::WORSHIP_CALL]);
-    Reading::factory()->create(['type' => ReadingType::LAW]);
-    Reading::factory()->create(['type' => ReadingType::CREED]);
+it('returns all readings matching search when element has no reading_type specified', function () {
+    Reading::factory()->create(['title' => 'Worship Reading', 'type' => ReadingType::WORSHIP_CALL]);
+    Reading::factory()->create(['title' => 'Law Reading', 'type' => ReadingType::LAW]);
+    Reading::factory()->create(['title' => 'Creed Reading', 'type' => ReadingType::CREED]);
 
-    // Create a service with a reading element that has no reading_type
     $service = Service::factory()->create();
     $readingElement = LiturgyElement::factory()->create([
         'liturgy_type' => Service::class,
@@ -62,11 +56,9 @@ it('returns all readings when element has no reading_type specified', function (
         'reading_type' => null,
     ]);
 
-    // Test the reading element component
-    $component = Livewire::test('elements.reading', ['element' => $readingElement]);
-
-    // The computed readings property should return all readings
-    $readings = $component->readings;
+    $readings = Livewire::test('elements.reading', ['element' => $readingElement])
+        ->set('search', 'Reading')
+        ->get('readings');
 
     expect($readings)->toHaveCount(3);
 });


### PR DESCRIPTION
## Summary
- Constrain the song/reading selector wrapper to `md:w-[226px]` so the listbox no longer causes layout shift on medium+ screens.
- Skip the database query in the `songs()` / `readings()` computed properties when `search` is empty, so the dropdown only fetches results once the user types (the selected item is still preserved).
- Update existing tests to drive the selectors via `set('search', ...)` and add coverage for the empty-search and selected-only paths.

## Test plan
- [ ] `php artisan test --filter=ElementSearchTest`
- [ ] `php artisan test --filter=ReadingTypeFilteringTest`
- [ ] Manually verify the song and reading selectors on a service page render at the correct width and only load results after typing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Search results for songs and readings now load only when a search term is entered, eliminating unnecessary database queries.

* **Style**
  * Adjusted layout spacing on medium-sized screens for song and reading selection components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->