### PR TITLE
Add emoji reactions to group conversation comments

### DIFF
--- a/resources/views/pages/groups/conversations/show.blade.php
+++ b/resources/views/pages/groups/conversations/show.blade.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Auth;
 use Livewire\Attributes\Computed;
 use Livewire\Component;
 use Spatie\Comments\Models\Comment;
+use Spatie\Comments\Support\Config;
 
 new class extends Component {
     public Group $group;
@@ -31,7 +32,7 @@ new class extends Component {
     {
         /** @var Collection<int, Comment> */
         return $this->conversation->comments()
-            ->with('commentator')
+            ->with(['commentator', 'reactions'])
             ->orderBy('created_at')
             ->get();
     }
@@ -53,6 +54,18 @@ new class extends Component {
         $this->conversation->postComment($validated['reply'], Auth::user());
 
         $this->reset('reply');
+        unset($this->comments);
+    }
+
+    public function react(int $commentId, string $reaction): void
+    {
+        $this->authorize('comment', $this->conversation);
+
+        abort_unless(in_array($reaction, Config::allowedReactions(), true), 422);
+
+        $comment = $this->conversation->comments()->findOrFail($commentId);
+        $comment->react($reaction);
+
         unset($this->comments);
     }
 
@@ -118,6 +131,23 @@ new class extends Component {
                         'bg-accent text-white' => $comment->commentator?->is(Auth::user()),
                     ])>
                         {!! $comment->text !!}
+                    </div>
+                    <div class="flex flex-row-reverse items-center space-x-3 -mt-1.5">
+                        @can('comment', $conversation)
+                            <flux:dropdown hover position="{{ $comment->commentator?->is(Auth::user()) ? 'left' : 'right' }}" align="center">
+                                <flux:button size="sm" variant="ghost" icon="face-smile" />
+                                <flux:popover>
+                                    <div class="flex">
+                                        @foreach (Config::allowedReactions() as $allowedReaction)
+                                            <flux:button size="sm" variant="ghost" square wire:click="react({{ $comment->id }}, '{{ $allowedReaction }}')">{{ $allowedReaction }}</flux:button>
+                                        @endforeach
+                                    </div>
+                                </flux:popover>
+                            </flux:dropdown>
+                        @endcan
+                        @foreach ($comment->reactions->summary() as $reaction)
+                            <span wire:key="reaction-{{ $comment->id }}-{{ $reaction['reaction'] }}" class="bg-zinc-100 dark:bg-zinc-800 rounded-full py-1 px-2">{{ $reaction['reaction'] }} {{ $reaction['count'] }}</span>
+                        @endforeach
                     </div>
                 </div>
                 @php($prevUser = $comment->commentator)

--- a/resources/views/pages/groups/conversations/show.blade.php
+++ b/resources/views/pages/groups/conversations/show.blade.php
@@ -63,6 +63,7 @@ new class extends Component {
 
         abort_unless(in_array($reaction, Config::allowedReactions(), true), 422);
 
+        /** @var Comment $comment */
         $comment = $this->conversation->comments()->findOrFail($commentId);
         $comment->react($reaction);
 

--- a/tests/Feature/GroupConversationsTest.php
+++ b/tests/Feature/GroupConversationsTest.php
@@ -312,6 +312,78 @@ test('a non-leader cannot reply when messaging is leaders only', function (): vo
         ->assertForbidden();
 });
 
+// --- Reactions ---
+
+test('a member can react to a conversation comment', function (): void {
+    $member = User::factory()->create();
+    $group = Group::factory()->create([
+        'messaging' => GroupMessaging::ALL_MEMBERS,
+    ]);
+    attachMember($group, $member);
+
+    $conversation = Conversation::factory()->create([
+        'group_id' => $group->id,
+        'user_id' => $member->id,
+    ]);
+    $conversation->postComment('Opening message', $member);
+    $comment = $conversation->comments()->first();
+
+    $this->actingAs($member);
+
+    Livewire::test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->call('react', $comment->id, '👍');
+
+    expect($comment->fresh()->reactions()->count())->toBe(1);
+});
+
+test('a non-leader cannot react when messaging is leaders only', function (): void {
+    $leader = User::factory()->create();
+    $member = User::factory()->create();
+    $group = Group::factory()->create([
+        'messaging' => GroupMessaging::ONLY_LEADERS,
+    ]);
+    attachMember($group, $leader, GroupRole::LEADER);
+    attachMember($group, $member);
+
+    $conversation = Conversation::factory()->create([
+        'group_id' => $group->id,
+        'user_id' => $leader->id,
+    ]);
+    $conversation->postComment('Leader message', $leader);
+    $comment = $conversation->comments()->first();
+
+    $this->actingAs($member);
+
+    Livewire::test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->call('react', $comment->id, '👍')
+        ->assertForbidden();
+
+    expect($comment->fresh()->reactions()->count())->toBe(0);
+});
+
+test('reacting with a disallowed value is rejected', function (): void {
+    $member = User::factory()->create();
+    $group = Group::factory()->create([
+        'messaging' => GroupMessaging::ALL_MEMBERS,
+    ]);
+    attachMember($group, $member);
+
+    $conversation = Conversation::factory()->create([
+        'group_id' => $group->id,
+        'user_id' => $member->id,
+    ]);
+    $conversation->postComment('Opening message', $member);
+    $comment = $conversation->comments()->first();
+
+    $this->actingAs($member);
+
+    Livewire::test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->call('react', $comment->id, '<script>alert(1)</script>')
+        ->assertStatus(422);
+
+    expect($comment->fresh()->reactions()->count())->toBe(0);
+});
+
 // --- Delete (policy::delete) ---
 
 test('the author can delete their own conversation', function (): void {


### PR DESCRIPTION
## Summary
- Adds an emoji-picker dropdown on each comment in a group conversation, with per-reaction summary chips rendered alongside.
- New Livewire `react()` action authorizes via the existing `comment` policy and validates the input against `config('comments.allowed_reactions')` so clients can't persist arbitrary strings.
- Eager-loads `reactions` in the comments query and sources the picker buttons from the same config the validation checks against, keeping UI and validation in lockstep.

## Test plan
- [x] `php artisan test tests/Feature/GroupConversationsTest.php` — covers happy path, leaders-only forbidden, and disallowed-reaction rejection (422).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comment reactions to group conversations, enabling members to quickly respond with predefined reactions
  * Comments now display aggregated reaction summaries showing community feedback
  * Enforced authorization checks to respect group messaging restrictions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->