### PR TITLE
Switch scripture auto-links to MereBible

### DIFF
--- a/app/Services/ScriptureLinker.php
+++ b/app/Services/ScriptureLinker.php
@@ -33,6 +33,14 @@ class ScriptureLinker
         'Revelation',
     ];
 
+    /** @var array<string, string> Overrides for book tokens whose MereBible slug differs from a simple lowercase. */
+    private const BOOK_SLUGS = [
+        'Psalm' => 'psalms',
+        'Psalms' => 'psalms',
+    ];
+
+    private const MEREBIBLE_BASE_URL = 'https://www.merebible.app/read/csb';
+
     public function linkify(string $html): string
     {
         if (trim($html) === '') {
@@ -101,7 +109,12 @@ class ScriptureLinker
 
             $anchor = $dom->createElement('a');
             $anchor->setAttribute('class', 'scripture-ref');
-            $anchor->setAttribute('href', 'https://www.biblegateway.com/passage/?search='.urlencode($full));
+            $anchor->setAttribute('href', $this->buildUrl(
+                $matches[1][$i][0],
+                $book,
+                $matches[3][$i][0],
+                $matches[4][$i][0],
+            ));
             $anchor->setAttribute('target', '_blank');
             $anchor->setAttribute('rel', 'noopener');
             $anchor->appendChild($dom->createTextNode($full));
@@ -120,5 +133,32 @@ class ScriptureLinker
         }
 
         $textNode->parentNode?->replaceChild($fragment, $textNode);
+    }
+
+    private function buildUrl(string $prefix, string $book, string $chapter, string $verses): string
+    {
+        $slug = self::BOOK_SLUGS[$book] ?? strtolower($book);
+
+        $trimmedPrefix = trim($prefix);
+        if ($trimmedPrefix !== '') {
+            $arabic = match ($trimmedPrefix) {
+                'I' => '1',
+                'II' => '2',
+                'III' => '3',
+                default => $trimmedPrefix,
+            };
+            $slug = $arabic.'-'.$slug;
+        }
+
+        $parts = preg_split('/[\x{2013}\-]/u', $verses, 2);
+        $verse = $parts[0];
+        $endVerse = $parts[1] ?? null;
+
+        $url = self::MEREBIBLE_BASE_URL."/{$slug}/{$chapter}?verse={$verse}";
+        if ($endVerse !== null) {
+            $url .= "&endVerse={$endVerse}";
+        }
+
+        return $url;
     }
 }

--- a/tests/Unit/ScriptureLinkerTest.php
+++ b/tests/Unit/ScriptureLinkerTest.php
@@ -11,7 +11,7 @@ test('wraps a canonical single-chapter reference', function (): void {
     $result = linkify('<p>See Romans 8:31 for the closer.</p>');
 
     expect($result)->toContain('<a class="scripture-ref"')
-        ->and($result)->toContain('href="https://www.biblegateway.com/passage/?search=Romans+8%3A31"')
+        ->and($result)->toContain('href="https://www.merebible.app/read/csb/romans/8?verse=31"')
         ->and($result)->toContain('target="_blank"')
         ->and($result)->toContain('rel="noopener"')
         ->and($result)->toContain('>Romans 8:31</a>')
@@ -23,7 +23,25 @@ test('wraps a reference with a numeric prefix', function (): void {
     $result = linkify('<p>1 Corinthians 13:4 sets the tone.</p>');
 
     expect($result)->toContain('>1 Corinthians 13:4</a>')
-        ->and($result)->toContain('search=1+Corinthians+13%3A4');
+        ->and($result)->toContain('href="https://www.merebible.app/read/csb/1-corinthians/13?verse=4"');
+});
+
+test('builds a range URL for a hyphenated verse range', function (): void {
+    $result = linkify('<p>Romans 8:31-39 is the arc.</p>');
+
+    expect($result)->toContain('href="https://www.merebible.app/read/csb/romans/8?verse=31&amp;endVerse=39"');
+});
+
+test('builds a range URL for an en-dash verse range', function (): void {
+    $result = linkify('<p>Romans 8:31–39 is the arc.</p>');
+
+    expect($result)->toContain('href="https://www.merebible.app/read/csb/romans/8?verse=31&amp;endVerse=39"');
+});
+
+test('maps the singular Psalm form to the plural psalms slug', function (): void {
+    $result = linkify('<p>Psalm 23:1 echoes the same.</p>');
+
+    expect($result)->toContain('href="https://www.merebible.app/read/csb/psalms/23?verse=1"');
 });
 
 test('wraps a verse range with a hyphen', function (): void {


### PR DESCRIPTION
## Summary
- Replace the BibleGateway search URL in `ScriptureLinker` with structured MereBible links of the form `https://www.merebible.app/read/csb/{book}/{chapter}?verse={v}[&endVerse={e}]`, using the regex's existing prefix/book/chapter/verse capture groups.
- Numbered books render as `1-corinthians`-style slugs, hyphen and en-dash verse ranges both produce `endVerse`, and `Psalm`/`Psalms` both fold to `psalms`.
- Updated existing URL assertions and added unit coverage for ranges and the Psalm slug fold.

## Test plan
- [x] `php artisan test --compact --filter=ScriptureLinker` (18/18)
- [x] `php artisan test --compact --filter=ConversationMessageRowTest` (15/15)
- [x] `vendor/bin/pint --dirty --format agent`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Updates**
  * Scripture references throughout the application now link to MereBible instead of BibleGateway, directing users to an enhanced platform for accessing biblical content.
  * Improved scripture reference link formatting with better support for various biblical notation styles, including multiple book name variations and flexible verse range specifications for more accurate cross-references.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jpangborn/stave/pull/86?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->