### PR TITLE
Fix dark mode broken after Flexoki theme adoption

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -16,23 +16,25 @@
 }
 
 /* ----------------------------------------------------------
-   Redefine Flux's `zinc` scale → semantic surface tokens.
+   Redefine Flux's `zinc` scale → Flexoki base gray scale.
    Flux uses `zinc` for nearly every gray (sidebar, borders,
-   text, inputs). Pointing each stop at our paper/ink/ui
-   tokens re-skins the entire surface system in one shot.
+   text, inputs). The base scale is static (does NOT flip
+   between modes), so the canonical `bg-zinc-50 dark:bg-zinc-900`
+   pattern keeps working: light bg in light mode, dark bg in
+   dark mode. Visual identity stays Flexoki (warm gray family).
    ---------------------------------------------------------- */
 @theme {
-    --color-zinc-50: var(--color-paper-2);
-    --color-zinc-100: var(--color-ui-3);
-    --color-zinc-200: var(--color-ui-2);
-    --color-zinc-300: var(--color-ui-1);
-    --color-zinc-400: var(--color-ink-4);
-    --color-zinc-500: var(--color-ink-3);
-    --color-zinc-600: var(--color-ink-3);
-    --color-zinc-700: var(--color-ink-2);
-    --color-zinc-800: var(--color-ink-2);
-    --color-zinc-900: var(--color-ink);
-    --color-zinc-950: var(--color-ink);
+    --color-zinc-50: var(--color-flexoki-base-50);
+    --color-zinc-100: var(--color-flexoki-base-100);
+    --color-zinc-200: var(--color-flexoki-base-200);
+    --color-zinc-300: var(--color-flexoki-base-300);
+    --color-zinc-400: var(--color-flexoki-base-400);
+    --color-zinc-500: var(--color-flexoki-base-500);
+    --color-zinc-600: var(--color-flexoki-base-600);
+    --color-zinc-700: var(--color-flexoki-base-700);
+    --color-zinc-800: var(--color-flexoki-base-800);
+    --color-zinc-900: var(--color-flexoki-base-900);
+    --color-zinc-950: var(--color-flexoki-base-950);
 }
 
 /* ----------------------------------------------------------
@@ -50,7 +52,9 @@
     .dark {
         --color-accent: var(--color-flexoki-purple-100);
         --color-accent-content: var(--color-flexoki-purple-100);
-        --color-accent-foreground: var(--color-ink);
+        /* --color-accent-foreground is left to Flux's default
+           (var(--color-zinc-800)), which resolves to a dark gray with
+           our static zinc scale — readable on the light lavender accent. */
     }
 }
 

--- a/resources/css/flexoki.css
+++ b/resources/css/flexoki.css
@@ -17,6 +17,24 @@
     --color-ui-2: #dad8ce;
     --color-ui-3: #e6e5e1;
 
+    /* ── Custom base gray scale (static, not mode-flipping) ──
+       Used to rewire Tailwind's `--color-zinc-*` so the scale
+       keeps its 50→950 light→dark gradient in both modes.
+       Mirrors the custom warm-cream surface tokens above where
+       they exist; falls back to Flexoki spec for stops the custom
+       palette doesn't define (300, 600, 800, 950). */
+    --color-flexoki-base-50: #f1f0ed;  /* custom paper-2 */
+    --color-flexoki-base-100: #e6e5e1; /* custom ui-3 */
+    --color-flexoki-base-200: #dad8ce; /* custom ui-2 */
+    --color-flexoki-base-300: #cecdc3; /* custom ui-1 */
+    --color-flexoki-base-400: #878580; /* custom ink-4 (= Flexoki 400) */
+    --color-flexoki-base-500: #6f6e69; /* custom ink-3 (= Flexoki 500) */
+    --color-flexoki-base-600: #575653; /* Flexoki 600 (custom palette has no stop here) */
+    --color-flexoki-base-700: #343331; /* custom ink-2 */
+    --color-flexoki-base-800: #282726; /* Flexoki 800 (custom palette has no stop here) */
+    --color-flexoki-base-900: #16161a; /* custom ink */
+    --color-flexoki-base-950: #100f0f; /* Flexoki black */
+
     /* ── Accent ramps ── */
     /* Red */
     --color-flexoki-red-50: #fbe8e8;


### PR DESCRIPTION
## Summary

Fixes #81. The Flexoki commit (#80) mapped Tailwind's `--color-zinc-*` onto semantic surface tokens (`paper`, `ui-*`, `ink-*`) that flip light↔dark with the `.dark` class, which inverted the zinc scale in dark mode — every `dark:bg-zinc-900` and `dark:border-zinc-700` resolved to cream instead of dark, and the `.dark` override of `--color-accent-foreground` to `var(--color-ink)` flipped to cream too, breaking button contrast. This PR adds a static `--color-flexoki-base-{50..950}` gray ramp that mirrors the custom warm-cream palette where it has stops and falls back to Flexoki spec for gaps, then repoints zinc at it so the gradient stays light→dark in both modes; the buggy `--color-accent-foreground` override is dropped so Flux's default (`var(--color-zinc-800)`) provides a dark foreground on the light-lavender accent. Light mode is pixel-identical for every zinc surface the custom palette defined; dark mode goes from broken to correct.

## Test plan

- [ ] `npm run build` succeeds
- [ ] `/dashboard` (dark mode hardcoded) renders a dark header/body, not cream
- [ ] Accent buttons show dark text on light-lavender bg, readable
- [ ] Group conversation comment bubbles, series detail pages, section table cells render dark surfaces in dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Updated the gray color scale to use a static base gradient across light and dark modes.
  * Refined dark mode accent color behavior for improved theme consistency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jpangborn/stave/pull/82)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->