### PR TITLE
Adopt Flexoki color palette

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -54,7 +54,7 @@
 
 @layer theme {
     .dark {
-        --color-accent: var(--color-flexoki-purple-600);
+        --color-accent: var(--color-flexoki-purple-400);
         --color-accent-content: var(--color-flexoki-purple-400);
         --color-accent-foreground: var(--color-flexoki-paper);
     }

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,5 +1,6 @@
 @import "tailwindcss";
 @import "../../vendor/livewire/flux/dist/flux.css";
+@import "./flexoki.css";
 
 @source '../views';
 @source '../../vendor/laravel/framework/src/Illuminate/Pagination/resources/views/*.blade.php';
@@ -14,33 +15,149 @@
         "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
 }
 
-/* Re-assign Flux's gray of choice... */
+/* Re-assign Flux's gray of choice (zinc) and Tailwind's gray to Flexoki base. */
 @theme {
-    --color-zinc-50: var(--color-slate-50);
-    --color-zinc-100: var(--color-slate-100);
-    --color-zinc-200: var(--color-slate-200);
-    --color-zinc-300: var(--color-slate-300);
-    --color-zinc-400: var(--color-slate-400);
-    --color-zinc-500: var(--color-slate-500);
-    --color-zinc-600: var(--color-slate-600);
-    --color-zinc-700: var(--color-slate-700);
-    --color-zinc-800: var(--color-slate-800);
-    --color-zinc-900: var(--color-slate-900);
-    --color-zinc-950: var(--color-slate-950);
+    --color-zinc-50: var(--color-flexoki-base-50);
+    --color-zinc-100: var(--color-flexoki-base-100);
+    --color-zinc-200: var(--color-flexoki-base-200);
+    --color-zinc-300: var(--color-flexoki-base-300);
+    --color-zinc-400: var(--color-flexoki-base-400);
+    --color-zinc-500: var(--color-flexoki-base-500);
+    --color-zinc-600: var(--color-flexoki-base-600);
+    --color-zinc-700: var(--color-flexoki-base-700);
+    --color-zinc-800: var(--color-flexoki-base-800);
+    --color-zinc-900: var(--color-flexoki-base-900);
+    --color-zinc-950: var(--color-flexoki-base-950);
+
+    --color-gray-50: var(--color-flexoki-base-50);
+    --color-gray-100: var(--color-flexoki-base-100);
+    --color-gray-200: var(--color-flexoki-base-200);
+    --color-gray-300: var(--color-flexoki-base-300);
+    --color-gray-400: var(--color-flexoki-base-400);
+    --color-gray-500: var(--color-flexoki-base-500);
+    --color-gray-600: var(--color-flexoki-base-600);
+    --color-gray-700: var(--color-flexoki-base-700);
+    --color-gray-800: var(--color-flexoki-base-800);
+    --color-gray-900: var(--color-flexoki-base-900);
+    --color-gray-950: var(--color-flexoki-base-950);
+
+    --color-white: var(--color-flexoki-paper);
+    --color-black: var(--color-flexoki-black);
 }
 
+/* Accent = Flexoki purple. Per Flexoki, fg uses the 600 stop on light and the 400 stop on dark. */
 @theme {
-    --color-accent: var(--color-indigo-500);
-    --color-accent-content: var(--color-indigo-600);
-    --color-accent-foreground: var(--color-white);
+    --color-accent: var(--color-flexoki-purple-600);
+    --color-accent-content: var(--color-flexoki-purple-600);
+    --color-accent-foreground: var(--color-flexoki-paper);
 }
 
 @layer theme {
     .dark {
-        --color-accent: var(--color-indigo-500);
-        --color-accent-content: var(--color-indigo-300);
-        --color-accent-foreground: var(--color-white);
+        --color-accent: var(--color-flexoki-purple-600);
+        --color-accent-content: var(--color-flexoki-purple-400);
+        --color-accent-foreground: var(--color-flexoki-paper);
     }
+}
+
+/* Replace Tailwind's saturated default hues with Flexoki equivalents.
+   Tailwind's `pink` maps to Flexoki's `magenta`. */
+@theme {
+    --color-red-50: var(--color-flexoki-red-50);
+    --color-red-100: var(--color-flexoki-red-100);
+    --color-red-200: var(--color-flexoki-red-200);
+    --color-red-300: var(--color-flexoki-red-300);
+    --color-red-400: var(--color-flexoki-red-400);
+    --color-red-500: var(--color-flexoki-red-500);
+    --color-red-600: var(--color-flexoki-red-600);
+    --color-red-700: var(--color-flexoki-red-700);
+    --color-red-800: var(--color-flexoki-red-800);
+    --color-red-900: var(--color-flexoki-red-900);
+    --color-red-950: var(--color-flexoki-red-950);
+
+    --color-orange-50: var(--color-flexoki-orange-50);
+    --color-orange-100: var(--color-flexoki-orange-100);
+    --color-orange-200: var(--color-flexoki-orange-200);
+    --color-orange-300: var(--color-flexoki-orange-300);
+    --color-orange-400: var(--color-flexoki-orange-400);
+    --color-orange-500: var(--color-flexoki-orange-500);
+    --color-orange-600: var(--color-flexoki-orange-600);
+    --color-orange-700: var(--color-flexoki-orange-700);
+    --color-orange-800: var(--color-flexoki-orange-800);
+    --color-orange-900: var(--color-flexoki-orange-900);
+    --color-orange-950: var(--color-flexoki-orange-950);
+
+    --color-yellow-50: var(--color-flexoki-yellow-50);
+    --color-yellow-100: var(--color-flexoki-yellow-100);
+    --color-yellow-200: var(--color-flexoki-yellow-200);
+    --color-yellow-300: var(--color-flexoki-yellow-300);
+    --color-yellow-400: var(--color-flexoki-yellow-400);
+    --color-yellow-500: var(--color-flexoki-yellow-500);
+    --color-yellow-600: var(--color-flexoki-yellow-600);
+    --color-yellow-700: var(--color-flexoki-yellow-700);
+    --color-yellow-800: var(--color-flexoki-yellow-800);
+    --color-yellow-900: var(--color-flexoki-yellow-900);
+    --color-yellow-950: var(--color-flexoki-yellow-950);
+
+    --color-green-50: var(--color-flexoki-green-50);
+    --color-green-100: var(--color-flexoki-green-100);
+    --color-green-200: var(--color-flexoki-green-200);
+    --color-green-300: var(--color-flexoki-green-300);
+    --color-green-400: var(--color-flexoki-green-400);
+    --color-green-500: var(--color-flexoki-green-500);
+    --color-green-600: var(--color-flexoki-green-600);
+    --color-green-700: var(--color-flexoki-green-700);
+    --color-green-800: var(--color-flexoki-green-800);
+    --color-green-900: var(--color-flexoki-green-900);
+    --color-green-950: var(--color-flexoki-green-950);
+
+    --color-cyan-50: var(--color-flexoki-cyan-50);
+    --color-cyan-100: var(--color-flexoki-cyan-100);
+    --color-cyan-200: var(--color-flexoki-cyan-200);
+    --color-cyan-300: var(--color-flexoki-cyan-300);
+    --color-cyan-400: var(--color-flexoki-cyan-400);
+    --color-cyan-500: var(--color-flexoki-cyan-500);
+    --color-cyan-600: var(--color-flexoki-cyan-600);
+    --color-cyan-700: var(--color-flexoki-cyan-700);
+    --color-cyan-800: var(--color-flexoki-cyan-800);
+    --color-cyan-900: var(--color-flexoki-cyan-900);
+    --color-cyan-950: var(--color-flexoki-cyan-950);
+
+    --color-blue-50: var(--color-flexoki-blue-50);
+    --color-blue-100: var(--color-flexoki-blue-100);
+    --color-blue-200: var(--color-flexoki-blue-200);
+    --color-blue-300: var(--color-flexoki-blue-300);
+    --color-blue-400: var(--color-flexoki-blue-400);
+    --color-blue-500: var(--color-flexoki-blue-500);
+    --color-blue-600: var(--color-flexoki-blue-600);
+    --color-blue-700: var(--color-flexoki-blue-700);
+    --color-blue-800: var(--color-flexoki-blue-800);
+    --color-blue-900: var(--color-flexoki-blue-900);
+    --color-blue-950: var(--color-flexoki-blue-950);
+
+    --color-purple-50: var(--color-flexoki-purple-50);
+    --color-purple-100: var(--color-flexoki-purple-100);
+    --color-purple-200: var(--color-flexoki-purple-200);
+    --color-purple-300: var(--color-flexoki-purple-300);
+    --color-purple-400: var(--color-flexoki-purple-400);
+    --color-purple-500: var(--color-flexoki-purple-500);
+    --color-purple-600: var(--color-flexoki-purple-600);
+    --color-purple-700: var(--color-flexoki-purple-700);
+    --color-purple-800: var(--color-flexoki-purple-800);
+    --color-purple-900: var(--color-flexoki-purple-900);
+    --color-purple-950: var(--color-flexoki-purple-950);
+
+    --color-pink-50: var(--color-flexoki-magenta-50);
+    --color-pink-100: var(--color-flexoki-magenta-100);
+    --color-pink-200: var(--color-flexoki-magenta-200);
+    --color-pink-300: var(--color-flexoki-magenta-300);
+    --color-pink-400: var(--color-flexoki-magenta-400);
+    --color-pink-500: var(--color-flexoki-magenta-500);
+    --color-pink-600: var(--color-flexoki-magenta-600);
+    --color-pink-700: var(--color-flexoki-magenta-700);
+    --color-pink-800: var(--color-flexoki-magenta-800);
+    --color-pink-900: var(--color-flexoki-magenta-900);
+    --color-pink-950: var(--color-flexoki-magenta-950);
 }
 
 @layer base {

--- a/resources/css/flexoki.css
+++ b/resources/css/flexoki.css
@@ -1,0 +1,144 @@
+/* Flexoki palette by Steph Ango — https://stephango.com/flexoki
+   Source: https://github.com/kepano/flexoki/blob/main/css/flexoki.css
+   Exposed as Tailwind color namespace `flexoki-*`. */
+
+@theme {
+    /* Base */
+    --color-flexoki-paper: #fffcf0;
+    --color-flexoki-black: #100f0f;
+
+    /* Warm gray scale */
+    --color-flexoki-base-50: #f2f0e5;
+    --color-flexoki-base-100: #e6e4d9;
+    --color-flexoki-base-150: #dad8ce;
+    --color-flexoki-base-200: #cecdc3;
+    --color-flexoki-base-300: #b7b5ac;
+    --color-flexoki-base-400: #9f9d96;
+    --color-flexoki-base-500: #878580;
+    --color-flexoki-base-600: #6f6e69;
+    --color-flexoki-base-700: #575653;
+    --color-flexoki-base-800: #403e3c;
+    --color-flexoki-base-850: #343331;
+    --color-flexoki-base-900: #282726;
+    --color-flexoki-base-950: #1c1b1a;
+
+    /* Red */
+    --color-flexoki-red-50: #ffe1d5;
+    --color-flexoki-red-100: #ffcabb;
+    --color-flexoki-red-150: #fdb2a2;
+    --color-flexoki-red-200: #f89a8a;
+    --color-flexoki-red-300: #e8705f;
+    --color-flexoki-red-400: #d14d41;
+    --color-flexoki-red-500: #c03e35;
+    --color-flexoki-red-600: #af3029;
+    --color-flexoki-red-700: #942822;
+    --color-flexoki-red-800: #6c201c;
+    --color-flexoki-red-850: #551b18;
+    --color-flexoki-red-900: #3e1715;
+    --color-flexoki-red-950: #261312;
+
+    /* Orange */
+    --color-flexoki-orange-50: #ffe7ce;
+    --color-flexoki-orange-100: #fed3af;
+    --color-flexoki-orange-150: #fcc192;
+    --color-flexoki-orange-200: #f9ae77;
+    --color-flexoki-orange-300: #ec8b49;
+    --color-flexoki-orange-400: #da702c;
+    --color-flexoki-orange-500: #cb6120;
+    --color-flexoki-orange-600: #bc5215;
+    --color-flexoki-orange-700: #9d4310;
+    --color-flexoki-orange-800: #71320d;
+    --color-flexoki-orange-850: #59290d;
+    --color-flexoki-orange-900: #40200d;
+    --color-flexoki-orange-950: #27180e;
+
+    /* Yellow */
+    --color-flexoki-yellow-50: #faeec6;
+    --color-flexoki-yellow-100: #f6e2a0;
+    --color-flexoki-yellow-150: #f1d67e;
+    --color-flexoki-yellow-200: #eccb60;
+    --color-flexoki-yellow-300: #dfb431;
+    --color-flexoki-yellow-400: #d0a215;
+    --color-flexoki-yellow-500: #be9207;
+    --color-flexoki-yellow-600: #ad8301;
+    --color-flexoki-yellow-700: #8e6b01;
+    --color-flexoki-yellow-800: #664d01;
+    --color-flexoki-yellow-850: #503d02;
+    --color-flexoki-yellow-900: #3a2d04;
+    --color-flexoki-yellow-950: #241e08;
+
+    /* Green */
+    --color-flexoki-green-50: #edeecf;
+    --color-flexoki-green-100: #dde2b2;
+    --color-flexoki-green-150: #cdd597;
+    --color-flexoki-green-200: #bec97e;
+    --color-flexoki-green-300: #a0af54;
+    --color-flexoki-green-400: #879a39;
+    --color-flexoki-green-500: #768d21;
+    --color-flexoki-green-600: #66800b;
+    --color-flexoki-green-700: #536907;
+    --color-flexoki-green-800: #3d4c07;
+    --color-flexoki-green-850: #313d07;
+    --color-flexoki-green-900: #252d09;
+    --color-flexoki-green-950: #1a1e0c;
+
+    /* Cyan */
+    --color-flexoki-cyan-50: #ddf1e4;
+    --color-flexoki-cyan-100: #bfe8d9;
+    --color-flexoki-cyan-150: #a2dece;
+    --color-flexoki-cyan-200: #87d3c3;
+    --color-flexoki-cyan-300: #5abdac;
+    --color-flexoki-cyan-400: #3aa99f;
+    --color-flexoki-cyan-500: #2f968d;
+    --color-flexoki-cyan-600: #24837b;
+    --color-flexoki-cyan-700: #1c6c66;
+    --color-flexoki-cyan-800: #164f4a;
+    --color-flexoki-cyan-850: #143f3c;
+    --color-flexoki-cyan-900: #122f2c;
+    --color-flexoki-cyan-950: #101f1d;
+
+    /* Blue */
+    --color-flexoki-blue-50: #e1eceb;
+    --color-flexoki-blue-100: #c6dde8;
+    --color-flexoki-blue-150: #abcfe2;
+    --color-flexoki-blue-200: #92bfdb;
+    --color-flexoki-blue-300: #66a0c8;
+    --color-flexoki-blue-400: #4385be;
+    --color-flexoki-blue-500: #3171b2;
+    --color-flexoki-blue-600: #205ea6;
+    --color-flexoki-blue-700: #1a4f8c;
+    --color-flexoki-blue-800: #163b66;
+    --color-flexoki-blue-850: #133051;
+    --color-flexoki-blue-900: #12253b;
+    --color-flexoki-blue-950: #101a24;
+
+    /* Purple — primary accent for Stave */
+    --color-flexoki-purple-50: #f0eaec;
+    --color-flexoki-purple-100: #e2d9e9;
+    --color-flexoki-purple-150: #d3cae6;
+    --color-flexoki-purple-200: #c4b9e0;
+    --color-flexoki-purple-300: #a699d0;
+    --color-flexoki-purple-400: #8b7ec8;
+    --color-flexoki-purple-500: #735eb5;
+    --color-flexoki-purple-600: #5e409d;
+    --color-flexoki-purple-700: #4f3685;
+    --color-flexoki-purple-800: #3c2a62;
+    --color-flexoki-purple-850: #31234e;
+    --color-flexoki-purple-900: #261c39;
+    --color-flexoki-purple-950: #1a1623;
+
+    /* Magenta */
+    --color-flexoki-magenta-50: #fee4e5;
+    --color-flexoki-magenta-100: #fccfda;
+    --color-flexoki-magenta-150: #f9b9cf;
+    --color-flexoki-magenta-200: #f4a4c2;
+    --color-flexoki-magenta-300: #e47da8;
+    --color-flexoki-magenta-400: #ce5d97;
+    --color-flexoki-magenta-500: #b74583;
+    --color-flexoki-magenta-600: #a02f6f;
+    --color-flexoki-magenta-700: #87285e;
+    --color-flexoki-magenta-800: #641f46;
+    --color-flexoki-magenta-850: #4f1b39;
+    --color-flexoki-magenta-900: #39172b;
+    --color-flexoki-magenta-950: #24131d;
+}


### PR DESCRIPTION
## Summary
- Add `resources/css/flexoki.css` containing the canonical Flexoki palette (Steph Ango, [kepano/flexoki](https://github.com/kepano/flexoki)) exposed as Tailwind `flexoki-*` custom properties.
- Remap Tailwind's zinc, gray, red, orange, yellow, green, cyan, blue, purple, and pink scales (plus `white` and `black`) onto Flexoki, with a clean 1:1 stop mapping across all 50–950 stops.
- Switch the Flux accent from indigo to Flexoki purple, using the 600 stop on light and the 400 stop on dark per Flexoki's foreground rule.

## Test plan
- [ ] `npm run build` succeeds
- [ ] Spot-check light and dark mode across primary screens (services list, service detail, song/reading pickers, group conversations) for accent, button, and text color regressions
- [ ] Verify form focus rings and Flux components render with the new accent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the application color theme to the new Flexoki palette, replacing the previous color scheme with warm grays and vibrant hues.
  * Changed the primary accent color from indigo to purple.
  * Remapped all color tokens to use the new Flexoki color system throughout the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->