### PR TITLE
Apply Flexoki theme with purple accent

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,5 +1,6 @@
 @import "tailwindcss";
 @import "../../vendor/livewire/flux/dist/flux.css";
+@import "./flexoki.css";
 
 @source '../views';
 @source '../../vendor/laravel/framework/src/Illuminate/Pagination/resources/views/*.blade.php';
@@ -14,33 +15,131 @@
         "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
 }
 
-/* Re-assign Flux's gray of choice... */
+/* ----------------------------------------------------------
+   Redefine Flux's `zinc` scale → semantic surface tokens.
+   Flux uses `zinc` for nearly every gray (sidebar, borders,
+   text, inputs). Pointing each stop at our paper/ink/ui
+   tokens re-skins the entire surface system in one shot.
+   ---------------------------------------------------------- */
 @theme {
-    --color-zinc-50: var(--color-slate-50);
-    --color-zinc-100: var(--color-slate-100);
-    --color-zinc-200: var(--color-slate-200);
-    --color-zinc-300: var(--color-slate-300);
-    --color-zinc-400: var(--color-slate-400);
-    --color-zinc-500: var(--color-slate-500);
-    --color-zinc-600: var(--color-slate-600);
-    --color-zinc-700: var(--color-slate-700);
-    --color-zinc-800: var(--color-slate-800);
-    --color-zinc-900: var(--color-slate-900);
-    --color-zinc-950: var(--color-slate-950);
+    --color-zinc-50: var(--color-paper-2);
+    --color-zinc-100: var(--color-ui-3);
+    --color-zinc-200: var(--color-ui-2);
+    --color-zinc-300: var(--color-ui-1);
+    --color-zinc-400: var(--color-ink-4);
+    --color-zinc-500: var(--color-ink-3);
+    --color-zinc-600: var(--color-ink-3);
+    --color-zinc-700: var(--color-ink-2);
+    --color-zinc-800: var(--color-ink-2);
+    --color-zinc-900: var(--color-ink);
+    --color-zinc-950: var(--color-ink);
 }
 
-@theme {
-    --color-accent: var(--color-indigo-500);
-    --color-accent-content: var(--color-indigo-600);
-    --color-accent-foreground: var(--color-white);
+/* ----------------------------------------------------------
+   Accent = Flexoki purple.
+   Light foreground = 600 stop (rich, saturated).
+   Dark  foreground = 100 stop (so it reads against #100F0F).
+   ---------------------------------------------------------- */
+:root {
+    --color-accent: var(--color-flexoki-purple-600);
+    --color-accent-content: var(--color-flexoki-purple-600);
+    --color-accent-foreground: var(--color-paper);
 }
 
 @layer theme {
     .dark {
-        --color-accent: var(--color-indigo-500);
-        --color-accent-content: var(--color-indigo-300);
-        --color-accent-foreground: var(--color-white);
+        --color-accent: var(--color-flexoki-purple-100);
+        --color-accent-content: var(--color-flexoki-purple-100);
+        --color-accent-foreground: var(--color-ink);
     }
+}
+
+/* ----------------------------------------------------------
+   Replace Tailwind's saturated default hues with Flexoki tones
+   so any incidental `text-red-500`, `bg-blue-100`, etc. picks
+   up the muted family. Flexoki has no 500/700/900 stop —
+   500 aliases 400, 700 aliases 600, 900 aliases 800.
+   ---------------------------------------------------------- */
+@theme {
+    /* Red */
+    --color-red-50: var(--color-flexoki-red-50);
+    --color-red-100: var(--color-flexoki-red-100);
+    --color-red-400: var(--color-flexoki-red-400);
+    --color-red-500: var(--color-flexoki-red-400);
+    --color-red-600: var(--color-flexoki-red-600);
+    --color-red-700: var(--color-flexoki-red-600);
+    --color-red-800: var(--color-flexoki-red-800);
+    --color-red-900: var(--color-flexoki-red-800);
+
+    /* Orange */
+    --color-orange-50: var(--color-flexoki-orange-50);
+    --color-orange-100: var(--color-flexoki-orange-100);
+    --color-orange-400: var(--color-flexoki-orange-400);
+    --color-orange-500: var(--color-flexoki-orange-400);
+    --color-orange-600: var(--color-flexoki-orange-600);
+    --color-orange-700: var(--color-flexoki-orange-600);
+    --color-orange-800: var(--color-flexoki-orange-800);
+    --color-orange-900: var(--color-flexoki-orange-800);
+
+    /* Yellow */
+    --color-yellow-50: var(--color-flexoki-yellow-50);
+    --color-yellow-100: var(--color-flexoki-yellow-100);
+    --color-yellow-400: var(--color-flexoki-yellow-400);
+    --color-yellow-500: var(--color-flexoki-yellow-400);
+    --color-yellow-600: var(--color-flexoki-yellow-600);
+    --color-yellow-700: var(--color-flexoki-yellow-600);
+    --color-yellow-800: var(--color-flexoki-yellow-800);
+    --color-yellow-900: var(--color-flexoki-yellow-800);
+
+    /* Green */
+    --color-green-50: var(--color-flexoki-green-50);
+    --color-green-100: var(--color-flexoki-green-100);
+    --color-green-400: var(--color-flexoki-green-400);
+    --color-green-500: var(--color-flexoki-green-400);
+    --color-green-600: var(--color-flexoki-green-600);
+    --color-green-700: var(--color-flexoki-green-600);
+    --color-green-800: var(--color-flexoki-green-800);
+    --color-green-900: var(--color-flexoki-green-800);
+
+    /* Cyan */
+    --color-cyan-50: var(--color-flexoki-cyan-50);
+    --color-cyan-100: var(--color-flexoki-cyan-100);
+    --color-cyan-400: var(--color-flexoki-cyan-400);
+    --color-cyan-500: var(--color-flexoki-cyan-400);
+    --color-cyan-600: var(--color-flexoki-cyan-600);
+    --color-cyan-700: var(--color-flexoki-cyan-600);
+    --color-cyan-800: var(--color-flexoki-cyan-800);
+    --color-cyan-900: var(--color-flexoki-cyan-800);
+
+    /* Blue */
+    --color-blue-50: var(--color-flexoki-blue-50);
+    --color-blue-100: var(--color-flexoki-blue-100);
+    --color-blue-400: var(--color-flexoki-blue-400);
+    --color-blue-500: var(--color-flexoki-blue-400);
+    --color-blue-600: var(--color-flexoki-blue-600);
+    --color-blue-700: var(--color-flexoki-blue-600);
+    --color-blue-800: var(--color-flexoki-blue-800);
+    --color-blue-900: var(--color-flexoki-blue-800);
+
+    /* Purple */
+    --color-purple-50: var(--color-flexoki-purple-50);
+    --color-purple-100: var(--color-flexoki-purple-100);
+    --color-purple-400: var(--color-flexoki-purple-400);
+    --color-purple-500: var(--color-flexoki-purple-400);
+    --color-purple-600: var(--color-flexoki-purple-600);
+    --color-purple-700: var(--color-flexoki-purple-600);
+    --color-purple-800: var(--color-flexoki-purple-800);
+    --color-purple-900: var(--color-flexoki-purple-800);
+
+    /* Pink → Flexoki magenta */
+    --color-pink-50: var(--color-flexoki-magenta-50);
+    --color-pink-100: var(--color-flexoki-magenta-100);
+    --color-pink-400: var(--color-flexoki-magenta-400);
+    --color-pink-500: var(--color-flexoki-magenta-400);
+    --color-pink-600: var(--color-flexoki-magenta-600);
+    --color-pink-700: var(--color-flexoki-magenta-600);
+    --color-pink-800: var(--color-flexoki-magenta-800);
+    --color-pink-900: var(--color-flexoki-magenta-800);
 }
 
 @layer base {
@@ -49,7 +148,7 @@
     ::before,
     ::backdrop,
     ::file-selector-button {
-        border-color: var(--color-gray-200, currentColor);
+        border-color: var(--color-ui-2, currentColor);
     }
 }
 
@@ -66,7 +165,3 @@ textarea:focus[data-flux-control],
 select:focus[data-flux-control] {
     @apply outline-hidden ring-2 ring-accent ring-offset-2 ring-offset-accent-foreground;
 }
-
-/* \[:where(&)\]:size-4 {
-    @apply size-4;
-} */

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -64,6 +64,8 @@
     /* Red */
     --color-red-50: var(--color-flexoki-red-50);
     --color-red-100: var(--color-flexoki-red-100);
+    --color-red-200: var(--color-flexoki-red-200);
+    --color-red-300: var(--color-flexoki-red-300);
     --color-red-400: var(--color-flexoki-red-400);
     --color-red-500: var(--color-flexoki-red-400);
     --color-red-600: var(--color-flexoki-red-600);
@@ -74,6 +76,8 @@
     /* Orange */
     --color-orange-50: var(--color-flexoki-orange-50);
     --color-orange-100: var(--color-flexoki-orange-100);
+    --color-orange-200: var(--color-flexoki-orange-200);
+    --color-orange-300: var(--color-flexoki-orange-300);
     --color-orange-400: var(--color-flexoki-orange-400);
     --color-orange-500: var(--color-flexoki-orange-400);
     --color-orange-600: var(--color-flexoki-orange-600);
@@ -84,6 +88,8 @@
     /* Yellow */
     --color-yellow-50: var(--color-flexoki-yellow-50);
     --color-yellow-100: var(--color-flexoki-yellow-100);
+    --color-yellow-200: var(--color-flexoki-yellow-200);
+    --color-yellow-300: var(--color-flexoki-yellow-300);
     --color-yellow-400: var(--color-flexoki-yellow-400);
     --color-yellow-500: var(--color-flexoki-yellow-400);
     --color-yellow-600: var(--color-flexoki-yellow-600);
@@ -94,6 +100,8 @@
     /* Green */
     --color-green-50: var(--color-flexoki-green-50);
     --color-green-100: var(--color-flexoki-green-100);
+    --color-green-200: var(--color-flexoki-green-200);
+    --color-green-300: var(--color-flexoki-green-300);
     --color-green-400: var(--color-flexoki-green-400);
     --color-green-500: var(--color-flexoki-green-400);
     --color-green-600: var(--color-flexoki-green-600);
@@ -104,6 +112,8 @@
     /* Cyan */
     --color-cyan-50: var(--color-flexoki-cyan-50);
     --color-cyan-100: var(--color-flexoki-cyan-100);
+    --color-cyan-200: var(--color-flexoki-cyan-200);
+    --color-cyan-300: var(--color-flexoki-cyan-300);
     --color-cyan-400: var(--color-flexoki-cyan-400);
     --color-cyan-500: var(--color-flexoki-cyan-400);
     --color-cyan-600: var(--color-flexoki-cyan-600);
@@ -114,6 +124,8 @@
     /* Blue */
     --color-blue-50: var(--color-flexoki-blue-50);
     --color-blue-100: var(--color-flexoki-blue-100);
+    --color-blue-200: var(--color-flexoki-blue-200);
+    --color-blue-300: var(--color-flexoki-blue-300);
     --color-blue-400: var(--color-flexoki-blue-400);
     --color-blue-500: var(--color-flexoki-blue-400);
     --color-blue-600: var(--color-flexoki-blue-600);
@@ -124,6 +136,8 @@
     /* Purple */
     --color-purple-50: var(--color-flexoki-purple-50);
     --color-purple-100: var(--color-flexoki-purple-100);
+    --color-purple-200: var(--color-flexoki-purple-200);
+    --color-purple-300: var(--color-flexoki-purple-300);
     --color-purple-400: var(--color-flexoki-purple-400);
     --color-purple-500: var(--color-flexoki-purple-400);
     --color-purple-600: var(--color-flexoki-purple-600);
@@ -134,6 +148,8 @@
     /* Pink → Flexoki magenta */
     --color-pink-50: var(--color-flexoki-magenta-50);
     --color-pink-100: var(--color-flexoki-magenta-100);
+    --color-pink-200: var(--color-flexoki-magenta-200);
+    --color-pink-300: var(--color-flexoki-magenta-300);
     --color-pink-400: var(--color-flexoki-magenta-400);
     --color-pink-500: var(--color-flexoki-magenta-400);
     --color-pink-600: var(--color-flexoki-magenta-600);

--- a/resources/css/flexoki.css
+++ b/resources/css/flexoki.css
@@ -21,6 +21,8 @@
     /* Red */
     --color-flexoki-red-50: #fbe8e8;
     --color-flexoki-red-100: #f0b8b3;
+    --color-flexoki-red-200: #f89a8a;
+    --color-flexoki-red-300: #e8705f;
     --color-flexoki-red-400: #d14d41;
     --color-flexoki-red-600: #af3029;
     --color-flexoki-red-800: #5c1a16;
@@ -28,6 +30,8 @@
     /* Orange */
     --color-flexoki-orange-50: #fce6d2;
     --color-flexoki-orange-100: #f2bd93;
+    --color-flexoki-orange-200: #f9ae77;
+    --color-flexoki-orange-300: #ec8b49;
     --color-flexoki-orange-400: #da702c;
     --color-flexoki-orange-600: #a8520f;
     --color-flexoki-orange-800: #5a2c08;
@@ -35,6 +39,8 @@
     /* Yellow */
     --color-flexoki-yellow-50: #faeec8;
     --color-flexoki-yellow-100: #efd688;
+    --color-flexoki-yellow-200: #eccb60;
+    --color-flexoki-yellow-300: #dfb431;
     --color-flexoki-yellow-400: #d0a215;
     --color-flexoki-yellow-600: #ad8301;
     --color-flexoki-yellow-800: #5a4500;
@@ -42,6 +48,8 @@
     /* Green */
     --color-flexoki-green-50: #edeecf;
     --color-flexoki-green-100: #bfc97b;
+    --color-flexoki-green-200: #bec97e;
+    --color-flexoki-green-300: #a0af54;
     --color-flexoki-green-400: #879a39;
     --color-flexoki-green-600: #617a19;
     --color-flexoki-green-800: #33420c;
@@ -49,6 +57,8 @@
     /* Cyan */
     --color-flexoki-cyan-50: #eaf3f3;
     --color-flexoki-cyan-100: #a8d8d8;
+    --color-flexoki-cyan-200: #87d3c3;
+    --color-flexoki-cyan-300: #5abdac;
     --color-flexoki-cyan-400: #24837b;
     --color-flexoki-cyan-600: #1a5e58;
     --color-flexoki-cyan-800: #0f3d39;
@@ -56,6 +66,8 @@
     /* Blue */
     --color-flexoki-blue-50: #e0eaf7;
     --color-flexoki-blue-100: #9dbce6;
+    --color-flexoki-blue-200: #92bfdb;
+    --color-flexoki-blue-300: #66a0c8;
     --color-flexoki-blue-400: #205ea6;
     --color-flexoki-blue-600: #103e83;
     --color-flexoki-blue-800: #0a2553;
@@ -63,6 +75,8 @@
     /* Purple — Stave's primary accent */
     --color-flexoki-purple-50: #f0eafa;
     --color-flexoki-purple-100: #d3bfef;
+    --color-flexoki-purple-200: #c4b9e0;
+    --color-flexoki-purple-300: #a699d0;
     --color-flexoki-purple-400: #8b7ec8;
     --color-flexoki-purple-600: #5e409d;
     --color-flexoki-purple-800: #3c2a6e;
@@ -70,6 +84,8 @@
     /* Magenta */
     --color-flexoki-magenta-50: #f7dcec;
     --color-flexoki-magenta-100: #e5a3c8;
+    --color-flexoki-magenta-200: #f4a4c2;
+    --color-flexoki-magenta-300: #e47da8;
     --color-flexoki-magenta-400: #a02f6f;
     --color-flexoki-magenta-600: #751f50;
     --color-flexoki-magenta-800: #3f1029;

--- a/resources/css/flexoki.css
+++ b/resources/css/flexoki.css
@@ -1,0 +1,91 @@
+/* resources/css/flexoki.css
+   Flexoki-derived palette + semantic surface tokens.
+   Source palette: https://stephango.com/flexoki
+*/
+
+@theme {
+    /* ── Surface tokens (light mode defaults) ── */
+    --color-paper: #faf9f6;
+    --color-paper-2: #f1f0ed;
+
+    --color-ink: #16161a;
+    --color-ink-2: #343331;
+    --color-ink-3: #6f6e69;
+    --color-ink-4: #878580;
+
+    --color-ui-1: #cecdc3;
+    --color-ui-2: #dad8ce;
+    --color-ui-3: #e6e5e1;
+
+    /* ── Accent ramps ── */
+    /* Red */
+    --color-flexoki-red-50: #fbe8e8;
+    --color-flexoki-red-100: #f0b8b3;
+    --color-flexoki-red-400: #d14d41;
+    --color-flexoki-red-600: #af3029;
+    --color-flexoki-red-800: #5c1a16;
+
+    /* Orange */
+    --color-flexoki-orange-50: #fce6d2;
+    --color-flexoki-orange-100: #f2bd93;
+    --color-flexoki-orange-400: #da702c;
+    --color-flexoki-orange-600: #a8520f;
+    --color-flexoki-orange-800: #5a2c08;
+
+    /* Yellow */
+    --color-flexoki-yellow-50: #faeec8;
+    --color-flexoki-yellow-100: #efd688;
+    --color-flexoki-yellow-400: #d0a215;
+    --color-flexoki-yellow-600: #ad8301;
+    --color-flexoki-yellow-800: #5a4500;
+
+    /* Green */
+    --color-flexoki-green-50: #edeecf;
+    --color-flexoki-green-100: #bfc97b;
+    --color-flexoki-green-400: #879a39;
+    --color-flexoki-green-600: #617a19;
+    --color-flexoki-green-800: #33420c;
+
+    /* Cyan */
+    --color-flexoki-cyan-50: #eaf3f3;
+    --color-flexoki-cyan-100: #a8d8d8;
+    --color-flexoki-cyan-400: #24837b;
+    --color-flexoki-cyan-600: #1a5e58;
+    --color-flexoki-cyan-800: #0f3d39;
+
+    /* Blue */
+    --color-flexoki-blue-50: #e0eaf7;
+    --color-flexoki-blue-100: #9dbce6;
+    --color-flexoki-blue-400: #205ea6;
+    --color-flexoki-blue-600: #103e83;
+    --color-flexoki-blue-800: #0a2553;
+
+    /* Purple — Stave's primary accent */
+    --color-flexoki-purple-50: #f0eafa;
+    --color-flexoki-purple-100: #d3bfef;
+    --color-flexoki-purple-400: #8b7ec8;
+    --color-flexoki-purple-600: #5e409d;
+    --color-flexoki-purple-800: #3c2a6e;
+
+    /* Magenta */
+    --color-flexoki-magenta-50: #f7dcec;
+    --color-flexoki-magenta-100: #e5a3c8;
+    --color-flexoki-magenta-400: #a02f6f;
+    --color-flexoki-magenta-600: #751f50;
+    --color-flexoki-magenta-800: #3f1029;
+}
+
+/* ── Dark mode surface tokens ── */
+.dark {
+    --color-paper: #100f0f;
+    --color-paper-2: #1c1b1a;
+
+    --color-ink: #fffcf0;
+    --color-ink-2: #e6e3d3;
+    --color-ink-3: #878580;
+    --color-ink-4: #6f6e69;
+
+    --color-ui-1: #343331;
+    --color-ui-2: #282726;
+    --color-ui-3: #1c1b1a;
+}


### PR DESCRIPTION
## Summary
- Re-skins the application with a Flexoki-derived palette: warm cream surfaces (`#FAF9F6` page, `#F1F0ED` panels, `#DAD8CE` borders) and `purple-600` (`#5E409D`) as the rich primary accent in light mode (`purple-100` in dark).
- New `resources/css/flexoki.css` defines the full Flexoki palette plus semantic surface tokens (`paper`, `ink`, `ui-*`); `app.css` rewires Flux's `--color-zinc-*` scale and `--color-accent-*` to those tokens, and aliases Tailwind's default hues to muted Flexoki tones so incidental `bg-red-500`/`text-blue-400`/etc. pick up the new family.
- CSS-only — no Blade, Livewire, or Flux component edits. Implements the v2 handoff from Claude Design verbatim, including §5.3 hue replacements for all 8 families.

## Test plan
- [x] `npm run build` — clean
- [x] `vendor/bin/pint --dirty --format agent` — passed
- [x] `vendor/bin/pest --parallel --testsuite=Feature` — 242 passed, 2 skipped
- [ ] Spot-check at `https://stave.test`: primary buttons render `#5E409D` with paper text, sidebar `#F1F0ED`, default borders warm `#DAD8CE`, `.dark` flips paper to `#100F0F` with `purple-100` accent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dark mode theme support now available with adaptive colors

* **Style**
  * Updated to Flexoki color theme with semantic color tokens
  * Redesigned accent color system using purple-based palette
  * Enhanced color consistency across light and dark modes

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jpangborn/stave/pull/80)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->