### PR TITLE
Fix ComponentNotFoundException on song edit page

### DIFF
--- a/resources/views/pages/songs/edit.blade.php
+++ b/resources/views/pages/songs/edit.blade.php
@@ -102,7 +102,7 @@ new class extends Component {
                     @if (!$form->song->recordings->isEmpty())
                         <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
                             @foreach($form->song->recordings as $recording)
-                                <livewire:recording-card :$recording :key="$recording->id"/>
+                                <livewire:recordings.card :$recording :key="$recording->id"/>
                             @endforeach
                         </div>
                     @else
@@ -120,7 +120,7 @@ new class extends Component {
                     @if (!$form->song->sheets->isEmpty())
                         <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
                             @foreach($form->song->sheets as $sheet)
-                                <livewire:sheet-card :$sheet :key="$sheet->id"/>
+                                <livewire:sheets.card :$sheet :key="$sheet->id"/>
                             @endforeach
                         </div>
                     @else
@@ -137,7 +137,7 @@ new class extends Component {
             <flux:separator variant="subtle" />
 
             @can(Permission::EDIT_SONGS)
-                <livewire:upload-song-files :song="$form->song"/>
+                <livewire:songs.upload-files :song="$form->song"/>
             @endcan
         </flux:tab.panel>
     </flux:tab.group>


### PR DESCRIPTION
## Summary
- Renamed three `<livewire:*>` tags in `resources/views/pages/songs/edit.blade.php` to use dot notation, matching the SFC view paths under `resources/views/livewire/{recordings,sheets,songs}/` (and the convention already in `songs/show.blade.php`).
- Resolves `Livewire\Exceptions\ComponentNotFoundException: Unable to find component: [recording-card]` thrown on `GET /songs/{id}/edit` whenever a song has at least one recording; also fixes latent failures that would have surfaced for `sheet-card` and `upload-song-files`.

## Test plan
- [ ] Visit `/songs/{id}/edit` for a song with ≥1 recording and ≥1 sheet → Files tab renders recordings, sheets, and upload section without exception.
- [ ] Confirm Nightwatch/Sentry stops receiving `ComponentNotFoundException` for `[recording-card]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal reorganization of the song editor's Files tab components. No user-facing functionality changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jpangborn/stave/pull/85?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->