### PR TITLE
Add group conversations with messaging-mode gating

### DIFF
--- a/app/Models/Conversation.php
+++ b/app/Models/Conversation.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\ConversationFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+use Spatie\Comments\Models\Comment;
+use Spatie\Comments\Models\Concerns\HasComments;
+use Spatie\Comments\Models\Concerns\Interfaces\CanComment;
+
+/**
+ * @property ?Carbon $last_comment_at
+ */
+#[Fillable(['group_id', 'user_id', 'title'])]
+class Conversation extends Model
+{
+    /** @use HasFactory<ConversationFactory> */
+    use HasComments, HasFactory;
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return [
+            'last_comment_at' => 'datetime',
+        ];
+    }
+
+    /** @return BelongsTo<Group, $this> */
+    public function group(): BelongsTo
+    {
+        return $this->belongsTo(Group::class);
+    }
+
+    /** @return BelongsTo<User, $this> */
+    public function creator(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+
+    public function postComment(string $text, ?CanComment $commentator = null): Comment
+    {
+        $comment = $this->comment($text, $commentator);
+
+        $this->forceFill(['last_comment_at' => $comment->created_at])->save();
+
+        return $comment;
+    }
+
+    public function commentableName(): string
+    {
+        return $this->title;
+    }
+
+    public function commentUrl(): string
+    {
+        return route('groups.conversations.show', [
+            'group' => $this->group_id,
+            'conversation' => $this,
+        ]);
+    }
+}

--- a/app/Models/Group.php
+++ b/app/Models/Group.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Facades\Storage;
 use Mews\Purifier\Casts\CleanHtmlInput;
 
@@ -72,5 +73,21 @@ class Group extends Model
             ->using(GroupUser::class)
             ->withPivot('role', 'status')
             ->withTimestamps();
+    }
+
+    /** @return HasMany<Conversation, $this> */
+    public function conversations(): HasMany
+    {
+        return $this->hasMany(Conversation::class);
+    }
+
+    public function hasActiveMember(User $user): bool
+    {
+        return $this->members()->whereKey($user->id)->exists();
+    }
+
+    public function hasLeader(User $user): bool
+    {
+        return $this->leaders()->whereKey($user->id)->exists();
     }
 }

--- a/app/Notifications/NewConversationNotification.php
+++ b/app/Notifications/NewConversationNotification.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Conversation;
+use App\Models\User;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class NewConversationNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(
+        public Conversation $conversation,
+        public User $author,
+    ) {}
+
+    /** @return array<int, string> */
+    public function via(object $notifiable): array
+    {
+        return ['mail', 'database'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        $group = $this->conversation->group;
+
+        return (new MailMessage())
+            ->subject("New conversation in {$group->name}")
+            ->line("{$this->author->name} started a new conversation: {$this->conversation->title}")
+            ->action('View Conversation', route('groups.conversations.show', [
+                'group' => $group,
+                'conversation' => $this->conversation,
+            ]));
+    }
+
+    /** @return array<string, mixed> */
+    public function toArray(object $notifiable): array
+    {
+        return [
+            'conversation_id' => $this->conversation->id,
+            'conversation_title' => $this->conversation->title,
+            'group_id' => $this->conversation->group_id,
+            'group_name' => $this->conversation->group->name,
+            'author_id' => $this->author->id,
+            'author_name' => $this->author->name,
+        ];
+    }
+}

--- a/app/Policies/ConversationPolicy.php
+++ b/app/Policies/ConversationPolicy.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Policies;
+
+use App\Enums\GroupMessaging;
+use App\Models\Conversation;
+use App\Models\Group;
+use App\Models\User;
+
+class ConversationPolicy
+{
+    public function viewAny(User $user, Group $group): bool
+    {
+        return $group->hasActiveMember($user);
+    }
+
+    public function view(User $user, Conversation $conversation): bool
+    {
+        return $conversation->group->hasActiveMember($user);
+    }
+
+    public function create(User $user, Group $group): bool
+    {
+        return $this->canPost($user, $group);
+    }
+
+    public function comment(User $user, Conversation $conversation): bool
+    {
+        return $this->canPost($user, $conversation->group);
+    }
+
+    public function update(User $user, Conversation $conversation): bool
+    {
+        return $this->isAuthorOrLeader($user, $conversation);
+    }
+
+    public function delete(User $user, Conversation $conversation): bool
+    {
+        return $this->isAuthorOrLeader($user, $conversation);
+    }
+
+    private function isAuthorOrLeader(User $user, Conversation $conversation): bool
+    {
+        return $this->isAuthor($user, $conversation)
+            || $conversation->group->hasLeader($user);
+    }
+
+    private function canPost(User $user, Group $group): bool
+    {
+        return match ($group->messaging) {
+            GroupMessaging::OFF => false,
+            GroupMessaging::ALL_MEMBERS => $group->hasActiveMember($user),
+            GroupMessaging::ONLY_LEADERS => $group->hasLeader($user),
+        };
+    }
+
+    private function isAuthor(User $user, Conversation $conversation): bool
+    {
+        return $conversation->user_id === $user->id;
+    }
+}

--- a/app/Policies/GroupPolicy.php
+++ b/app/Policies/GroupPolicy.php
@@ -19,7 +19,7 @@ class GroupPolicy
             return true;
         }
 
-        return $this->isActiveMember($user, $group);
+        return $group->hasActiveMember($user);
     }
 
     /**
@@ -34,7 +34,7 @@ class GroupPolicy
 
         return ! $group->allUsers()
             ->where('user_id', $user->id)
-            ->whereNotIn('status', [MembershipStatus::REJECTED])
+            ->where('status', '!=', MembershipStatus::REJECTED)
             ->exists();
     }
 
@@ -43,7 +43,7 @@ class GroupPolicy
      */
     public function manageMembers(User $user, Group $group): bool
     {
-        return $this->isLeader($user, $group);
+        return $group->hasLeader($user);
     }
 
     /**
@@ -52,7 +52,7 @@ class GroupPolicy
      */
     public function update(User $user, Group $group): bool
     {
-        return $this->isLeader($user, $group);
+        return $group->hasLeader($user);
     }
 
     /**
@@ -61,7 +61,7 @@ class GroupPolicy
      */
     public function delete(User $user, Group $group): bool
     {
-        return $this->isLeader($user, $group);
+        return $group->hasLeader($user);
     }
 
     /**
@@ -70,24 +70,10 @@ class GroupPolicy
      */
     public function leave(User $user, Group $group): bool
     {
-        if (! $this->isActiveMember($user, $group)) {
+        if (! $group->hasActiveMember($user)) {
             return false;
         }
 
-        if ($this->isLeader($user, $group) && $group->leaders()->count() === 1) {
-            return false;
-        }
-
-        return true;
-    }
-
-    private function isActiveMember(User $user, Group $group): bool
-    {
-        return $group->members()->where('user_id', $user->id)->exists();
-    }
-
-    private function isLeader(User $user, Group $group): bool
-    {
-        return $group->leaders()->where('user_id', $user->id)->exists();
+        return ! $group->hasLeader($user) || $group->leaders()->count() > 1;
     }
 }

--- a/database/factories/ConversationFactory.php
+++ b/database/factories/ConversationFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Conversation;
+use App\Models\Group;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Conversation>
+ */
+class ConversationFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'group_id' => Group::factory(),
+            'user_id' => User::factory(),
+            'title' => $this->faker->sentence(4),
+            'last_comment_at' => null,
+        ];
+    }
+}

--- a/database/migrations/2026_05_03_190353_create_conversations_table.php
+++ b/database/migrations/2026_05_03_190353_create_conversations_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('conversations', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('group_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->nullable()->constrained()->nullOnDelete();
+            $table->string('title');
+            $table->timestamp('last_comment_at')->nullable();
+            $table->timestamps();
+
+            $table->index(['group_id', 'last_comment_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('conversations');
+    }
+};

--- a/resources/views/pages/groups/conversations/create.blade.php
+++ b/resources/views/pages/groups/conversations/create.blade.php
@@ -1,0 +1,96 @@
+<?php
+
+use App\Models\Conversation;
+use App\Models\Group;
+use App\Notifications\NewConversationNotification;
+use Flux\Flux;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Notification;
+use Livewire\Component;
+
+new class extends Component {
+    public Group $group;
+
+    public string $title = '';
+    public string $body = '';
+
+    public function mount(Group $group): void
+    {
+        $this->authorize('create', [Conversation::class, $group]);
+
+        $this->group = $group;
+    }
+
+    public function save(): void
+    {
+        $this->authorize('create', [Conversation::class, $this->group]);
+
+        $validated = $this->validate([
+            'title' => ['required', 'string', 'max:255'],
+            'body' => ['required', 'string'],
+        ]);
+
+        if (trim(strip_tags($validated['body'])) === '') {
+            $this->addError('body', 'Please write an opening message.');
+
+            return;
+        }
+
+        $conversation = DB::transaction(function () use ($validated): Conversation {
+            $conversation = $this->group->conversations()->create([
+                'user_id' => Auth::id(),
+                'title' => $validated['title'],
+            ]);
+
+            $conversation->postComment($validated['body'], Auth::user());
+
+            return $conversation;
+        });
+
+        $this->notifyMembers($conversation);
+
+        Flux::toast(variant: 'success', text: 'Conversation started.');
+
+        $this->redirect(route('groups.conversations.show', [
+            'group' => $this->group,
+            'conversation' => $conversation,
+        ]), navigate: true);
+    }
+
+    private function notifyMembers(Conversation $conversation): void
+    {
+        $recipients = $this->group->members()
+            ->where('users.id', '!=', Auth::id())
+            ->get();
+
+        Notification::send($recipients, new NewConversationNotification($conversation, Auth::user()));
+    }
+};
+?>
+
+<section class="w-full">
+    <flux:heading size="xl" level="1">Start a Conversation</flux:heading>
+    <flux:subheading size="lg" class="mb-6">Post a new conversation in {{ $group->name }}.</flux:subheading>
+
+    <form wire:submit="save" class="max-w-2xl space-y-6">
+        <flux:field>
+            <flux:label badge="Required">Title</flux:label>
+            <flux:input type="text" name="title" wire:model="title" />
+            <flux:error name="title" />
+        </flux:field>
+
+        <flux:editor
+            label="Message"
+            wire:model="body"
+            toolbar="heading | bold italic underline strike | bullet ordered blockquote | link ~ undo redo"
+            class="**:data-[slot=content]:min-h-[200px]"
+        />
+        <flux:error name="body" />
+
+        <div class="flex items-center gap-2">
+            <flux:button type="submit" variant="primary" icon="paper-airplane">Post</flux:button>
+            <flux:button :href="route('groups.show', $group)" variant="ghost" wire:navigate>Cancel</flux:button>
+        </div>
+    </form>
+</section>

--- a/resources/views/pages/groups/conversations/show.blade.php
+++ b/resources/views/pages/groups/conversations/show.blade.php
@@ -1,0 +1,145 @@
+<?php
+
+use App\Models\Conversation;
+use App\Models\Group;
+use Flux\Flux;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\Auth;
+use Livewire\Attributes\Computed;
+use Livewire\Component;
+use Spatie\Comments\Models\Comment;
+
+new class extends Component {
+    public Group $group;
+    public Conversation $conversation;
+
+    public string $reply = '';
+
+    public function mount(Group $group, Conversation $conversation): void
+    {
+        abort_unless($conversation->group_id === $group->id, 404);
+
+        $this->authorize('view', $conversation);
+
+        $this->group = $group;
+        $this->conversation = $conversation;
+    }
+
+    /** @return Collection<int, Comment> */
+    #[Computed]
+    public function comments(): Collection
+    {
+        /** @var Collection<int, Comment> */
+        return $this->conversation->comments()
+            ->with('commentator')
+            ->orderBy('created_at')
+            ->get();
+    }
+
+    public function postReply(): void
+    {
+        $this->authorize('comment', $this->conversation);
+
+        $validated = $this->validate([
+            'reply' => ['required', 'string'],
+        ]);
+
+        if (trim(strip_tags($validated['reply'])) === '') {
+            $this->addError('reply', 'Please write a reply.');
+
+            return;
+        }
+
+        $this->conversation->postComment($validated['reply'], Auth::user());
+
+        $this->reset('reply');
+        unset($this->comments);
+    }
+
+    public function deleteConversation(): void
+    {
+        $this->authorize('delete', $this->conversation);
+
+        $this->conversation->delete();
+
+        Flux::toast(variant: 'success', text: 'Conversation deleted.');
+
+        $this->redirect(route('groups.show', $this->group), navigate: true);
+    }
+};
+?>
+
+<section class="w-full">
+    <div class="flex items-start justify-between gap-4">
+        <div>
+            <flux:button :href="route('groups.show', $group)" variant="ghost" size="sm" icon="arrow-left" wire:navigate>
+                Back to {{ $group->name }}
+            </flux:button>
+            <flux:heading size="xl" level="1" class="mt-2">{{ $conversation->title }}</flux:heading>
+            <flux:subheading>
+                Started by {{ $conversation->creator?->name ?? 'Unknown' }} {{ $conversation->created_at->diffForHumans() }}
+            </flux:subheading>
+        </div>
+
+        @can('delete', $conversation)
+            <flux:button wire:click="deleteConversation" variant="danger" size="sm" icon="trash"
+                wire:confirm="Delete this conversation and all its messages?">
+                Delete
+            </flux:button>
+        @endcan
+    </div>
+
+    <div class="mt-8 max-w-3xl">
+        <div class="flex flex-col w-full space-y-2
+            **:[h1]:text-xl **:[h1]:font-semibold **:[h2]:text-lg **:[h2]:font-semibold **:[h3]:font-semibold
+            **:[strong]:font-semibold **:[em]:italic **:[u]:underline **:[s]:line-through
+            **:[ol]:list-decimal **:[ol]:ml-5 **:[ul]:list-disc **:[ul]:ml-5
+            **:[a]:underline
+            **:[blockquote]:border-l-4 **:[blockquote]:pl-2">
+            @php($prevUser = null)
+
+            @foreach ($this->comments as $comment)
+                <div wire:key="comment-{{ $comment->id }}" @class([
+                    'text-left max-w-3/4 space-y-2',
+                    'self-start' => ! $comment->commentator?->is(Auth::user()),
+                    'self-end' => $comment->commentator?->is(Auth::user()),
+                ])>
+                    @if ($comment->commentator?->isNot($prevUser))
+                        <div class="flex items-center space-x-2">
+                            <flux:avatar size="xs" name="{{ $comment->commentator?->name }}" color="auto" />
+                            <flux:heading>{{ $comment->commentator?->name ?? 'Unknown' }}</flux:heading>
+                            <flux:subheading class="text-xs">{{ $comment->created_at->diffForHumans() }}</flux:subheading>
+                        </div>
+                    @endif
+
+                    <div @class([
+                        'rounded-md p-2 space-y-2',
+                        'bg-zinc-100 dark:bg-zinc-800' => ! $comment->commentator?->is(Auth::user()),
+                        'bg-accent text-white' => $comment->commentator?->is(Auth::user()),
+                    ])>
+                        {!! $comment->text !!}
+                    </div>
+                </div>
+                @php($prevUser = $comment->commentator)
+            @endforeach
+        </div>
+
+        @can('comment', $conversation)
+            <form wire:submit="postReply" class="mt-6">
+                <flux:composer wire:model="reply" label="Reply" label:sr-only placeholder="Write a reply...">
+                    <x-slot name="input">
+                        <flux:editor
+                            variant="borderless"
+                            toolbar="heading | bold italic underline strike | bullet ordered blockquote | link ~ undo redo"
+                            class="**:data-[slot=content]:min-h-[100px]!"
+                        />
+                    </x-slot>
+                    <x-slot name="actionsTrailing">
+                        <flux:button type="submit" variant="primary" size="sm" icon="paper-airplane" wire:loading.attr="disabled" />
+                    </x-slot>
+                </flux:composer>
+                <flux:error name="reply" />
+            </form>
+        @endcan
+    </div>
+</section>

--- a/resources/views/pages/groups/show.blade.php
+++ b/resources/views/pages/groups/show.blade.php
@@ -1,8 +1,10 @@
 <?php
 
+use App\Enums\GroupMessaging;
 use App\Enums\GroupRole;
 use App\Enums\GroupVisibility;
 use App\Enums\MembershipStatus;
+use App\Models\Conversation;
 use App\Models\Group;
 use App\Models\GroupUser;
 use App\Models\User;
@@ -14,6 +16,7 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\Storage;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Url;
@@ -32,6 +35,10 @@ new class extends Component {
     {
         $this->authorize('view', $group);
         $this->group = $group;
+
+        if (! $this->conversationsVisible) {
+            $this->tab = 'members';
+        }
     }
 
     #[Computed]
@@ -65,6 +72,23 @@ new class extends Component {
     public function activeMembers(): Collection
     {
         return $this->group->members()->get();
+    }
+
+    #[Computed]
+    public function conversationsVisible(): bool
+    {
+        return $this->isMember && $this->group->messaging !== GroupMessaging::OFF;
+    }
+
+    /** @return Collection<int, Conversation> */
+    #[Computed]
+    public function conversations(): Collection
+    {
+        return $this->group->conversations()
+            ->with('creator')
+            ->withCount('comments')
+            ->orderByRaw('COALESCE(last_comment_at, created_at) desc')
+            ->get();
     }
 
     /** @return Collection<int, User>|BaseCollection<int, User> */
@@ -278,9 +302,10 @@ new class extends Component {
 
     private function notifyLeaders(): void
     {
-        $notification = new GroupJoinRequestNotification($this->group, Auth::user());
-
-        $this->group->leaders->each(fn (User $leader) => $leader->notify($notification));
+        Notification::send(
+            $this->group->leaders,
+            new GroupJoinRequestNotification($this->group, Auth::user()),
+        );
     }
 };
 ?>
@@ -331,7 +356,9 @@ new class extends Component {
 
     <flux:tab.group class="mt-8">
         <flux:tabs wire:model="tab">
-            <flux:tab name="conversations" icon="chat-bubble-left-right">Conversations</flux:tab>
+            @if ($this->conversationsVisible)
+                <flux:tab name="conversations" icon="chat-bubble-left-right">Conversations</flux:tab>
+            @endif
             @if ($this->isMember)
                 <flux:tab name="members" icon="user-group">
                     Members
@@ -342,13 +369,54 @@ new class extends Component {
             @endif
         </flux:tabs>
 
-        <flux:tab.panel name="conversations">
-            <div class="text-center py-12">
-                <flux:icon.chat-bubble-left-right class="mx-auto size-12 text-zinc-400" />
-                <flux:heading size="lg" class="mt-4">Conversations coming soon</flux:heading>
-                <flux:subheading>Group conversations will be available in a future update.</flux:subheading>
-            </div>
-        </flux:tab.panel>
+        @if ($this->conversationsVisible)
+            <flux:tab.panel name="conversations">
+                <div class="flex items-center justify-between mb-4">
+                    <flux:heading size="lg">Conversations</flux:heading>
+                    @can('create', [Conversation::class, $group])
+                        <flux:button :href="route('groups.conversations.create', $group)" variant="primary" size="sm" icon="plus" wire:navigate>
+                            New Conversation
+                        </flux:button>
+                    @endcan
+                </div>
+
+                @if ($this->conversations->isEmpty())
+                    <div class="text-center py-12">
+                        <flux:icon.chat-bubble-left-right class="mx-auto size-12 text-zinc-400" />
+                        <flux:heading size="lg" class="mt-4">No conversations yet</flux:heading>
+                        @can('create', [Conversation::class, $group])
+                            <flux:subheading>Start the first conversation in this group.</flux:subheading>
+                        @endcan
+                    </div>
+                @else
+                    <flux:table>
+                        <flux:table.columns>
+                            <flux:table.column>Title</flux:table.column>
+                            <flux:table.column>Started by</flux:table.column>
+                            <flux:table.column>Messages</flux:table.column>
+                            <flux:table.column>Last activity</flux:table.column>
+                        </flux:table.columns>
+
+                        <flux:table.rows>
+                            @foreach ($this->conversations as $conversation)
+                                <flux:table.row :key="$conversation->id">
+                                    <flux:table.cell>
+                                        <flux:link :href="route('groups.conversations.show', ['group' => $group, 'conversation' => $conversation])" wire:navigate>
+                                            {{ $conversation->title }}
+                                        </flux:link>
+                                    </flux:table.cell>
+                                    <flux:table.cell>{{ $conversation->creator?->name ?? 'Unknown' }}</flux:table.cell>
+                                    <flux:table.cell>{{ $conversation->comments_count }}</flux:table.cell>
+                                    <flux:table.cell class="whitespace-nowrap">
+                                        {{ ($conversation->last_comment_at ?? $conversation->created_at)->diffForHumans() }}
+                                    </flux:table.cell>
+                                </flux:table.row>
+                            @endforeach
+                        </flux:table.rows>
+                    </flux:table>
+                @endif
+            </flux:tab.panel>
+        @endif
 
         @if ($this->isMember)
             <flux:tab.panel name="members">

--- a/routes/web.php
+++ b/routes/web.php
@@ -71,6 +71,13 @@ Route::middleware(['auth'])->group(function (): void {
             Route::livewire('/create', 'pages::groups.create')->name('create');
             Route::livewire('/{group}', 'pages::groups.show')->name('show');
             Route::livewire('/{group}/edit', 'pages::groups.edit')->name('edit');
+
+            Route::name('conversations.')
+                ->prefix('/{group}/conversations')
+                ->group(function (): void {
+                    Route::livewire('/create', 'pages::groups.conversations.create')->name('create');
+                    Route::livewire('/{conversation}', 'pages::groups.conversations.show')->name('show');
+                });
         });
 
     Route::name('people.')

--- a/tests/Feature/GroupConversationsTest.php
+++ b/tests/Feature/GroupConversationsTest.php
@@ -1,0 +1,399 @@
+<?php
+
+use App\Enums\GroupMessaging;
+use App\Enums\GroupRole;
+use App\Enums\GroupVisibility;
+use App\Enums\MembershipStatus;
+use App\Models\Conversation;
+use App\Models\Group;
+use App\Models\User;
+use App\Notifications\NewConversationNotification;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+/** @group groups */
+function attachMember(Group $group, User $user, GroupRole $role = GroupRole::MEMBER): void
+{
+    $group->allUsers()->attach($user, [
+        'role' => $role,
+        'status' => MembershipStatus::ACTIVE,
+    ]);
+}
+
+// --- Tab visibility on the group show page ---
+
+test('conversations tab is hidden when messaging is off', function (): void {
+    $user = User::factory()->create();
+    $group = Group::factory()->create([
+        'visibility' => GroupVisibility::PUBLIC,
+        'messaging' => GroupMessaging::OFF,
+    ]);
+    attachMember($group, $user);
+
+    $this->actingAs($user)
+        ->get("/groups/{$group->id}")
+        ->assertSuccessful()
+        ->assertDontSee('Conversations');
+});
+
+test('conversations tab is hidden for non-members of a public group', function (): void {
+    $user = User::factory()->create();
+    $group = Group::factory()->create([
+        'visibility' => GroupVisibility::PUBLIC,
+        'messaging' => GroupMessaging::ALL_MEMBERS,
+    ]);
+
+    $this->actingAs($user)
+        ->get("/groups/{$group->id}")
+        ->assertSuccessful()
+        ->assertDontSee('Conversations');
+});
+
+test('conversations tab is visible to members when messaging is on', function (): void {
+    $user = User::factory()->create();
+    $group = Group::factory()->create([
+        'visibility' => GroupVisibility::PUBLIC,
+        'messaging' => GroupMessaging::ALL_MEMBERS,
+    ]);
+    attachMember($group, $user);
+
+    $this->actingAs($user)
+        ->get("/groups/{$group->id}")
+        ->assertSuccessful()
+        ->assertSee('Conversations');
+});
+
+// --- Create page access (policy::create) ---
+
+test('non-members cannot access the conversation create page', function (): void {
+    $user = User::factory()->create();
+    $group = Group::factory()->create([
+        'visibility' => GroupVisibility::PUBLIC,
+        'messaging' => GroupMessaging::ALL_MEMBERS,
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('groups.conversations.create', $group))
+        ->assertForbidden();
+});
+
+test('members cannot access the create page when messaging is off', function (): void {
+    $user = User::factory()->create();
+    $group = Group::factory()->create([
+        'visibility' => GroupVisibility::PUBLIC,
+        'messaging' => GroupMessaging::OFF,
+    ]);
+    attachMember($group, $user);
+
+    $this->actingAs($user)
+        ->get(route('groups.conversations.create', $group))
+        ->assertForbidden();
+});
+
+test('members can access the create page when messaging is open to all members', function (): void {
+    $user = User::factory()->create();
+    $group = Group::factory()->create([
+        'visibility' => GroupVisibility::PUBLIC,
+        'messaging' => GroupMessaging::ALL_MEMBERS,
+    ]);
+    attachMember($group, $user);
+
+    $this->actingAs($user)
+        ->get(route('groups.conversations.create', $group))
+        ->assertSuccessful();
+});
+
+test('non-leader members cannot access the create page when messaging is leaders only', function (): void {
+    $user = User::factory()->create();
+    $group = Group::factory()->create([
+        'visibility' => GroupVisibility::PUBLIC,
+        'messaging' => GroupMessaging::ONLY_LEADERS,
+    ]);
+    attachMember($group, $user);
+
+    $this->actingAs($user)
+        ->get(route('groups.conversations.create', $group))
+        ->assertForbidden();
+});
+
+test('leaders can access the create page when messaging is leaders only', function (): void {
+    $leader = User::factory()->create();
+    $group = Group::factory()->create([
+        'visibility' => GroupVisibility::PUBLIC,
+        'messaging' => GroupMessaging::ONLY_LEADERS,
+    ]);
+    attachMember($group, $leader, GroupRole::LEADER);
+
+    $this->actingAs($leader)
+        ->get(route('groups.conversations.create', $group))
+        ->assertSuccessful();
+});
+
+// --- Creating a conversation ---
+
+test('a member can create a conversation and an opening comment', function (): void {
+    Notification::fake();
+
+    $author = User::factory()->create();
+    $other = User::factory()->create();
+    $group = Group::factory()->create([
+        'visibility' => GroupVisibility::PUBLIC,
+        'messaging' => GroupMessaging::ALL_MEMBERS,
+    ]);
+    attachMember($group, $author);
+    attachMember($group, $other);
+
+    $this->actingAs($author);
+
+    Livewire::test('pages::groups.conversations.create', ['group' => $group])
+        ->set('title', 'Welcome aboard')
+        ->set('body', '<p>Hi everyone!</p>')
+        ->call('save')
+        ->assertHasNoErrors()
+        ->assertRedirect();
+
+    $conversation = Conversation::where('group_id', $group->id)->firstOrFail();
+
+    expect($conversation->title)->toBe('Welcome aboard');
+    expect($conversation->user_id)->toBe($author->id);
+    expect($conversation->comments()->count())->toBe(1);
+    expect($conversation->refresh()->last_comment_at)->not->toBeNull();
+
+    Notification::assertSentTo($other, NewConversationNotification::class);
+    Notification::assertNotSentTo($author, NewConversationNotification::class);
+});
+
+test('an empty body fails validation', function (): void {
+    $author = User::factory()->create();
+    $group = Group::factory()->create([
+        'visibility' => GroupVisibility::PUBLIC,
+        'messaging' => GroupMessaging::ALL_MEMBERS,
+    ]);
+    attachMember($group, $author);
+
+    $this->actingAs($author);
+
+    Livewire::test('pages::groups.conversations.create', ['group' => $group])
+        ->set('title', 'Empty')
+        ->set('body', '<p>   </p>')
+        ->call('save')
+        ->assertHasErrors('body');
+});
+
+// --- Viewing a conversation ---
+
+test('non-members cannot view a conversation in a public group', function (): void {
+    $member = User::factory()->create();
+    $other = User::factory()->create();
+    $group = Group::factory()->create([
+        'visibility' => GroupVisibility::PUBLIC,
+        'messaging' => GroupMessaging::ALL_MEMBERS,
+    ]);
+    attachMember($group, $member);
+
+    $conversation = Conversation::factory()->create([
+        'group_id' => $group->id,
+        'user_id' => $member->id,
+    ]);
+
+    $this->actingAs($other)
+        ->get(route('groups.conversations.show', ['group' => $group, 'conversation' => $conversation]))
+        ->assertForbidden();
+});
+
+test('members can view a conversation', function (): void {
+    $member = User::factory()->create();
+    $group = Group::factory()->create([
+        'visibility' => GroupVisibility::PUBLIC,
+        'messaging' => GroupMessaging::ALL_MEMBERS,
+    ]);
+    attachMember($group, $member);
+
+    $conversation = Conversation::factory()->create([
+        'group_id' => $group->id,
+        'user_id' => $member->id,
+        'title' => 'Sunday plans',
+    ]);
+    $conversation->postComment('Opening message', $member);
+
+    $this->actingAs($member)
+        ->get(route('groups.conversations.show', ['group' => $group, 'conversation' => $conversation]))
+        ->assertSuccessful()
+        ->assertSee('Sunday plans')
+        ->assertSee('Opening message');
+});
+
+test('a 404 is returned when the conversation does not belong to the group', function (): void {
+    $user = User::factory()->create();
+    $groupA = Group::factory()->create(['messaging' => GroupMessaging::ALL_MEMBERS]);
+    $groupB = Group::factory()->create(['messaging' => GroupMessaging::ALL_MEMBERS]);
+    attachMember($groupA, $user);
+    attachMember($groupB, $user);
+
+    $conversation = Conversation::factory()->create([
+        'group_id' => $groupA->id,
+        'user_id' => $user->id,
+    ]);
+
+    $this->actingAs($user)
+        ->get("/groups/{$groupB->id}/conversations/{$conversation->id}")
+        ->assertNotFound();
+});
+
+// --- Posting replies (policy::comment) ---
+
+test('a member can post a reply', function (): void {
+    $member = User::factory()->create();
+    $group = Group::factory()->create([
+        'messaging' => GroupMessaging::ALL_MEMBERS,
+    ]);
+    attachMember($group, $member);
+
+    $conversation = Conversation::factory()->create([
+        'group_id' => $group->id,
+        'user_id' => $member->id,
+    ]);
+
+    $this->actingAs($member);
+
+    Livewire::test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->set('reply', '<p>Reply text</p>')
+        ->call('postReply')
+        ->assertHasNoErrors();
+
+    expect($conversation->comments()->count())->toBe(1);
+    expect($conversation->refresh()->last_comment_at)->not->toBeNull();
+});
+
+test('an empty reply fails validation', function (): void {
+    $member = User::factory()->create();
+    $group = Group::factory()->create([
+        'messaging' => GroupMessaging::ALL_MEMBERS,
+    ]);
+    attachMember($group, $member);
+
+    $conversation = Conversation::factory()->create([
+        'group_id' => $group->id,
+        'user_id' => $member->id,
+    ]);
+
+    $this->actingAs($member);
+
+    Livewire::test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->set('reply', '<p>   </p>')
+        ->call('postReply')
+        ->assertHasErrors('reply');
+
+    expect($conversation->comments()->count())->toBe(0);
+});
+
+test('a non-leader cannot reply when messaging is leaders only', function (): void {
+    $member = User::factory()->create();
+    $leader = User::factory()->create();
+    $group = Group::factory()->create([
+        'messaging' => GroupMessaging::ONLY_LEADERS,
+    ]);
+    attachMember($group, $leader, GroupRole::LEADER);
+    attachMember($group, $member);
+
+    $conversation = Conversation::factory()->create([
+        'group_id' => $group->id,
+        'user_id' => $leader->id,
+    ]);
+
+    $this->actingAs($member);
+
+    Livewire::test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->set('reply', '<p>Should fail</p>')
+        ->call('postReply')
+        ->assertForbidden();
+});
+
+// --- Delete (policy::delete) ---
+
+test('the author can delete their own conversation', function (): void {
+    $author = User::factory()->create();
+    $group = Group::factory()->create([
+        'messaging' => GroupMessaging::ALL_MEMBERS,
+    ]);
+    attachMember($group, $author);
+
+    $conversation = Conversation::factory()->create([
+        'group_id' => $group->id,
+        'user_id' => $author->id,
+    ]);
+
+    $this->actingAs($author);
+
+    Livewire::test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->call('deleteConversation')
+        ->assertRedirect(route('groups.show', $group));
+
+    $this->assertDatabaseMissing('conversations', ['id' => $conversation->id]);
+});
+
+test('a leader can delete any conversation in their group', function (): void {
+    $leader = User::factory()->create();
+    $author = User::factory()->create();
+    $group = Group::factory()->create([
+        'messaging' => GroupMessaging::ALL_MEMBERS,
+    ]);
+    attachMember($group, $leader, GroupRole::LEADER);
+    attachMember($group, $author);
+
+    $conversation = Conversation::factory()->create([
+        'group_id' => $group->id,
+        'user_id' => $author->id,
+    ]);
+
+    $this->actingAs($leader);
+
+    Livewire::test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->call('deleteConversation')
+        ->assertRedirect(route('groups.show', $group));
+
+    $this->assertDatabaseMissing('conversations', ['id' => $conversation->id]);
+});
+
+test('a non-author non-leader member cannot delete a conversation', function (): void {
+    $author = User::factory()->create();
+    $other = User::factory()->create();
+    $group = Group::factory()->create([
+        'messaging' => GroupMessaging::ALL_MEMBERS,
+    ]);
+    attachMember($group, $author);
+    attachMember($group, $other);
+
+    $conversation = Conversation::factory()->create([
+        'group_id' => $group->id,
+        'user_id' => $author->id,
+    ]);
+
+    $this->actingAs($other);
+
+    Livewire::test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->call('deleteConversation')
+        ->assertForbidden();
+
+    $this->assertDatabaseHas('conversations', ['id' => $conversation->id]);
+});
+
+// --- Cleanup cascade ---
+
+test('deleting the group deletes its conversations', function (): void {
+    $author = User::factory()->create();
+    $group = Group::factory()->create();
+    attachMember($group, $author);
+
+    $conversation = Conversation::factory()->create([
+        'group_id' => $group->id,
+        'user_id' => $author->id,
+    ]);
+
+    $group->delete();
+
+    $this->assertDatabaseMissing('conversations', ['id' => $conversation->id]);
+});

--- a/tests/Feature/GroupJoinTest.php
+++ b/tests/Feature/GroupJoinTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\GroupMessaging;
 use App\Enums\GroupRole;
 use App\Enums\GroupVisibility;
 use App\Enums\MembershipStatus;
@@ -392,14 +393,18 @@ test('non-member of public group sees request to join button', function (): void
         ->assertSee('Request to Join');
 });
 
-test('conversations tab placeholder is visible', function (): void {
+test('conversations tab is visible to members when messaging is enabled', function (): void {
     $user = User::factory()->create();
-    $group = Group::factory()->create(['visibility' => GroupVisibility::PUBLIC]);
+    $group = Group::factory()->create([
+        'visibility' => GroupVisibility::PUBLIC,
+        'messaging' => GroupMessaging::ALL_MEMBERS,
+    ]);
+    $group->allUsers()->attach($user, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
 
     $this->actingAs($user);
 
     Livewire::test('pages::groups.show', ['group' => $group])
-        ->assertSee('Conversations coming soon');
+        ->assertSee('Conversations');
 });
 
 test('group description is displayed in header', function (): void {


### PR DESCRIPTION
## Summary
- Adds threaded group conversations backed by the Spatie comments package, with a new `Conversation` model, migration, factory, and policy.
- Conversation visibility and posting are gated by the group's messaging setting (off / all members / leaders only); authors and leaders can delete.
- New conversations notify other group members via email + database; existing `GroupPolicy` is refactored onto `Group::hasActiveMember`/`hasLeader` helpers.

## Test plan
- [ ] `php artisan test --filter='GroupConversations|GroupJoin'`
- [ ] Manually start a conversation, reply, and delete one as author and as a leader
- [ ] Toggle group messaging between off / all members / leaders only and verify tab + actions update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added group conversations functionality allowing members to start and participate in discussion threads.
  * Implemented conversation management including creation, viewing, and commenting.
  * Added notifications to group members when new conversations are started.
  * Integrated role-based access control for conversation visibility and participation based on group messaging settings.
  * Added conversation deletion capabilities for authors and group leaders.

* **Tests**
  * Added comprehensive test coverage for conversation creation, access control, and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->