### PR TITLE
Span messages and composer to full conversation column width

### DIFF
--- a/resources/views/pages/groups/conversations/show.blade.php
+++ b/resources/views/pages/groups/conversations/show.blade.php
@@ -325,7 +325,7 @@ new class extends Component {
 
         {{-- Messages --}}
         <div class="flex-1 overflow-auto px-6 py-4">
-            <div class="mx-auto max-w-3xl">
+            <div>
                 @php($currentUser = Auth::user())
                 @php($canComment = $currentUser?->can('comment', $conversation) ?? false)
                 @php($quickReactions = array_slice(Config::allowedReactions(), 0, 6))
@@ -536,7 +536,6 @@ new class extends Component {
             <div class="border-t border-zinc-200 px-6 py-4 dark:border-zinc-700">
                 <form
                     wire:submit="postReply"
-                    class="mx-auto max-w-3xl"
                     x-data
                     x-on:keydown.enter="if ($event.metaKey || $event.ctrlKey) { $event.preventDefault(); $el.requestSubmit() }"
                 >


### PR DESCRIPTION
## Summary

In the redesigned group conversation page, the pinned strip stretches edge-to-edge inside the conversation column (`mx-6`), but the messages list and composer were still constrained to `max-w-3xl mx-auto` — producing an inconsistent gutter once the page is wide. Dropped those inner caps so the messages and composer share the same horizontal bounds as the pinned strip.

## Test plan

- [ ] Visit `/groups/{id}/conversations/{id}` and confirm messages + composer line up with the pinned strip's left/right edges

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the messages section layout to use full available width instead of a constrained container.
  * Updated the composer area layout to match the messages section width behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jpangborn/stave/pull/84?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->