### PR TITLE
Redesign group conversation page with pin, prayer, scripture links

### DIFF
--- a/app/Models/Comment.php
+++ b/app/Models/Comment.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+use Spatie\Comments\Models\Comment as SpatieComment;
+
+/**
+ * @property ?Carbon $pinned_at
+ * @property ?int $pinned_by_user_id
+ * @property bool $is_prayer
+ */
+class Comment extends SpatieComment
+{
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return [
+            'pinned_at' => 'datetime',
+            'is_prayer' => 'boolean',
+        ];
+    }
+
+    /** @return BelongsTo<User, $this> */
+    public function pinnedBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'pinned_by_user_id');
+    }
+
+    public function isPinned(): bool
+    {
+        return $this->pinned_at !== null;
+    }
+
+    public function pin(User $pinnedBy): self
+    {
+        $this->forceFill([
+            'pinned_at' => now(),
+            'pinned_by_user_id' => $pinnedBy->id,
+        ])->save();
+
+        return $this;
+    }
+
+    public function unpin(): self
+    {
+        $this->forceFill([
+            'pinned_at' => null,
+            'pinned_by_user_id' => null,
+        ])->save();
+
+        return $this;
+    }
+
+    public function togglePrayer(): self
+    {
+        $this->forceFill(['is_prayer' => ! $this->is_prayer])->save();
+
+        return $this;
+    }
+}

--- a/app/Models/Conversation.php
+++ b/app/Models/Conversation.php
@@ -7,8 +7,8 @@ use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Support\Carbon;
-use Spatie\Comments\Models\Comment;
 use Spatie\Comments\Models\Concerns\HasComments;
 use Spatie\Comments\Models\Concerns\Interfaces\CanComment;
 
@@ -41,9 +41,22 @@ class Conversation extends Model
         return $this->belongsTo(User::class, 'user_id');
     }
 
-    public function postComment(string $text, ?CanComment $commentator = null): Comment
+    /** @return MorphMany<Comment, $this> */
+    public function pinnedComments(): MorphMany
     {
+        return $this->morphMany(Comment::class, 'commentable')
+            ->whereNotNull('pinned_at')
+            ->orderByDesc('pinned_at');
+    }
+
+    public function postComment(string $text, ?CanComment $commentator = null, bool $isPrayer = false): Comment
+    {
+        /** @var Comment $comment */
         $comment = $this->comment($text, $commentator);
+
+        if ($isPrayer) {
+            $comment->forceFill(['is_prayer' => true])->save();
+        }
 
         $this->forceFill(['last_comment_at' => $comment->created_at])->save();
 

--- a/app/Policies/CommentPolicy.php
+++ b/app/Policies/CommentPolicy.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Comment;
+use App\Models\Conversation;
+use App\Models\User;
+
+class CommentPolicy
+{
+    public function pin(User $user, Comment $comment): bool
+    {
+        $conversation = $this->conversationFor($comment);
+
+        if (! $conversation instanceof Conversation) {
+            return false;
+        }
+
+        return $this->isAuthor($user, $comment)
+            || $conversation->group->hasLeader($user);
+    }
+
+    public function unpin(User $user, Comment $comment): bool
+    {
+        return $this->pin($user, $comment);
+    }
+
+    public function markPrayer(User $user, Comment $comment): bool
+    {
+        $conversation = $this->conversationFor($comment);
+
+        if (! $conversation instanceof Conversation) {
+            return false;
+        }
+
+        return $conversation->group->hasActiveMember($user);
+    }
+
+    private function conversationFor(Comment $comment): ?Conversation
+    {
+        $commentable = $comment->commentable;
+
+        return $commentable instanceof Conversation ? $commentable : null;
+    }
+
+    private function isAuthor(User $user, Comment $comment): bool
+    {
+        return $comment->commentator_type === $user->getMorphClass()
+            && $comment->commentator_id === $user->id;
+    }
+}

--- a/app/Services/ScriptureLinker.php
+++ b/app/Services/ScriptureLinker.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace App\Services;
+
+use DOMDocument;
+use DOMText;
+use DOMXPath;
+
+class ScriptureLinker
+{
+    /**
+     * Matches "Romans 8:31", "John 1:14", "1 Corinthians 13:4", "Romans 8:31-39", "Romans 8:31–39".
+     *
+     * Group 1: optional numeric prefix (1, 2, 3, I, II, III)
+     * Group 2: book name (single title-cased word — every canonical book is a single token)
+     * Group 3: chapter
+     * Group 4: verse or verse range
+     *
+     * Restricting the book to one token prevents an adjacent capitalized word
+     * ("See Romans 8:31") from being swept into the match.
+     */
+    private const SCRIPTURE_REGEX = '/\b((?:1|2|3|I|II|III)\s+)?([A-Z][a-z]+)\s(\d+):(\d+(?:[\x{2013}-]\d+)?)\b/u';
+
+    /** @var array<int, string> Canonical book names. The captured book token must appear here for the ref to link. */
+    private const CANONICAL_BOOKS = [
+        'Genesis', 'Exodus', 'Leviticus', 'Numbers', 'Deuteronomy', 'Joshua', 'Judges', 'Ruth',
+        'Samuel', 'Kings', 'Chronicles', 'Ezra', 'Nehemiah', 'Esther', 'Job', 'Psalms', 'Psalm',
+        'Proverbs', 'Ecclesiastes', 'Song', 'Isaiah', 'Jeremiah', 'Lamentations', 'Ezekiel',
+        'Daniel', 'Hosea', 'Joel', 'Amos', 'Obadiah', 'Jonah', 'Micah', 'Nahum', 'Habakkuk',
+        'Zephaniah', 'Haggai', 'Zechariah', 'Malachi', 'Matthew', 'Mark', 'Luke', 'John', 'Acts',
+        'Romans', 'Corinthians', 'Galatians', 'Ephesians', 'Philippians', 'Colossians',
+        'Thessalonians', 'Timothy', 'Titus', 'Philemon', 'Hebrews', 'James', 'Peter', 'Jude',
+        'Revelation',
+    ];
+
+    public function linkify(string $html): string
+    {
+        if (trim($html) === '') {
+            return $html;
+        }
+
+        $dom = new DOMDocument();
+        $previous = libxml_use_internal_errors(true);
+        // Wrap in a synthetic root so the input is treated as a fragment and not auto-wrapped in <html>/<body>.
+        $dom->loadHTML(
+            '<?xml encoding="UTF-8"?><div data-scripture-root>'.$html.'</div>',
+            LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD
+        );
+        libxml_clear_errors();
+        libxml_use_internal_errors($previous);
+
+        $xpath = new DOMXPath($dom);
+        $textNodes = $xpath->query('//text()[not(ancestor::a)]');
+
+        if ($textNodes !== false) {
+            foreach ($textNodes as $textNode) {
+                /** @var DOMText $textNode */
+                $this->linkifyTextNode($dom, $textNode);
+            }
+        }
+
+        $root = $dom->getElementsByTagName('div')->item(0);
+        if ($root === null) {
+            return $html;
+        }
+
+        $output = '';
+        foreach ($root->childNodes as $child) {
+            $output .= $dom->saveHTML($child);
+        }
+
+        return $output;
+    }
+
+    private function linkifyTextNode(DOMDocument $dom, DOMText $textNode): void
+    {
+        $text = $textNode->nodeValue ?? '';
+
+        if (preg_match_all(self::SCRIPTURE_REGEX, $text, $matches, PREG_OFFSET_CAPTURE) === false) {
+            return;
+        }
+
+        if ($matches[0] === []) {
+            return;
+        }
+
+        $fragment = $dom->createDocumentFragment();
+        $cursor = 0;
+        $emitted = false;
+
+        foreach ($matches[0] as $i => [$full, $offset]) {
+            $book = $matches[2][$i][0];
+
+            if (! in_array($book, self::CANONICAL_BOOKS, true)) {
+                continue;
+            }
+
+            if ($offset > $cursor) {
+                $fragment->appendChild($dom->createTextNode(substr($text, $cursor, $offset - $cursor)));
+            }
+
+            $anchor = $dom->createElement('a');
+            $anchor->setAttribute('class', 'scripture-ref');
+            $anchor->setAttribute('href', 'https://www.biblegateway.com/passage/?search='.urlencode($full));
+            $anchor->setAttribute('target', '_blank');
+            $anchor->setAttribute('rel', 'noopener');
+            $anchor->appendChild($dom->createTextNode($full));
+            $fragment->appendChild($anchor);
+
+            $cursor = $offset + strlen($full);
+            $emitted = true;
+        }
+
+        if (! $emitted) {
+            return;
+        }
+
+        if ($cursor < strlen($text)) {
+            $fragment->appendChild($dom->createTextNode(substr($text, $cursor)));
+        }
+
+        $textNode->parentNode?->replaceChild($fragment, $textNode);
+    }
+}

--- a/config/comments.php
+++ b/config/comments.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Models\Comment;
 use App\Models\User;
 use App\Notifications\ServiceCommentNotification;
 use Spatie\Comments\Actions\ApproveCommentAction;
@@ -8,7 +9,6 @@ use Spatie\Comments\Actions\RejectCommentAction;
 use Spatie\Comments\Actions\ResolveMentionsAutocompleteAction;
 use Spatie\Comments\Actions\SendNotificationsForApprovedCommentAction;
 use Spatie\Comments\Actions\SendNotificationsForPendingCommentAction;
-use Spatie\Comments\Models\Comment;
 use Spatie\Comments\Models\CommentNotificationSubscription;
 use Spatie\Comments\Models\Reaction;
 use Spatie\Comments\Notifications\PendingCommentNotification;

--- a/database/migrations/2026_05_15_235459_add_pin_and_prayer_to_comments_table.php
+++ b/database/migrations/2026_05_15_235459_add_pin_and_prayer_to_comments_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('comments', function (Blueprint $table): void {
+            $table->timestamp('pinned_at')->nullable()->after('approved_at');
+            $table->foreignId('pinned_by_user_id')->nullable()->after('pinned_at')->constrained('users')->nullOnDelete();
+            $table->boolean('is_prayer')->default(false)->after('pinned_by_user_id');
+
+            $table->index(['commentable_type', 'commentable_id', 'pinned_at'], 'comments_pinned_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('comments', function (Blueprint $table): void {
+            $table->dropIndex('comments_pinned_idx');
+            $table->dropConstrainedForeignId('pinned_by_user_id');
+            $table->dropColumn(['pinned_at', 'is_prayer']);
+        });
+    }
+};

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -185,3 +185,12 @@ textarea:focus[data-flux-control],
 select:focus[data-flux-control] {
     @apply outline-hidden ring-2 ring-accent ring-offset-2 ring-offset-accent-foreground;
 }
+
+a.scripture-ref {
+    @apply inline-block rounded px-1.5 py-0.5 text-[0.95em] font-semibold text-accent no-underline whitespace-nowrap;
+    background-color: color-mix(in oklab, var(--color-accent) 12%, transparent);
+}
+
+a.scripture-ref:hover {
+    background-color: color-mix(in oklab, var(--color-accent) 20%, transparent);
+}

--- a/resources/views/pages/groups/conversations/show.blade.php
+++ b/resources/views/pages/groups/conversations/show.blade.php
@@ -81,7 +81,7 @@ new class extends Component {
     public function contributors(): BaseCollection
     {
         $contributorIds = $this->conversation->comments()
-            ->where('commentator_type', User::class)
+            ->where('commentator_type', (new User)->getMorphClass())
             ->distinct()
             ->pluck('commentator_id');
 
@@ -240,7 +240,8 @@ new class extends Component {
                     <flux:subheading class="mt-1">
                         Started by {{ $conversation->creator?->name ?? 'Unknown' }}
                         · {{ $conversation->created_at->diffForHumans() }}
-                        · {{ $this->memberCount() }} {{ str('member')->plural($this->memberCount()) }}
+                        @php($memberCount = $this->memberCount())
+                        · {{ $memberCount }} {{ str('member')->plural($memberCount) }}
                     </flux:subheading>
                 </div>
 
@@ -318,7 +319,7 @@ new class extends Component {
                         {{ Str::limit(strip_tags($firstPinned->text), 140) }}
                     </div>
                 </div>
-                <flux:button wire:click="dismissPinnedStrip" variant="ghost" size="sm" icon="x-mark" square />
+                <flux:button wire:click="dismissPinnedStrip" variant="ghost" size="sm" icon="x-mark" square aria-label="Dismiss pinned message" />
             </div>
         @endif
 
@@ -328,6 +329,20 @@ new class extends Component {
                 @php($currentUser = Auth::user())
                 @php($canComment = $currentUser?->can('comment', $conversation) ?? false)
                 @php($quickReactions = array_slice(Config::allowedReactions(), 0, 6))
+
+                @if ($this->comments->isEmpty())
+                    <div class="flex flex-col items-center justify-center px-6 py-16 text-center" data-test="empty-state">
+                        <flux:icon.chat-bubble-left-right class="size-10 text-zinc-300 dark:text-zinc-600" />
+                        <flux:heading size="lg" class="mt-4">No messages yet</flux:heading>
+                        <flux:subheading class="mt-1">
+                            @if ($canComment)
+                                Kick things off — your reply will start the thread.
+                            @else
+                                Be the first to post here once messaging opens up.
+                            @endif
+                        </flux:subheading>
+                    </div>
+                @endif
 
                 @foreach ($this->groupedComments as $dateString => $dayComments)
                     <div class="my-2 flex items-center gap-3.5 px-2 py-3" data-test="day-divider">
@@ -445,10 +460,10 @@ new class extends Component {
 
                             {{-- Hover toolbar --}}
                             @if ($canComment)
-                                <div class="absolute -top-3 right-4 hidden items-center gap-0.5 rounded-md border border-zinc-200 bg-white p-0.5 shadow-md group-hover/row:flex dark:border-zinc-700 dark:bg-zinc-900" data-test="hover-toolbar">
+                                <div class="absolute -top-3 right-4 hidden items-center gap-0.5 rounded-md border border-zinc-200 bg-white p-0.5 shadow-md group-hover/row:flex group-focus-within/row:flex dark:border-zinc-700 dark:bg-zinc-900" data-test="hover-toolbar" role="toolbar" aria-label="Message actions">
                                     <flux:dropdown align="end">
                                         <flux:tooltip content="React">
-                                            <button type="button" class="flex size-7 items-center justify-center rounded text-zinc-500 hover:bg-zinc-100 hover:text-zinc-900 dark:hover:bg-zinc-800 dark:hover:text-white">
+                                            <button type="button" aria-label="React" class="flex size-7 items-center justify-center rounded text-zinc-500 hover:bg-zinc-100 hover:text-zinc-900 focus-visible:bg-zinc-100 focus-visible:text-zinc-900 focus-visible:outline-none dark:hover:bg-zinc-800 dark:hover:text-white dark:focus-visible:bg-zinc-800 dark:focus-visible:text-white">
                                                 <flux:icon.face-smile variant="micro" />
                                             </button>
                                         </flux:tooltip>
@@ -462,18 +477,21 @@ new class extends Component {
                                     </flux:dropdown>
 
                                     <flux:tooltip content="Reply (coming soon)">
-                                        <button type="button" disabled class="flex size-7 cursor-not-allowed items-center justify-center rounded text-zinc-300 dark:text-zinc-600" data-test="reply-stub">
+                                        <button type="button" aria-label="Reply (coming soon)" disabled class="flex size-7 cursor-not-allowed items-center justify-center rounded text-zinc-300 dark:text-zinc-600" data-test="reply-stub">
                                             <flux:icon.arrow-uturn-left variant="micro" />
                                         </button>
                                     </flux:tooltip>
 
                                     @can('markPrayer', $comment)
-                                        <flux:tooltip content="{{ $comment->is_prayer ? 'Unmark prayer' : 'Mark as prayer' }}">
+                                        @php($prayerLabel = $comment->is_prayer ? 'Unmark prayer' : 'Mark as prayer')
+                                        <flux:tooltip content="{{ $prayerLabel }}">
                                             <button
                                                 type="button"
                                                 wire:click="togglePrayer({{ $comment->id }})"
+                                                aria-label="{{ $prayerLabel }}"
+                                                aria-pressed="{{ $comment->is_prayer ? 'true' : 'false' }}"
                                                 @class([
-                                                    'flex size-7 items-center justify-center rounded',
+                                                    'flex size-7 items-center justify-center rounded focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent',
                                                     'text-accent bg-accent/10 hover:bg-accent/20' => $comment->is_prayer,
                                                     'text-zinc-500 hover:bg-zinc-100 hover:text-zinc-900 dark:hover:bg-zinc-800 dark:hover:text-white' => ! $comment->is_prayer,
                                                 ])
@@ -488,7 +506,7 @@ new class extends Component {
                                     @can('pin', $comment)
                                         <flux:dropdown align="end">
                                             <flux:tooltip content="More">
-                                                <button type="button" class="flex size-7 items-center justify-center rounded text-zinc-500 hover:bg-zinc-100 hover:text-zinc-900 dark:hover:bg-zinc-800 dark:hover:text-white" data-test="more-trigger">
+                                                <button type="button" aria-label="More actions" aria-haspopup="menu" class="flex size-7 items-center justify-center rounded text-zinc-500 hover:bg-zinc-100 hover:text-zinc-900 focus-visible:bg-zinc-100 focus-visible:text-zinc-900 focus-visible:outline-none dark:hover:bg-zinc-800 dark:hover:text-white dark:focus-visible:bg-zinc-800 dark:focus-visible:text-white" data-test="more-trigger">
                                                     <flux:icon.ellipsis-horizontal variant="micro" />
                                                 </button>
                                             </flux:tooltip>
@@ -535,6 +553,7 @@ new class extends Component {
                             <button
                                 type="button"
                                 wire:click="$toggle('replyIsPrayer')"
+                                aria-pressed="{{ $replyIsPrayer ? 'true' : 'false' }}"
                                 @class([
                                     'inline-flex h-7 items-center gap-1.5 rounded-full border px-3 text-xs font-semibold transition-colors',
                                     'border-yellow-300 bg-yellow-50 text-yellow-800 dark:border-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-200' => $replyIsPrayer,

--- a/resources/views/pages/groups/conversations/show.blade.php
+++ b/resources/views/pages/groups/conversations/show.blade.php
@@ -1,13 +1,18 @@
 <?php
 
+use App\Models\Comment;
 use App\Models\Conversation;
 use App\Models\Group;
+use App\Models\User;
+use App\Services\ScriptureLinker;
 use Flux\Flux;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Str;
 use Livewire\Attributes\Computed;
 use Livewire\Component;
-use Spatie\Comments\Models\Comment;
 use Spatie\Comments\Support\Config;
 
 new class extends Component {
@@ -15,6 +20,10 @@ new class extends Component {
     public Conversation $conversation;
 
     public string $reply = '';
+
+    public bool $replyIsPrayer = false;
+
+    public bool $pinnedStripOpen = true;
 
     public function mount(Group $group, Conversation $conversation): void
     {
@@ -37,6 +46,88 @@ new class extends Component {
             ->get();
     }
 
+    /** @return Collection<int, Comment> */
+    #[Computed]
+    public function pinnedComments(): Collection
+    {
+        /** @var Collection<int, Comment> */
+        return $this->conversation->pinnedComments()
+            ->with('pinnedBy')
+            ->get();
+    }
+
+    /** @return Collection<int, User> */
+    #[Computed]
+    public function members(): Collection
+    {
+        /** @var Collection<int, User> */
+        return $this->group->members()->orderBy('name')->get();
+    }
+
+    public function memberCount(): int
+    {
+        return $this->members->count();
+    }
+
+    /** @return BaseCollection<int, User> */
+    #[Computed]
+    public function displayedMembers(): BaseCollection
+    {
+        return $this->members->take(4);
+    }
+
+    /** @return BaseCollection<int, User> */
+    #[Computed]
+    public function contributors(): BaseCollection
+    {
+        $contributorIds = $this->conversation->comments()
+            ->where('commentator_type', User::class)
+            ->distinct()
+            ->pluck('commentator_id');
+
+        return $this->members->filter(fn (User $user): bool => $contributorIds->contains($user->id))->values();
+    }
+
+    /** @return BaseCollection<int, User> */
+    #[Computed]
+    public function nonContributors(): BaseCollection
+    {
+        $contributorIds = $this->contributors->pluck('id');
+
+        return $this->members->reject(fn (User $user): bool => $contributorIds->contains($user->id))->values();
+    }
+
+    /** @return BaseCollection<int|string, Collection<int, Comment>> */
+    #[Computed]
+    public function groupedComments(): BaseCollection
+    {
+        return $this->comments->groupBy(fn (Comment $comment): string => $comment->created_at->toDateString())->collect();
+    }
+
+    /** @return array<int, string> */
+    #[Computed]
+    public function memberRoles(): array
+    {
+        return $this->members->mapWithKeys(function (User $user): array {
+            /** @var \App\Models\GroupUser $pivot */
+            $pivot = $user->getRelation('pivot');
+
+            return [$user->id => $pivot->role->label()];
+        })->all();
+    }
+
+    public function dayLabel(string $dateString): string
+    {
+        $date = Carbon::parse($dateString);
+
+        return match (true) {
+            $date->isToday() => 'Today',
+            $date->isYesterday() => 'Yesterday',
+            $date->isCurrentYear() => $date->format('M j'),
+            default => $date->format('M j, Y'),
+        };
+    }
+
     public function postReply(): void
     {
         $this->authorize('comment', $this->conversation);
@@ -51,10 +142,10 @@ new class extends Component {
             return;
         }
 
-        $this->conversation->postComment($validated['reply'], Auth::user());
+        $this->conversation->postComment($validated['reply'], Auth::user(), $this->replyIsPrayer);
 
-        $this->reset('reply');
-        unset($this->comments);
+        $this->reset('reply', 'replyIsPrayer');
+        unset($this->comments, $this->contributors, $this->nonContributors);
     }
 
     public function react(int $commentId, string $reaction): void
@@ -65,9 +156,57 @@ new class extends Component {
 
         /** @var Comment $comment */
         $comment = $this->conversation->comments()->findOrFail($commentId);
-        $comment->react($reaction);
+        $user = Auth::user();
+
+        if ($comment->findReaction($reaction, $user)) {
+            $comment->deleteReaction($reaction, $user);
+        } else {
+            $comment->react($reaction, $user);
+        }
 
         unset($this->comments);
+    }
+
+    public function pinComment(int $commentId): void
+    {
+        /** @var Comment $comment */
+        $comment = $this->conversation->comments()->findOrFail($commentId);
+
+        $this->authorize('pin', $comment);
+
+        $comment->pin(Auth::user());
+
+        $this->pinnedStripOpen = true;
+        unset($this->comments, $this->pinnedComments);
+    }
+
+    public function unpinComment(int $commentId): void
+    {
+        /** @var Comment $comment */
+        $comment = $this->conversation->comments()->findOrFail($commentId);
+
+        $this->authorize('unpin', $comment);
+
+        $comment->unpin();
+
+        unset($this->comments, $this->pinnedComments);
+    }
+
+    public function togglePrayer(int $commentId): void
+    {
+        /** @var Comment $comment */
+        $comment = $this->conversation->comments()->findOrFail($commentId);
+
+        $this->authorize('markPrayer', $comment);
+
+        $comment->togglePrayer();
+
+        unset($this->comments);
+    }
+
+    public function dismissPinnedStrip(): void
+    {
+        $this->pinnedStripOpen = false;
     }
 
     public function deleteConversation(): void
@@ -83,94 +222,406 @@ new class extends Component {
 };
 ?>
 
-<section class="w-full">
-    <div class="flex items-start justify-between gap-4">
-        <div>
+<section class="-m-6 lg:-m-8 flex h-[calc(100vh-3rem)] lg:h-[calc(100vh-4rem)] min-h-0">
+    {{-- Conversation column --}}
+    <div class="flex min-w-0 flex-1 flex-col bg-white dark:bg-zinc-800">
+        {{-- Header --}}
+        <header class="border-b border-zinc-200 px-6 pt-4 dark:border-zinc-700">
             <flux:button :href="route('groups.show', $group)" variant="ghost" size="sm" icon="arrow-left" wire:navigate>
                 Back to {{ $group->name }}
             </flux:button>
-            <flux:heading size="xl" level="1" class="mt-2">{{ $conversation->title }}</flux:heading>
-            <flux:subheading>
-                Started by {{ $conversation->creator?->name ?? 'Unknown' }} {{ $conversation->created_at->diffForHumans() }}
-            </flux:subheading>
-        </div>
 
-        @can('delete', $conversation)
-            <flux:button wire:click="deleteConversation" variant="danger" size="sm" icon="trash"
-                wire:confirm="Delete this conversation and all its messages?">
-                Delete
-            </flux:button>
-        @endcan
-    </div>
-
-    <div class="mt-8 max-w-3xl">
-        <div class="flex flex-col w-full space-y-2
-            **:[h1]:text-xl **:[h1]:font-semibold **:[h2]:text-lg **:[h2]:font-semibold **:[h3]:font-semibold
-            **:[strong]:font-semibold **:[em]:italic **:[u]:underline **:[s]:line-through
-            **:[ol]:list-decimal **:[ol]:ml-5 **:[ul]:list-disc **:[ul]:ml-5
-            **:[a]:underline
-            **:[blockquote]:border-l-4 **:[blockquote]:pl-2">
-            @php($prevUser = null)
-
-            @foreach ($this->comments as $comment)
-                <div wire:key="comment-{{ $comment->id }}" @class([
-                    'text-left max-w-3/4 space-y-2',
-                    'self-start' => ! $comment->commentator?->is(Auth::user()),
-                    'self-end' => $comment->commentator?->is(Auth::user()),
-                ])>
-                    @if ($comment->commentator?->isNot($prevUser))
-                        <div class="flex items-center space-x-2">
-                            <flux:avatar size="xs" name="{{ $comment->commentator?->name }}" color="auto" />
-                            <flux:heading>{{ $comment->commentator?->name ?? 'Unknown' }}</flux:heading>
-                            <flux:subheading class="text-xs">{{ $comment->created_at->diffForHumans() }}</flux:subheading>
-                        </div>
-                    @endif
-
-                    <div @class([
-                        'rounded-md p-2 space-y-2',
-                        'bg-zinc-100 dark:bg-zinc-800' => ! $comment->commentator?->is(Auth::user()),
-                        'bg-accent text-white' => $comment->commentator?->is(Auth::user()),
-                    ])>
-                        {!! $comment->text !!}
+            <div class="mt-3 flex items-start justify-between gap-4">
+                <div class="min-w-0 flex-1">
+                    <div class="flex items-center gap-2.5">
+                        <flux:heading size="xl" level="1">{{ $conversation->title }}</flux:heading>
+                        <flux:badge size="sm" :color="$group->visibility->color()">{{ $group->name }}</flux:badge>
                     </div>
-                    <div class="flex flex-row-reverse items-center space-x-3 -mt-1.5">
-                        @can('comment', $conversation)
-                            <flux:dropdown hover position="{{ $comment->commentator?->is(Auth::user()) ? 'left' : 'right' }}" align="center">
-                                <flux:button size="sm" variant="ghost" icon="face-smile" />
-                                <flux:popover>
-                                    <div class="flex">
-                                        @foreach (Config::allowedReactions() as $allowedReaction)
-                                            <flux:button size="sm" variant="ghost" square wire:click="react({{ $comment->id }}, '{{ $allowedReaction }}')">{{ $allowedReaction }}</flux:button>
-                                        @endforeach
-                                    </div>
-                                </flux:popover>
-                            </flux:dropdown>
-                        @endcan
-                        @foreach ($comment->reactions->summary() as $reaction)
-                            <span wire:key="reaction-{{ $comment->id }}-{{ $reaction['reaction'] }}" class="bg-zinc-100 dark:bg-zinc-800 rounded-full py-1 px-2">{{ $reaction['reaction'] }} {{ $reaction['count'] }}</span>
+                    <flux:subheading class="mt-1">
+                        Started by {{ $conversation->creator?->name ?? 'Unknown' }}
+                        · {{ $conversation->created_at->diffForHumans() }}
+                        · {{ $this->memberCount() }} {{ str('member')->plural($this->memberCount()) }}
+                    </flux:subheading>
+                </div>
+
+                <div class="flex items-center gap-2">
+                    {{-- Stacked avatar group --}}
+                    <div class="flex -space-x-2">
+                        @foreach ($this->displayedMembers as $member)
+                            <div class="ring-2 ring-white dark:ring-zinc-800 rounded-lg" wire:key="header-avatar-{{ $member->id }}">
+                                <flux:avatar size="xs" name="{{ $member->name }}" color="auto" />
+                            </div>
                         @endforeach
+                        @if ($this->memberCount() > 4)
+                            <div class="flex size-7 items-center justify-center rounded-lg bg-zinc-200 text-xs font-semibold text-zinc-600 ring-2 ring-white dark:bg-zinc-700 dark:text-zinc-300 dark:ring-zinc-800">
+                                +{{ $this->memberCount() - 4 }}
+                            </div>
+                        @endif
+                    </div>
+
+                    <flux:tooltip content="Search (coming soon)">
+                        <flux:button variant="ghost" size="sm" icon="magnifying-glass" square disabled />
+                    </flux:tooltip>
+
+                    @can('delete', $conversation)
+                        <flux:dropdown align="end">
+                            <flux:button variant="ghost" size="sm" icon="ellipsis-horizontal" square />
+                            <flux:menu>
+                                <flux:menu.item
+                                    wire:click="deleteConversation"
+                                    icon="trash"
+                                    variant="danger"
+                                    wire:confirm="Delete this conversation and all its messages?"
+                                >Delete conversation</flux:menu.item>
+                            </flux:menu>
+                        </flux:dropdown>
+                    @endcan
+                </div>
+            </div>
+
+            {{-- Tab bar --}}
+            <nav class="mt-3 -mb-px flex gap-1" aria-label="Conversation views">
+                <span
+                    class="flex items-center gap-1.5 border-b-2 border-accent px-3 py-2 text-sm font-bold text-zinc-900 dark:text-white"
+                    aria-current="page"
+                >
+                    Conversation
+                    <flux:badge size="sm" inset="top bottom" data-test="comment-count-badge">{{ $this->comments->count() }}</flux:badge>
+                </span>
+                <flux:tooltip content="Coming soon">
+                    <button
+                        type="button"
+                        disabled
+                        class="cursor-not-allowed border-b-2 border-transparent px-3 py-2 text-sm font-medium text-zinc-400 dark:text-zinc-500"
+                    >Files</button>
+                </flux:tooltip>
+                <a
+                    href="{{ route('groups.show', ['group' => $group, 'tab' => 'members']) }}"
+                    wire:navigate
+                    class="border-b-2 border-transparent px-3 py-2 text-sm font-medium text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-white"
+                >Members</a>
+            </nav>
+        </header>
+
+        {{-- Pinned strip --}}
+        @if ($pinnedStripOpen && $this->pinnedComments->isNotEmpty())
+            @php($firstPinned = $this->pinnedComments->first())
+            <div class="mx-6 mt-4 flex items-start gap-2.5 rounded-lg border border-accent/30 bg-accent/5 px-3 py-2.5" data-test="pinned-strip">
+                <div class="flex size-6 shrink-0 items-center justify-center rounded-md border border-accent/30 bg-white text-accent dark:bg-zinc-900">
+                    <flux:icon.bookmark variant="micro" />
+                </div>
+                <div class="min-w-0 flex-1">
+                    <div class="text-xs font-semibold uppercase tracking-wide text-accent">
+                        Pinned by {{ $firstPinned->pinnedBy?->name ?? 'Unknown' }}
+                    </div>
+                    <div class="mt-0.5 truncate text-sm text-zinc-700 dark:text-zinc-200">
+                        {{ Str::limit(strip_tags($firstPinned->text), 140) }}
                     </div>
                 </div>
-                @php($prevUser = $comment->commentator)
-            @endforeach
+                <flux:button wire:click="dismissPinnedStrip" variant="ghost" size="sm" icon="x-mark" square />
+            </div>
+        @endif
+
+        {{-- Messages --}}
+        <div class="flex-1 overflow-auto px-6 py-4">
+            <div class="mx-auto max-w-3xl">
+                @php($currentUser = Auth::user())
+                @php($canComment = $currentUser?->can('comment', $conversation) ?? false)
+                @php($quickReactions = array_slice(Config::allowedReactions(), 0, 6))
+
+                @foreach ($this->groupedComments as $dateString => $dayComments)
+                    <div class="my-2 flex items-center gap-3.5 px-2 py-3" data-test="day-divider">
+                        <div class="h-px flex-1 bg-zinc-200 dark:bg-zinc-700"></div>
+                        <span class="text-xs font-semibold uppercase tracking-wider text-zinc-500">
+                            {{ $this->dayLabel($dateString) }}
+                        </span>
+                        <div class="h-px flex-1 bg-zinc-200 dark:bg-zinc-700"></div>
+                    </div>
+
+                    @foreach ($dayComments as $comment)
+                        @php($isMine = $comment->commentator?->is($currentUser))
+                        @php($role = $this->memberRoles[$comment->commentator_id] ?? null)
+
+                        <div
+                            wire:key="comment-{{ $comment->id }}"
+                            @class([
+                                'group/row relative flex gap-3 rounded-md border-l-2 px-3 py-3 transition-colors',
+                                'border-transparent hover:bg-zinc-50 dark:hover:bg-zinc-900/60' => ! $isMine,
+                                'border-accent bg-accent/5 hover:bg-accent/10' => $isMine,
+                            ])
+                            data-test="message-row"
+                            @if ($isMine) data-test-mine="true" @endif
+                        >
+                            <flux:avatar size="md" name="{{ $comment->commentator?->name }}" color="auto" />
+
+                            <div class="min-w-0 flex-1">
+                                {{-- Header line --}}
+                                <div class="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+                                    <span @class([
+                                        'text-sm font-bold',
+                                        'text-accent' => $isMine,
+                                        'text-zinc-900 dark:text-white' => ! $isMine,
+                                    ])>
+                                        {{ $comment->commentator?->name ?? 'Unknown' }}@if ($isMine) <span class="font-normal text-zinc-500">(you)</span>@endif
+                                    </span>
+                                    @if ($role)
+                                        <span class="text-xs text-zinc-500">{{ $role }}</span>
+                                    @endif
+                                    <span class="text-xs text-zinc-400">· {{ $comment->created_at->diffForHumans() }}</span>
+
+                                    @if ($comment->isPinned())
+                                        <flux:badge size="sm" color="green" inset="top bottom" data-test="pinned-badge">Pinned</flux:badge>
+                                    @endif
+                                    @if ($comment->is_prayer)
+                                        <flux:badge size="sm" color="amber" inset="top bottom" data-test="prayer-badge">Prayer</flux:badge>
+                                    @endif
+                                </div>
+
+                                {{-- Body --}}
+                                <div class="mt-1 text-sm leading-relaxed text-zinc-700 dark:text-zinc-200
+                                    **:[h1]:text-xl **:[h1]:font-semibold **:[h2]:text-lg **:[h2]:font-semibold **:[h3]:font-semibold
+                                    **:[strong]:font-semibold **:[em]:italic **:[u]:underline **:[s]:line-through
+                                    **:[ol]:list-decimal **:[ol]:ml-5 **:[ul]:list-disc **:[ul]:ml-5
+                                    **:[a]:underline
+                                    **:[blockquote]:border-l-4 **:[blockquote]:pl-2">
+                                    {!! app(ScriptureLinker::class)->linkify($comment->text) !!}
+                                </div>
+
+                                {{-- Reactions row --}}
+                                @php($summary = $comment->reactions->summary($currentUser))
+                                @if ($summary->isNotEmpty())
+                                    <div class="mt-2 flex flex-wrap items-center gap-1.5">
+                                        @foreach ($summary as $reaction)
+                                            @php($mine = (bool) ($reaction['commentator_reacted'] ?? false))
+                                            @if ($canComment)
+                                                <button
+                                                    wire:key="reaction-{{ $comment->id }}-{{ $reaction['reaction'] }}"
+                                                    wire:click="react({{ $comment->id }}, '{{ $reaction['reaction'] }}')"
+                                                    type="button"
+                                                    @class([
+                                                        'inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-semibold transition-colors',
+                                                        'border-accent bg-accent/10 text-accent' => $mine,
+                                                        'border-zinc-200 bg-white text-zinc-600 hover:bg-zinc-100 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700' => ! $mine,
+                                                    ])
+                                                    data-test="reaction-chip"
+                                                    @if ($mine) data-test-mine="true" @endif
+                                                >
+                                                    <span>{{ $reaction['reaction'] }}</span>
+                                                    <span>{{ $reaction['count'] }}</span>
+                                                </button>
+                                            @else
+                                                <span
+                                                    wire:key="reaction-{{ $comment->id }}-{{ $reaction['reaction'] }}"
+                                                    class="inline-flex items-center gap-1 rounded-full border border-zinc-200 bg-white px-2 py-0.5 text-xs font-semibold text-zinc-600 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300"
+                                                >
+                                                    <span>{{ $reaction['reaction'] }}</span>
+                                                    <span>{{ $reaction['count'] }}</span>
+                                                </span>
+                                            @endif
+                                        @endforeach
+
+                                        @if ($canComment)
+                                            <flux:dropdown align="start">
+                                                <button
+                                                    type="button"
+                                                    class="inline-flex h-6 items-center justify-center rounded-full border border-dashed border-zinc-300 px-2 text-xs text-zinc-500 hover:bg-zinc-100 hover:text-zinc-900 dark:border-zinc-600 dark:hover:bg-zinc-800"
+                                                    aria-label="Add reaction"
+                                                    data-test="reaction-picker-trigger"
+                                                >
+                                                    <flux:icon.face-smile variant="micro" />
+                                                </button>
+                                                <flux:popover>
+                                                    <div class="flex">
+                                                        @foreach ($quickReactions as $allowedReaction)
+                                                            <flux:button size="sm" variant="ghost" square wire:click="react({{ $comment->id }}, '{{ $allowedReaction }}')">{{ $allowedReaction }}</flux:button>
+                                                        @endforeach
+                                                    </div>
+                                                </flux:popover>
+                                            </flux:dropdown>
+                                        @endif
+                                    </div>
+                                @endif
+                            </div>
+
+                            {{-- Hover toolbar --}}
+                            @if ($canComment)
+                                <div class="absolute -top-3 right-4 hidden items-center gap-0.5 rounded-md border border-zinc-200 bg-white p-0.5 shadow-md group-hover/row:flex dark:border-zinc-700 dark:bg-zinc-900" data-test="hover-toolbar">
+                                    <flux:dropdown align="end">
+                                        <flux:tooltip content="React">
+                                            <button type="button" class="flex size-7 items-center justify-center rounded text-zinc-500 hover:bg-zinc-100 hover:text-zinc-900 dark:hover:bg-zinc-800 dark:hover:text-white">
+                                                <flux:icon.face-smile variant="micro" />
+                                            </button>
+                                        </flux:tooltip>
+                                        <flux:popover>
+                                            <div class="flex">
+                                                @foreach ($quickReactions as $allowedReaction)
+                                                    <flux:button size="sm" variant="ghost" square wire:click="react({{ $comment->id }}, '{{ $allowedReaction }}')">{{ $allowedReaction }}</flux:button>
+                                                @endforeach
+                                            </div>
+                                        </flux:popover>
+                                    </flux:dropdown>
+
+                                    <flux:tooltip content="Reply (coming soon)">
+                                        <button type="button" disabled class="flex size-7 cursor-not-allowed items-center justify-center rounded text-zinc-300 dark:text-zinc-600" data-test="reply-stub">
+                                            <flux:icon.arrow-uturn-left variant="micro" />
+                                        </button>
+                                    </flux:tooltip>
+
+                                    @can('markPrayer', $comment)
+                                        <flux:tooltip content="{{ $comment->is_prayer ? 'Unmark prayer' : 'Mark as prayer' }}">
+                                            <button
+                                                type="button"
+                                                wire:click="togglePrayer({{ $comment->id }})"
+                                                @class([
+                                                    'flex size-7 items-center justify-center rounded',
+                                                    'text-accent bg-accent/10 hover:bg-accent/20' => $comment->is_prayer,
+                                                    'text-zinc-500 hover:bg-zinc-100 hover:text-zinc-900 dark:hover:bg-zinc-800 dark:hover:text-white' => ! $comment->is_prayer,
+                                                ])
+                                                data-test="prayer-toggle"
+                                                @if ($comment->is_prayer) data-test-active="true" @endif
+                                            >
+                                                <flux:icon.hand-raised variant="micro" />
+                                            </button>
+                                        </flux:tooltip>
+                                    @endcan
+
+                                    @can('pin', $comment)
+                                        <flux:dropdown align="end">
+                                            <flux:tooltip content="More">
+                                                <button type="button" class="flex size-7 items-center justify-center rounded text-zinc-500 hover:bg-zinc-100 hover:text-zinc-900 dark:hover:bg-zinc-800 dark:hover:text-white" data-test="more-trigger">
+                                                    <flux:icon.ellipsis-horizontal variant="micro" />
+                                                </button>
+                                            </flux:tooltip>
+                                            <flux:menu>
+                                                @if ($comment->isPinned())
+                                                    <flux:menu.item wire:click="unpinComment({{ $comment->id }})" icon="bookmark-slash" data-test="unpin-item">
+                                                        Unpin from top
+                                                    </flux:menu.item>
+                                                @else
+                                                    <flux:menu.item wire:click="pinComment({{ $comment->id }})" icon="bookmark" data-test="pin-item">
+                                                        Pin to top
+                                                    </flux:menu.item>
+                                                @endif
+                                            </flux:menu>
+                                        </flux:dropdown>
+                                    @endcan
+                                </div>
+                            @endif
+                        </div>
+                    @endforeach
+                @endforeach
+            </div>
         </div>
 
+        {{-- Composer --}}
         @can('comment', $conversation)
-            <form wire:submit="postReply" class="mt-6">
-                <flux:composer wire:model="reply" label="Reply" label:sr-only placeholder="Write a reply...">
-                    <x-slot name="input">
-                        <flux:editor
-                            variant="borderless"
-                            toolbar="heading | bold italic underline strike | bullet ordered blockquote | link ~ undo redo"
-                            class="**:data-[slot=content]:min-h-[100px]!"
-                        />
-                    </x-slot>
-                    <x-slot name="actionsTrailing">
-                        <flux:button type="submit" variant="primary" size="sm" icon="paper-airplane" wire:loading.attr="disabled" />
-                    </x-slot>
-                </flux:composer>
-                <flux:error name="reply" />
-            </form>
+            <div class="border-t border-zinc-200 px-6 py-4 dark:border-zinc-700">
+                <form
+                    wire:submit="postReply"
+                    class="mx-auto max-w-3xl"
+                    x-data
+                    x-on:keydown.enter="if ($event.metaKey || $event.ctrlKey) { $event.preventDefault(); $el.requestSubmit() }"
+                >
+                    <flux:composer wire:model="reply" label="Reply" label:sr-only placeholder="Write a reply…  (try mentioning Romans 8:31)">
+                        <x-slot name="input">
+                            <flux:editor
+                                variant="borderless"
+                                toolbar="heading | bold italic underline strike | bullet ordered blockquote | link ~ undo redo"
+                                class="**:data-[slot=content]:min-h-[100px]!"
+                            />
+                        </x-slot>
+
+                        <x-slot name="footer">
+                            <button
+                                type="button"
+                                wire:click="$toggle('replyIsPrayer')"
+                                @class([
+                                    'inline-flex h-7 items-center gap-1.5 rounded-full border px-3 text-xs font-semibold transition-colors',
+                                    'border-yellow-300 bg-yellow-50 text-yellow-800 dark:border-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-200' => $replyIsPrayer,
+                                    'border-zinc-200 bg-white text-zinc-600 hover:bg-zinc-100 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700' => ! $replyIsPrayer,
+                                ])
+                                data-test="composer-prayer-toggle"
+                                @if ($replyIsPrayer) data-test-active="true" @endif
+                            >
+                                <flux:icon.hand-raised variant="micro" />
+                                {{ $replyIsPrayer ? 'Sending as prayer' : 'Mark as prayer' }}
+                            </button>
+
+                            <flux:tooltip content="Type @ to mention a member">
+                                <button
+                                    type="button"
+                                    class="inline-flex h-7 items-center gap-1.5 rounded-md px-2 text-xs font-semibold text-zinc-500 hover:bg-zinc-100 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-white"
+                                    data-test="composer-mention"
+                                >
+                                    <flux:icon.at-symbol variant="micro" />
+                                    Mention
+                                </button>
+                            </flux:tooltip>
+
+                            <div class="ms-auto flex items-center gap-2">
+                                <span class="hidden items-center gap-1 text-xs text-zinc-400 sm:inline-flex" data-test="composer-shortcut-hint">
+                                    <kbd class="rounded border border-zinc-200 bg-zinc-100 px-1.5 py-0.5 text-[10px] font-semibold text-zinc-600 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-400">⌘</kbd>
+                                    <kbd class="rounded border border-zinc-200 bg-zinc-100 px-1.5 py-0.5 text-[10px] font-semibold text-zinc-600 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-400">↵</kbd>
+                                    to send
+                                </span>
+                                <flux:button type="submit" variant="primary" size="sm" icon="paper-airplane" wire:loading.attr="disabled">Send</flux:button>
+                            </div>
+                        </x-slot>
+                    </flux:composer>
+                    <flux:error name="reply" />
+                </form>
+            </div>
         @endcan
     </div>
+
+    {{-- Members rail --}}
+    <aside
+        class="hidden w-[260px] shrink-0 flex-col overflow-auto border-l border-zinc-200 bg-zinc-50 px-5 py-6 lg:flex dark:border-zinc-700 dark:bg-zinc-900"
+        aria-label="Members"
+        data-test="members-rail"
+    >
+        <div class="mb-4 text-xs font-semibold uppercase tracking-wider text-zinc-500">
+            Members · {{ $this->memberCount() }}
+        </div>
+
+        @if ($this->contributors->isNotEmpty())
+            <section class="mb-6" data-test="rail-in-conversation">
+                <div class="mb-2 flex items-center justify-between px-1 text-xs font-semibold uppercase tracking-wider text-zinc-500">
+                    <span>In conversation</span>
+                    <span>{{ $this->contributors->count() }}</span>
+                </div>
+                <div class="space-y-0.5">
+                    @foreach ($this->contributors as $member)
+                        <div class="flex items-center gap-2.5 rounded-md px-2 py-1.5 hover:bg-zinc-100 dark:hover:bg-zinc-800" wire:key="rail-contrib-{{ $member->id }}">
+                            <flux:avatar size="xs" name="{{ $member->name }}" color="auto" />
+                            <div class="min-w-0 flex-1">
+                                <div class="truncate text-sm font-semibold">{{ $member->name }}</div>
+                                <div class="text-xs text-zinc-500">{{ $member->pivot->role->label() }}</div>
+                            </div>
+                        </div>
+                    @endforeach
+                </div>
+            </section>
+        @endif
+
+        @if ($this->nonContributors->isNotEmpty())
+            <section data-test="rail-not-yet-posted">
+                <div class="mb-2 flex items-center justify-between px-1 text-xs font-semibold uppercase tracking-wider text-zinc-500">
+                    <span>Not yet posted</span>
+                    <span>{{ $this->nonContributors->count() }}</span>
+                </div>
+                <div class="space-y-0.5">
+                    @foreach ($this->nonContributors as $member)
+                        <div class="flex items-center gap-2.5 rounded-md px-2 py-1.5 hover:bg-zinc-100 dark:hover:bg-zinc-800" wire:key="rail-noncontrib-{{ $member->id }}">
+                            <flux:avatar size="xs" name="{{ $member->name }}" color="auto" />
+                            <div class="min-w-0 flex-1">
+                                <div class="truncate text-sm font-semibold">{{ $member->name }}</div>
+                                <div class="text-xs text-zinc-500">{{ $member->pivot->role->label() }}</div>
+                            </div>
+                        </div>
+                    @endforeach
+                </div>
+            </section>
+        @endif
+    </aside>
 </section>

--- a/tests/Browser/GroupConversationSmokeTest.php
+++ b/tests/Browser/GroupConversationSmokeTest.php
@@ -1,0 +1,77 @@
+<?php
+
+use App\Enums\GroupMessaging;
+use App\Enums\GroupRole;
+use App\Enums\GroupVisibility;
+use App\Enums\MembershipStatus;
+use App\Models\Conversation;
+use App\Models\Group;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+/** @group browser */
+it('renders an empty group conversation without smoke', function (): void {
+    $user = User::factory()->create(['name' => 'Smoke Tester']);
+    $group = Group::factory()->create([
+        'visibility' => GroupVisibility::PUBLIC,
+        'messaging' => GroupMessaging::ALL_MEMBERS,
+        'name' => 'Elders',
+    ]);
+    $group->allUsers()->attach($user, ['role' => GroupRole::LEADER, 'status' => MembershipStatus::ACTIVE]);
+
+    $conversation = Conversation::factory()->create([
+        'group_id' => $group->id,
+        'user_id' => $user->id,
+        'title' => 'Smoke conversation',
+    ]);
+
+    $this->actingAs($user);
+
+    $page = visit(route('groups.conversations.show', ['group' => $group, 'conversation' => $conversation]));
+
+    $page->assertSee('Smoke conversation')
+        ->assertSee('No messages yet')
+        ->assertNoJavascriptErrors()
+        ->assertNoSmoke();
+});
+
+/** @group browser */
+it('renders a populated group conversation with pinned, prayer, and scripture refs', function (): void {
+    $leader = User::factory()->create(['name' => 'Karen Reyes']);
+    $member = User::factory()->create(['name' => 'Marcus Tan']);
+    $group = Group::factory()->create([
+        'visibility' => GroupVisibility::PUBLIC,
+        'messaging' => GroupMessaging::ALL_MEMBERS,
+        'name' => 'Elders',
+    ]);
+    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($member, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+
+    $conversation = Conversation::factory()->create([
+        'group_id' => $group->id,
+        'user_id' => $leader->id,
+        'title' => 'Sunday Service Planning',
+    ]);
+
+    $pinned = $conversation->postComment('<p>Anchor the set in Romans 8:31 tonight.</p>', $leader);
+    $pinned->fresh()->pin($leader);
+
+    $prayer = $conversation->postComment('<p>Praying for the Hawkins family.</p>', $member);
+    $prayer->fresh()->togglePrayer();
+
+    $conversation->postComment('<p>I will bring John 1:14 into the closing.</p>', $leader);
+
+    $this->actingAs($leader);
+
+    $page = visit(route('groups.conversations.show', ['group' => $group, 'conversation' => $conversation]));
+
+    $page->assertSee('Sunday Service Planning')
+        ->assertSee('Pinned by Karen Reyes')
+        ->assertSee('Romans 8:31')
+        ->assertSee('John 1:14')
+        ->assertSee('Prayer')
+        ->assertNoJavascriptErrors()
+        ->assertNoSmoke();
+});

--- a/tests/Feature/CommentPinPrayerInteractionTest.php
+++ b/tests/Feature/CommentPinPrayerInteractionTest.php
@@ -1,0 +1,188 @@
+<?php
+
+use App\Enums\GroupMessaging;
+use App\Enums\GroupRole;
+use App\Enums\GroupVisibility;
+use App\Enums\MembershipStatus;
+use App\Models\Conversation;
+use App\Models\Group;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+function buildInteractionScenario(): array
+{
+    $author = User::factory()->create(['name' => 'Author Ada']);
+    $group = Group::factory()->create([
+        'visibility' => GroupVisibility::PUBLIC,
+        'messaging' => GroupMessaging::ALL_MEMBERS,
+    ]);
+    $group->allUsers()->attach($author, ['role' => GroupRole::LEADER, 'status' => MembershipStatus::ACTIVE]);
+
+    $conversation = Conversation::factory()->create([
+        'group_id' => $group->id,
+        'user_id' => $author->id,
+        'title' => 'Service thread',
+    ]);
+
+    return [$group, $conversation, $author];
+}
+
+// --- pinComment ---
+
+test('an authorized user can pin a comment via the Livewire action', function (): void {
+    [$group, $conversation, $author] = buildInteractionScenario();
+    $comment = $conversation->postComment('pin me', $author);
+
+    Livewire::actingAs($author)
+        ->test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->call('pinComment', $comment->id);
+
+    expect($comment->fresh()->isPinned())->toBeTrue()
+        ->and($comment->fresh()->pinned_by_user_id)->toBe($author->id);
+});
+
+test('pinning re-opens the pinned strip even if the user previously dismissed it', function (): void {
+    [$group, $conversation, $author] = buildInteractionScenario();
+    $comment = $conversation->postComment('pin me later', $author);
+
+    Livewire::actingAs($author)
+        ->test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->call('dismissPinnedStrip')
+        ->assertSet('pinnedStripOpen', false)
+        ->call('pinComment', $comment->id)
+        ->assertSet('pinnedStripOpen', true)
+        ->assertSeeHtml('data-test="pinned-strip"');
+});
+
+test('a non-author non-leader member cannot pin a comment', function (): void {
+    [$group, $conversation, $author] = buildInteractionScenario();
+    $other = User::factory()->create();
+    $group->allUsers()->attach($other, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+
+    $comment = $conversation->postComment('not yours', $author);
+
+    Livewire::actingAs($other)
+        ->test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->call('pinComment', $comment->id)
+        ->assertForbidden();
+
+    expect($comment->fresh()->isPinned())->toBeFalse();
+});
+
+// --- unpinComment ---
+
+test('an authorized user can unpin a pinned comment', function (): void {
+    [$group, $conversation, $author] = buildInteractionScenario();
+    $comment = $conversation->postComment('pinned', $author);
+    $comment->fresh()->pin($author);
+
+    Livewire::actingAs($author)
+        ->test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->call('unpinComment', $comment->id);
+
+    expect($comment->fresh()->isPinned())->toBeFalse()
+        ->and($comment->fresh()->pinned_by_user_id)->toBeNull();
+});
+
+test('a non-author non-leader member cannot unpin a comment', function (): void {
+    [$group, $conversation, $author] = buildInteractionScenario();
+    $other = User::factory()->create();
+    $group->allUsers()->attach($other, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+
+    $comment = $conversation->postComment('not yours', $author);
+    $comment->fresh()->pin($author);
+
+    Livewire::actingAs($other)
+        ->test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->call('unpinComment', $comment->id)
+        ->assertForbidden();
+
+    expect($comment->fresh()->isPinned())->toBeTrue();
+});
+
+// --- togglePrayer ---
+
+test('any active group member can mark a comment as prayer', function (): void {
+    [$group, $conversation, $author] = buildInteractionScenario();
+    $member = User::factory()->create();
+    $group->allUsers()->attach($member, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+
+    $comment = $conversation->postComment('pray for this', $author);
+
+    Livewire::actingAs($member)
+        ->test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->call('togglePrayer', $comment->id);
+
+    expect($comment->fresh()->is_prayer)->toBeTrue();
+});
+
+test('togglePrayer flips an already-prayer comment back off', function (): void {
+    [$group, $conversation, $author] = buildInteractionScenario();
+    $comment = $conversation->postComment('pray for this', $author);
+    $comment->fresh()->togglePrayer();
+
+    Livewire::actingAs($author)
+        ->test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->call('togglePrayer', $comment->id);
+
+    expect($comment->fresh()->is_prayer)->toBeFalse();
+});
+
+// --- View rendering ---
+
+test('the prayer toggle button is marked active when a comment is_prayer', function (): void {
+    [$group, $conversation, $author] = buildInteractionScenario();
+    $comment = $conversation->postComment('praying', $author);
+    $comment->fresh()->togglePrayer();
+
+    Livewire::actingAs($author)
+        ->test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->assertSeeHtml('data-test="prayer-toggle"')
+        ->assertSeeHtml('data-test-active="true"');
+});
+
+test('the More dropdown contains the Pin item for an unpinned comment', function (): void {
+    [$group, $conversation, $author] = buildInteractionScenario();
+    $conversation->postComment('hi', $author);
+
+    Livewire::actingAs($author)
+        ->test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->assertSeeHtml('data-test="pin-item"')
+        ->assertDontSeeHtml('data-test="unpin-item"');
+});
+
+test('the More dropdown contains the Unpin item for a pinned comment', function (): void {
+    [$group, $conversation, $author] = buildInteractionScenario();
+    $comment = $conversation->postComment('pinned', $author);
+    $comment->fresh()->pin($author);
+
+    Livewire::actingAs($author)
+        ->test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->assertSeeHtml('data-test="unpin-item"')
+        ->assertDontSeeHtml('data-test="pin-item"');
+});
+
+test('the More dropdown is hidden for a member who cannot pin', function (): void {
+    [$group, $conversation, $author] = buildInteractionScenario();
+    $other = User::factory()->create();
+    $group->allUsers()->attach($other, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+    $conversation->postComment('hi', $author);
+
+    Livewire::actingAs($other)
+        ->test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->assertDontSeeHtml('data-test="more-trigger"');
+});
+
+test('the prayer toggle button is rendered for active group members', function (): void {
+    [$group, $conversation, $author] = buildInteractionScenario();
+    $member = User::factory()->create();
+    $group->allUsers()->attach($member, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+    $conversation->postComment('hi', $author);
+
+    Livewire::actingAs($member)
+        ->test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->assertSeeHtml('data-test="prayer-toggle"');
+});

--- a/tests/Feature/CommentPinPrayerTest.php
+++ b/tests/Feature/CommentPinPrayerTest.php
@@ -1,0 +1,155 @@
+<?php
+
+use App\Enums\GroupMessaging;
+use App\Enums\GroupRole;
+use App\Enums\GroupVisibility;
+use App\Enums\MembershipStatus;
+use App\Models\Comment;
+use App\Models\Conversation;
+use App\Models\Group;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+function makeGroupConversation(GroupRole $authorRole = GroupRole::MEMBER): array
+{
+    $group = Group::factory()->create([
+        'visibility' => GroupVisibility::PUBLIC,
+        'messaging' => GroupMessaging::ALL_MEMBERS,
+    ]);
+
+    $author = User::factory()->create();
+    $group->allUsers()->attach($author, ['role' => $authorRole, 'status' => MembershipStatus::ACTIVE]);
+
+    $conversation = Conversation::factory()->create(['group_id' => $group->id, 'user_id' => $author->id]);
+    $comment = $conversation->postComment('Hello group', $author);
+
+    return [$group, $conversation, $comment->fresh(), $author];
+}
+
+// --- Model behavior ---
+
+test('pin sets pinned_at and pinned_by_user_id', function (): void {
+    [$group, $conversation, $comment, $author] = makeGroupConversation();
+
+    expect($comment->isPinned())->toBeFalse();
+
+    $comment->pin($author);
+
+    expect($comment->fresh()->isPinned())->toBeTrue()
+        ->and($comment->fresh()->pinned_by_user_id)->toBe($author->id)
+        ->and($comment->fresh()->pinned_at)->not->toBeNull();
+});
+
+test('unpin clears pinned_at and pinned_by_user_id', function (): void {
+    [$group, $conversation, $comment, $author] = makeGroupConversation();
+
+    $comment->pin($author);
+    $comment->unpin();
+
+    expect($comment->fresh()->isPinned())->toBeFalse()
+        ->and($comment->fresh()->pinned_by_user_id)->toBeNull()
+        ->and($comment->fresh()->pinned_at)->toBeNull();
+});
+
+test('togglePrayer flips is_prayer', function (): void {
+    [$group, $conversation, $comment, $author] = makeGroupConversation();
+
+    expect($comment->is_prayer)->toBeFalse();
+
+    $comment->togglePrayer();
+    expect($comment->fresh()->is_prayer)->toBeTrue();
+
+    $comment->fresh()->togglePrayer();
+    expect($comment->fresh()->is_prayer)->toBeFalse();
+});
+
+test('Comment loaded from the database is the App namespace subclass', function (): void {
+    [$group, $conversation, $comment] = makeGroupConversation();
+
+    expect($conversation->comments()->first())->toBeInstanceOf(Comment::class);
+});
+
+test('Conversation pinnedComments returns only pinned ones, newest first', function (): void {
+    [$group, $conversation, $first, $author] = makeGroupConversation();
+
+    $second = $conversation->postComment('second', $author);
+    $third = $conversation->postComment('third', $author);
+
+    $first->fresh()->pin($author);
+    $this->travel(1)->seconds();
+    $third->fresh()->pin($author);
+
+    $pinned = $conversation->pinnedComments()->get();
+
+    expect($pinned)->toHaveCount(2)
+        ->and($pinned->first()->id)->toBe($third->id)
+        ->and($pinned->last()->id)->toBe($first->id);
+});
+
+// --- Policy: pin / unpin ---
+
+test('author of the comment can pin their own comment', function (): void {
+    [$group, $conversation, $comment, $author] = makeGroupConversation();
+
+    expect($author->can('pin', $comment))->toBeTrue()
+        ->and($author->can('unpin', $comment))->toBeTrue();
+});
+
+test('group leader can pin any comment in the conversation', function (): void {
+    [$group, $conversation, $comment] = makeGroupConversation();
+
+    $leader = User::factory()->create();
+    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => MembershipStatus::ACTIVE]);
+
+    expect($leader->can('pin', $comment))->toBeTrue()
+        ->and($leader->can('unpin', $comment))->toBeTrue();
+});
+
+test('a non-leader member who did not author the comment cannot pin it', function (): void {
+    [$group, $conversation, $comment] = makeGroupConversation();
+
+    $otherMember = User::factory()->create();
+    $group->allUsers()->attach($otherMember, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+
+    expect($otherMember->can('pin', $comment))->toBeFalse()
+        ->and($otherMember->can('unpin', $comment))->toBeFalse();
+});
+
+test('a user outside the group cannot pin a comment', function (): void {
+    [$group, $conversation, $comment] = makeGroupConversation();
+
+    $outsider = User::factory()->create();
+
+    expect($outsider->can('pin', $comment))->toBeFalse()
+        ->and($outsider->can('unpin', $comment))->toBeFalse();
+});
+
+// --- Policy: markPrayer ---
+
+test('any active group member can mark prayer on any comment', function (): void {
+    [$group, $conversation, $comment] = makeGroupConversation();
+
+    $otherMember = User::factory()->create();
+    $group->allUsers()->attach($otherMember, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+
+    expect($otherMember->can('markPrayer', $comment))->toBeTrue();
+});
+
+test('a non-member cannot mark prayer', function (): void {
+    [$group, $conversation, $comment] = makeGroupConversation();
+
+    $outsider = User::factory()->create();
+
+    expect($outsider->can('markPrayer', $comment))->toBeFalse();
+});
+
+test('a pending member cannot mark prayer', function (): void {
+    [$group, $conversation, $comment] = makeGroupConversation();
+
+    $pending = User::factory()->create();
+    $group->allUsers()->attach($pending, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::PENDING]);
+
+    expect($pending->can('markPrayer', $comment))->toBeFalse();
+});

--- a/tests/Feature/ConversationComposerTest.php
+++ b/tests/Feature/ConversationComposerTest.php
@@ -1,0 +1,151 @@
+<?php
+
+use App\Enums\GroupMessaging;
+use App\Enums\GroupRole;
+use App\Enums\GroupVisibility;
+use App\Enums\MembershipStatus;
+use App\Models\Conversation;
+use App\Models\Group;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+function buildComposerScenario(): array
+{
+    $member = User::factory()->create();
+    $group = Group::factory()->create([
+        'visibility' => GroupVisibility::PUBLIC,
+        'messaging' => GroupMessaging::ALL_MEMBERS,
+    ]);
+    $group->allUsers()->attach($member, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+
+    $conversation = Conversation::factory()->create([
+        'group_id' => $group->id,
+        'user_id' => $member->id,
+    ]);
+
+    return [$group, $conversation, $member];
+}
+
+test('postComment persists is_prayer when the flag is passed', function (): void {
+    [$group, $conversation, $member] = buildComposerScenario();
+
+    $comment = $conversation->postComment('<p>praying</p>', $member, isPrayer: true);
+
+    expect($comment->fresh()->is_prayer)->toBeTrue();
+});
+
+test('postComment defaults is_prayer to false when no flag is passed', function (): void {
+    [$group, $conversation, $member] = buildComposerScenario();
+
+    $comment = $conversation->postComment('<p>plain</p>', $member);
+
+    expect($comment->fresh()->is_prayer)->toBeFalse();
+});
+
+test('submitting with replyIsPrayer on persists is_prayer on the comment', function (): void {
+    [$group, $conversation, $member] = buildComposerScenario();
+
+    Livewire::actingAs($member)
+        ->test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->set('reply', '<p>Praying for the Hawkins family</p>')
+        ->set('replyIsPrayer', true)
+        ->call('postReply')
+        ->assertHasNoErrors();
+
+    $comment = $conversation->fresh()->comments()->first();
+    expect($comment->is_prayer)->toBeTrue();
+});
+
+test('submitting with the prayer flag off creates a non-prayer comment', function (): void {
+    [$group, $conversation, $member] = buildComposerScenario();
+
+    Livewire::actingAs($member)
+        ->test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->set('reply', '<p>routine note</p>')
+        ->call('postReply')
+        ->assertHasNoErrors();
+
+    $comment = $conversation->fresh()->comments()->first();
+    expect($comment->is_prayer)->toBeFalse();
+});
+
+test('replyIsPrayer resets to false after a successful send', function (): void {
+    [$group, $conversation, $member] = buildComposerScenario();
+
+    Livewire::actingAs($member)
+        ->test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->set('reply', '<p>praying again</p>')
+        ->set('replyIsPrayer', true)
+        ->call('postReply')
+        ->assertSet('replyIsPrayer', false)
+        ->assertSet('reply', '');
+});
+
+test('replyIsPrayer is preserved when a validation error occurs', function (): void {
+    [$group, $conversation, $member] = buildComposerScenario();
+
+    Livewire::actingAs($member)
+        ->test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->set('reply', '<p>   </p>')
+        ->set('replyIsPrayer', true)
+        ->call('postReply')
+        ->assertHasErrors('reply')
+        ->assertSet('replyIsPrayer', true);
+});
+
+test('the composer renders the prayer toggle button', function (): void {
+    [$group, $conversation, $member] = buildComposerScenario();
+
+    Livewire::actingAs($member)
+        ->test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->assertSeeHtml('data-test="composer-prayer-toggle"');
+});
+
+test('the prayer toggle marks active when replyIsPrayer is true', function (): void {
+    [$group, $conversation, $member] = buildComposerScenario();
+
+    Livewire::actingAs($member)
+        ->test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->set('replyIsPrayer', true)
+        ->assertSeeHtml('data-test-active="true"')
+        ->assertSee('Sending as prayer');
+});
+
+test('the composer renders the keyboard shortcut hint', function (): void {
+    [$group, $conversation, $member] = buildComposerScenario();
+
+    $this->actingAs($member)
+        ->get(route('groups.conversations.show', ['group' => $group, 'conversation' => $conversation]))
+        ->assertSeeHtml('data-test="composer-shortcut-hint"')
+        ->assertSee('to send');
+});
+
+test('the composer renders the mention button', function (): void {
+    [$group, $conversation, $member] = buildComposerScenario();
+
+    $this->actingAs($member)
+        ->get(route('groups.conversations.show', ['group' => $group, 'conversation' => $conversation]))
+        ->assertSeeHtml('data-test="composer-mention"')
+        ->assertSee('Mention');
+});
+
+test('the composer is hidden for users who cannot comment', function (): void {
+    $leader = User::factory()->create();
+    $reader = User::factory()->create();
+    $group = Group::factory()->create([
+        'visibility' => GroupVisibility::PUBLIC,
+        'messaging' => GroupMessaging::ONLY_LEADERS,
+    ]);
+    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($reader, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+
+    $conversation = Conversation::factory()->create(['group_id' => $group->id, 'user_id' => $leader->id]);
+
+    $this->actingAs($reader)
+        ->get(route('groups.conversations.show', ['group' => $group, 'conversation' => $conversation]))
+        ->assertDontSeeHtml('data-test="composer-prayer-toggle"')
+        ->assertDontSeeHtml('data-test="composer-shortcut-hint"');
+});

--- a/tests/Feature/ConversationMessageRowTest.php
+++ b/tests/Feature/ConversationMessageRowTest.php
@@ -1,0 +1,244 @@
+<?php
+
+use App\Enums\GroupMessaging;
+use App\Enums\GroupRole;
+use App\Enums\GroupVisibility;
+use App\Enums\MembershipStatus;
+use App\Models\Conversation;
+use App\Models\Group;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+function buildRowScenario(): array
+{
+    $viewer = User::factory()->create(['name' => 'Viewer Vex']);
+    $group = Group::factory()->create([
+        'visibility' => GroupVisibility::PUBLIC,
+        'messaging' => GroupMessaging::ALL_MEMBERS,
+        'name' => 'Elders',
+    ]);
+    $group->allUsers()->attach($viewer, ['role' => GroupRole::LEADER, 'status' => MembershipStatus::ACTIVE]);
+
+    $conversation = Conversation::factory()->create([
+        'group_id' => $group->id,
+        'user_id' => $viewer->id,
+        'title' => 'Planning thread',
+    ]);
+
+    return [$group, $conversation, $viewer];
+}
+
+// --- Day dividers ---
+
+test('day dividers separate comments posted on different days', function (): void {
+    [$group, $conversation, $viewer] = buildRowScenario();
+
+    $this->travelTo(now()->subDays(2)->setTime(10, 0));
+    $conversation->postComment('two days ago', $viewer);
+
+    $this->travelTo(now()->addDay()->setTime(10, 0));
+    $conversation->postComment('yesterday', $viewer);
+
+    $this->travelTo(now()->addDay()->setTime(10, 0));
+    $conversation->postComment('today', $viewer);
+
+    $this->travelBack();
+
+    $this->actingAs($viewer)
+        ->get(route('groups.conversations.show', ['group' => $group, 'conversation' => $conversation]))
+        ->assertSuccessful()
+        ->assertSeeInOrder([
+            'two days ago',
+            'Yesterday',
+            'yesterday',
+            'Today',
+            'today',
+        ]);
+});
+
+test('comments posted on the same day get a single divider', function (): void {
+    [$group, $conversation, $viewer] = buildRowScenario();
+    $conversation->postComment('first today', $viewer);
+    $conversation->postComment('second today', $viewer);
+
+    $rendered = Livewire::actingAs($viewer)
+        ->test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->html();
+
+    expect(substr_count($rendered, 'data-test="day-divider"'))->toBe(1);
+});
+
+// --- Own message emphasis ---
+
+test('own messages render with the accent left border and a "(you)" suffix', function (): void {
+    [$group, $conversation, $viewer] = buildRowScenario();
+    $conversation->postComment('mine', $viewer);
+
+    $this->actingAs($viewer)
+        ->get(route('groups.conversations.show', ['group' => $group, 'conversation' => $conversation]))
+        ->assertSeeHtml('data-test-mine="true"')
+        ->assertSeeHtml('border-accent')
+        ->assertSee('(you)');
+});
+
+test('other peoples messages do not get the mine attribute', function (): void {
+    [$group, $conversation, $viewer] = buildRowScenario();
+    $other = User::factory()->create(['name' => 'Other Owen']);
+    $group->allUsers()->attach($other, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+    $conversation->postComment('theirs', $other);
+
+    $html = Livewire::actingAs($viewer)
+        ->test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->html();
+
+    expect($html)->not->toContain('data-test-mine="true"')
+        ->and($html)->not->toContain('(you)');
+});
+
+test('the author role label appears in the message header line', function (): void {
+    [$group, $conversation, $viewer] = buildRowScenario();
+    $conversation->postComment('hi', $viewer);
+
+    $this->actingAs($viewer)
+        ->get(route('groups.conversations.show', ['group' => $group, 'conversation' => $conversation]))
+        ->assertSee('Leader');
+});
+
+// --- Pinned / Prayer badges ---
+
+test('a pinned comment renders the Pinned badge', function (): void {
+    [$group, $conversation, $viewer] = buildRowScenario();
+    $comment = $conversation->postComment('pin me', $viewer);
+    $comment->fresh()->pin($viewer);
+
+    $this->actingAs($viewer)
+        ->get(route('groups.conversations.show', ['group' => $group, 'conversation' => $conversation]))
+        ->assertSeeHtml('data-test="pinned-badge"')
+        ->assertSee('Pinned');
+});
+
+test('a prayer comment renders the Prayer badge', function (): void {
+    [$group, $conversation, $viewer] = buildRowScenario();
+    $comment = $conversation->postComment('praying', $viewer);
+    $comment->fresh()->togglePrayer();
+
+    $this->actingAs($viewer)
+        ->get(route('groups.conversations.show', ['group' => $group, 'conversation' => $conversation]))
+        ->assertSeeHtml('data-test="prayer-badge"')
+        ->assertSee('Prayer');
+});
+
+test('an ordinary comment shows neither badge', function (): void {
+    [$group, $conversation, $viewer] = buildRowScenario();
+    $conversation->postComment('plain', $viewer);
+
+    $this->actingAs($viewer)
+        ->get(route('groups.conversations.show', ['group' => $group, 'conversation' => $conversation]))
+        ->assertDontSeeHtml('data-test="pinned-badge"')
+        ->assertDontSeeHtml('data-test="prayer-badge"');
+});
+
+// --- Reactions ---
+
+test('a reaction chip the viewer added carries the mine flag', function (): void {
+    [$group, $conversation, $viewer] = buildRowScenario();
+    $comment = $conversation->postComment('react to me', $viewer);
+
+    Livewire::actingAs($viewer)
+        ->test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->call('react', $comment->id, '👍')
+        ->assertSeeHtml('data-test-mine="true"');
+});
+
+test('a reaction chip the viewer did not add does not carry the mine flag', function (): void {
+    [$group, $conversation, $viewer] = buildRowScenario();
+    $other = User::factory()->create();
+    $group->allUsers()->attach($other, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+
+    $comment = $conversation->postComment('react to me', $other);
+    $comment->fresh()->react('👍', $other);
+
+    $html = Livewire::actingAs($viewer)
+        ->test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->html();
+
+    expect($html)->toContain('data-test="reaction-chip"')
+        ->and(preg_match('/data-test="reaction-chip"[^>]*data-test-mine/', $html))->toBe(0);
+});
+
+test('clicking a reaction the viewer already gave removes it', function (): void {
+    [$group, $conversation, $viewer] = buildRowScenario();
+    $comment = $conversation->postComment('react to me', $viewer);
+    $comment->fresh()->react('👍', $viewer);
+
+    expect($comment->fresh()->reactions()->count())->toBe(1);
+
+    Livewire::actingAs($viewer)
+        ->test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->call('react', $comment->id, '👍');
+
+    expect($comment->fresh()->reactions()->count())->toBe(0);
+});
+
+test('reaction picker only renders the first six allowed reactions', function (): void {
+    [$group, $conversation, $viewer] = buildRowScenario();
+    $conversation->postComment('hi', $viewer);
+
+    $html = Livewire::actingAs($viewer)
+        ->test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->html();
+
+    $allowed = config('comments.allowed_reactions');
+    foreach (array_slice($allowed, 0, 6) as $expected) {
+        expect($html)->toContain($expected);
+    }
+});
+
+// --- Hover toolbar ---
+
+test('the hover toolbar renders for users who can comment', function (): void {
+    [$group, $conversation, $viewer] = buildRowScenario();
+    $conversation->postComment('hi', $viewer);
+
+    $this->actingAs($viewer)
+        ->get(route('groups.conversations.show', ['group' => $group, 'conversation' => $conversation]))
+        ->assertSeeHtml('data-test="hover-toolbar"')
+        ->assertSeeHtml('data-test="reply-stub"');
+});
+
+test('the hover toolbar does not render for read-only viewers (leaders-only group)', function (): void {
+    $leader = User::factory()->create();
+    $member = User::factory()->create();
+    $group = Group::factory()->create([
+        'visibility' => GroupVisibility::PUBLIC,
+        'messaging' => GroupMessaging::ONLY_LEADERS,
+    ]);
+    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($member, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+
+    $conversation = Conversation::factory()->create([
+        'group_id' => $group->id,
+        'user_id' => $leader->id,
+    ]);
+    $conversation->postComment('leader-only post', $leader);
+
+    $this->actingAs($member)
+        ->get(route('groups.conversations.show', ['group' => $group, 'conversation' => $conversation]))
+        ->assertSuccessful()
+        ->assertDontSeeHtml('data-test="hover-toolbar"');
+});
+
+// --- Scripture auto-linking ---
+
+test('scripture references in comment bodies are rendered as scripture-ref links', function (): void {
+    [$group, $conversation, $viewer] = buildRowScenario();
+    $conversation->postComment('<p>Anchor the set in Romans 8:31 tonight.</p>', $viewer);
+
+    $this->actingAs($viewer)
+        ->get(route('groups.conversations.show', ['group' => $group, 'conversation' => $conversation]))
+        ->assertSeeHtml('class="scripture-ref"')
+        ->assertSeeHtml('Romans 8:31</a>');
+});

--- a/tests/Feature/GroupConversationLayoutTest.php
+++ b/tests/Feature/GroupConversationLayoutTest.php
@@ -149,3 +149,77 @@ test('Members tab links to the groups page members tab', function (): void {
         ->get(route('groups.conversations.show', ['group' => $group, 'conversation' => $conversation]))
         ->assertSee(route('groups.show', ['group' => $group, 'tab' => 'members']), false);
 });
+
+// --- Phase G: empty state ---
+
+test('empty state renders when the conversation has no comments', function (): void {
+    [$group, $conversation, $viewer] = buildLayoutScenario();
+
+    $this->actingAs($viewer)
+        ->get(route('groups.conversations.show', ['group' => $group, 'conversation' => $conversation]))
+        ->assertSeeHtml('data-test="empty-state"')
+        ->assertSee('No messages yet')
+        ->assertSee('Kick things off');
+});
+
+test('empty state encourages read-only viewers differently than commenters', function (): void {
+    $leader = User::factory()->create();
+    $reader = User::factory()->create();
+    $group = Group::factory()->create([
+        'visibility' => GroupVisibility::PUBLIC,
+        'messaging' => GroupMessaging::ONLY_LEADERS,
+    ]);
+    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($reader, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+
+    $conversation = Conversation::factory()->create(['group_id' => $group->id, 'user_id' => $leader->id]);
+
+    $this->actingAs($reader)
+        ->get(route('groups.conversations.show', ['group' => $group, 'conversation' => $conversation]))
+        ->assertSeeHtml('data-test="empty-state"')
+        ->assertDontSee('Kick things off')
+        ->assertSee('Be the first to post here once messaging opens up');
+});
+
+test('empty state disappears once at least one comment exists', function (): void {
+    [$group, $conversation, $viewer] = buildLayoutScenario();
+    $conversation->postComment('hello', $viewer);
+
+    $this->actingAs($viewer)
+        ->get(route('groups.conversations.show', ['group' => $group, 'conversation' => $conversation]))
+        ->assertDontSeeHtml('data-test="empty-state"');
+});
+
+// --- Phase G: accessibility ---
+
+test('the hover toolbar exposes a toolbar landmark with a label', function (): void {
+    [$group, $conversation, $viewer] = buildLayoutScenario();
+    $conversation->postComment('hi', $viewer);
+
+    $this->actingAs($viewer)
+        ->get(route('groups.conversations.show', ['group' => $group, 'conversation' => $conversation]))
+        ->assertSeeHtml('role="toolbar"')
+        ->assertSeeHtml('aria-label="Message actions"');
+});
+
+test('the prayer toggle reports its pressed state via aria-pressed', function (): void {
+    [$group, $conversation, $viewer] = buildLayoutScenario();
+    $comment = $conversation->postComment('praying', $viewer);
+    $comment->fresh()->togglePrayer();
+
+    $this->actingAs($viewer)
+        ->get(route('groups.conversations.show', ['group' => $group, 'conversation' => $conversation]))
+        ->assertSeeHtml('aria-pressed="true"');
+});
+
+test('icon-only buttons carry aria-labels', function (): void {
+    [$group, $conversation, $viewer] = buildLayoutScenario();
+    $comment = $conversation->postComment('hi', $viewer);
+    $comment->fresh()->react('👍', $viewer);
+
+    $this->actingAs($viewer)
+        ->get(route('groups.conversations.show', ['group' => $group, 'conversation' => $conversation]))
+        ->assertSeeHtml('aria-label="React"')
+        ->assertSeeHtml('aria-label="More actions"')
+        ->assertSeeHtml('aria-label="Add reaction"');
+});

--- a/tests/Feature/GroupConversationLayoutTest.php
+++ b/tests/Feature/GroupConversationLayoutTest.php
@@ -1,0 +1,151 @@
+<?php
+
+use App\Enums\GroupMessaging;
+use App\Enums\GroupRole;
+use App\Enums\GroupVisibility;
+use App\Enums\MembershipStatus;
+use App\Models\Conversation;
+use App\Models\Group;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+/** Builds a group with a viewer member, a posted conversation. */
+function buildLayoutScenario(int $extraMembers = 0): array
+{
+    $viewer = User::factory()->create(['name' => 'Viewer Vex']);
+    $group = Group::factory()->create([
+        'visibility' => GroupVisibility::PUBLIC,
+        'messaging' => GroupMessaging::ALL_MEMBERS,
+        'name' => 'Elders',
+    ]);
+    $group->allUsers()->attach($viewer, ['role' => GroupRole::LEADER, 'status' => MembershipStatus::ACTIVE]);
+
+    for ($i = 0; $i < $extraMembers; $i++) {
+        $member = User::factory()->create(['name' => "Member {$i}"]);
+        $group->allUsers()->attach($member, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+    }
+
+    $conversation = Conversation::factory()->create([
+        'group_id' => $group->id,
+        'user_id' => $viewer->id,
+        'title' => 'Sunday Service Planning',
+    ]);
+
+    return [$group, $conversation, $viewer];
+}
+
+test('shows the tab bar with Conversation Files and Members tabs', function (): void {
+    [$group, $conversation, $viewer] = buildLayoutScenario();
+
+    $this->actingAs($viewer)
+        ->get(route('groups.conversations.show', ['group' => $group, 'conversation' => $conversation]))
+        ->assertSuccessful()
+        ->assertSee('Conversation', false)
+        ->assertSee('Files', false)
+        ->assertSee('Members', false)
+        ->assertSeeHtml('data-test="comment-count-badge"');
+});
+
+test('the conversation count badge reflects the number of comments', function (): void {
+    [$group, $conversation, $viewer] = buildLayoutScenario();
+    $conversation->postComment('first', $viewer);
+    $conversation->postComment('second', $viewer);
+
+    Livewire::actingAs($viewer)
+        ->test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->assertSeeHtmlInOrder([
+            'data-test="comment-count-badge"',
+            '2',
+        ]);
+});
+
+test('the members rail renders with In conversation when there are contributors', function (): void {
+    [$group, $conversation, $viewer] = buildLayoutScenario(extraMembers: 2);
+    $conversation->postComment('hello', $viewer);
+
+    Livewire::actingAs($viewer)
+        ->test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->assertSeeHtml('data-test="members-rail"')
+        ->assertSeeHtml('data-test="rail-in-conversation"')
+        ->assertSeeHtml('data-test="rail-not-yet-posted"')
+        ->assertSeeInOrder(['In conversation', 'Not yet posted']);
+});
+
+test('the rail omits Not yet posted when every member has posted', function (): void {
+    [$group, $conversation, $viewer] = buildLayoutScenario();
+    $conversation->postComment('hi', $viewer);
+
+    Livewire::actingAs($viewer)
+        ->test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->assertSeeHtml('data-test="rail-in-conversation"')
+        ->assertDontSeeHtml('data-test="rail-not-yet-posted"');
+});
+
+test('the rail omits In conversation when no one has posted yet', function (): void {
+    [$group, $conversation, $viewer] = buildLayoutScenario(extraMembers: 1);
+
+    Livewire::actingAs($viewer)
+        ->test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->assertDontSeeHtml('data-test="rail-in-conversation"')
+        ->assertSeeHtml('data-test="rail-not-yet-posted"');
+});
+
+test('renders a stacked avatar overflow chip when there are more than four members', function (): void {
+    [$group, $conversation, $viewer] = buildLayoutScenario(extraMembers: 6);
+
+    $this->actingAs($viewer)
+        ->get(route('groups.conversations.show', ['group' => $group, 'conversation' => $conversation]))
+        ->assertSee('+3');
+});
+
+test('does not render the overflow chip when four or fewer members', function (): void {
+    [$group, $conversation, $viewer] = buildLayoutScenario(extraMembers: 2);
+
+    $this->actingAs($viewer)
+        ->get(route('groups.conversations.show', ['group' => $group, 'conversation' => $conversation]))
+        ->assertDontSee('+1')
+        ->assertDontSee('+0');
+});
+
+test('pinned strip renders when there is a pinned comment and dismisses on click', function (): void {
+    [$group, $conversation, $viewer] = buildLayoutScenario();
+    $comment = $conversation->postComment('Pin this for visibility please.', $viewer);
+    $comment->fresh()->pin($viewer);
+
+    Livewire::actingAs($viewer)
+        ->test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->assertSeeHtml('data-test="pinned-strip"')
+        ->assertSee('Pin this for visibility please.')
+        ->assertSee('Pinned by Viewer Vex', false)
+        ->call('dismissPinnedStrip')
+        ->assertDontSeeHtml('data-test="pinned-strip"');
+});
+
+test('pinned strip does not render when there are no pinned comments', function (): void {
+    [$group, $conversation, $viewer] = buildLayoutScenario();
+    $conversation->postComment('Just a normal message.', $viewer);
+
+    $this->actingAs($viewer)
+        ->get(route('groups.conversations.show', ['group' => $group, 'conversation' => $conversation]))
+        ->assertDontSeeHtml('data-test="pinned-strip"');
+});
+
+test('back link points at the group page', function (): void {
+    [$group, $conversation, $viewer] = buildLayoutScenario();
+
+    $this->actingAs($viewer)
+        ->get(route('groups.conversations.show', ['group' => $group, 'conversation' => $conversation]))
+        ->assertSee('Back to Elders')
+        ->assertSee(route('groups.show', $group), false);
+});
+
+test('Members tab links to the groups page members tab', function (): void {
+    [$group, $conversation, $viewer] = buildLayoutScenario();
+
+    $this->actingAs($viewer)
+        ->get(route('groups.conversations.show', ['group' => $group, 'conversation' => $conversation]))
+        ->assertSee(route('groups.show', ['group' => $group, 'tab' => 'members']), false);
+});

--- a/tests/Unit/ScriptureLinkerTest.php
+++ b/tests/Unit/ScriptureLinkerTest.php
@@ -1,0 +1,109 @@
+<?php
+
+use App\Services\ScriptureLinker;
+
+function linkify(string $html): string
+{
+    return (new ScriptureLinker())->linkify($html);
+}
+
+test('wraps a canonical single-chapter reference', function (): void {
+    $result = linkify('<p>See Romans 8:31 for the closer.</p>');
+
+    expect($result)->toContain('<a class="scripture-ref"')
+        ->and($result)->toContain('href="https://www.biblegateway.com/passage/?search=Romans+8%3A31"')
+        ->and($result)->toContain('target="_blank"')
+        ->and($result)->toContain('rel="noopener"')
+        ->and($result)->toContain('>Romans 8:31</a>')
+        ->and($result)->toContain('See ')
+        ->and($result)->toContain(' for the closer.');
+});
+
+test('wraps a reference with a numeric prefix', function (): void {
+    $result = linkify('<p>1 Corinthians 13:4 sets the tone.</p>');
+
+    expect($result)->toContain('>1 Corinthians 13:4</a>')
+        ->and($result)->toContain('search=1+Corinthians+13%3A4');
+});
+
+test('wraps a verse range with a hyphen', function (): void {
+    $result = linkify('<p>Romans 8:31-39 is the arc.</p>');
+
+    expect($result)->toContain('>Romans 8:31-39</a>');
+});
+
+test('wraps a verse range with an en-dash', function (): void {
+    $result = linkify('<p>Romans 8:31–39 is the arc.</p>');
+
+    expect($result)->toContain('>Romans 8:31–39</a>');
+});
+
+test('wraps multiple references in the same body', function (): void {
+    $result = linkify('<p>Romans 8:31 and John 1:14 both fit.</p>');
+
+    expect($result)->toContain('>Romans 8:31</a>')
+        ->and($result)->toContain('>John 1:14</a>')
+        ->and(substr_count($result, 'class="scripture-ref"'))->toBe(2);
+});
+
+test('skips non-canonical book names', function (): void {
+    $result = linkify('<p>Wonderful 12:34 should not link.</p>');
+
+    expect($result)->not->toContain('scripture-ref');
+});
+
+test('skips a reference that already lives inside an anchor', function (): void {
+    $input = '<p>See <a href="https://example.com">Romans 8:31</a> for more.</p>';
+    $result = linkify($input);
+
+    expect(substr_count($result, 'class="scripture-ref"'))->toBe(0)
+        ->and($result)->toContain('<a href="https://example.com">Romans 8:31</a>');
+});
+
+test('still links references that sit outside an unrelated anchor', function (): void {
+    $input = '<p>See <a href="https://example.com">resource</a> and Romans 8:31 below.</p>';
+    $result = linkify($input);
+
+    expect(substr_count($result, 'class="scripture-ref"'))->toBe(1)
+        ->and($result)->toContain('>Romans 8:31</a>');
+});
+
+test('links references inside other inline elements like blockquote', function (): void {
+    $result = linkify('<blockquote>John 1:14 grounds the whole night.</blockquote>');
+
+    expect($result)->toContain('>John 1:14</a>')
+        ->and($result)->toContain('<blockquote>');
+});
+
+test('preserves the surrounding HTML structure', function (): void {
+    $result = linkify('<p>Hello <strong>world</strong> Romans 8:31.</p>');
+
+    expect($result)->toContain('<strong>world</strong>')
+        ->and($result)->toContain('>Romans 8:31</a>');
+});
+
+test('returns an empty string unchanged', function (): void {
+    expect(linkify(''))->toBe('');
+});
+
+test('returns whitespace input unchanged', function (): void {
+    expect(linkify('   '))->toBe('   ');
+});
+
+test('does not link a token that looks like a verse but is not after a book', function (): void {
+    $result = linkify('<p>The number 8:31 alone is not a scripture.</p>');
+
+    expect($result)->not->toContain('scripture-ref');
+});
+
+test('handles the Psalm singular form from the canonical list', function (): void {
+    $result = linkify('<p>Psalm 23:1 echoes the same.</p>');
+
+    expect($result)->toContain('>Psalm 23:1</a>');
+});
+
+test('handles a numeric-prefixed book whose last token is canonical', function (): void {
+    $result = linkify('<p>1 John 1:14 is the line.</p>');
+
+    expect($result)->toContain('>1 John 1:14</a>');
+});


### PR DESCRIPTION
## Summary

Rebuilds `groups/{group}/conversations/{conversation}` against the new design: three-column layout (conversation + 260px members rail with **In conversation** / **Not yet posted**), header with stacked-avatar group and **Conversation / Files / Members** tab bar, day-divider message grouping, left-aligned rows with "(you)" emphasis, toggleable reaction chips, a hover toolbar (React, Reply stub, Prayer, More), and a pinned strip. Introduces first-class **Pin** and **Prayer** flags on comments via `App\Models\Comment` (extends Spatie's, adds `pinned_at` / `pinned_by_user_id` / `is_prayer` columns, custom `CommentPolicy`). The composer adds a "Mark as prayer" pill toggle, a Mention stub, and a ⌘↵ kbd hint with Cmd/Ctrl+Enter submission. A new `ScriptureLinker` service wraps canonical scripture refs (`Romans 8:31`, `1 Corinthians 13:4`, ranges) at render time in Bible Gateway links.

## Test plan

- [ ] Visit `/groups/{id}/conversations/{id}` — confirm three-column layout, header tabs (count badge, disabled Files, Members link to group page), stacked avatars + overflow chip
- [ ] Post a comment, react to one (and click again to toggle off), pin one (strip appears at top + Pinned badge), mark prayer on one (Prayer badge + active toolbar state)
- [ ] Dismiss the pinned strip, then pin a different comment — strip should reappear
- [ ] Type `Romans 8:31` in the composer and send — the rendered comment links the ref to biblegateway.com
- [ ] Submit a reply with the "Mark as prayer" pill on — comment is created with `is_prayer = true` and the toggle resets
- [ ] Cmd/Ctrl+Enter from inside the editor submits the form
- [ ] As a non-leader, non-author member: confirm the More dropdown is hidden but the Prayer toggle is still available
- [ ] `npm run pest` and `npm run larastan` both green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Pin important comments in conversations for easy reference
  * Mark comments as prayers for community reflection
  * Scripture references in messages automatically link to BibleGateway
  * Redesigned conversation interface with members rail showing contributors and participants
  * Prayer toggle button in message composer for quick prayer submission
  * Messages now grouped by day for better organization
  * Pinned comments display in a dedicated strip at the top of conversations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jpangborn/stave/pull/83?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->