### PR TITLE
Fix viewport bottom gap on group conversation page

### DIFF
--- a/resources/views/pages/groups/conversations/show.blade.php
+++ b/resources/views/pages/groups/conversations/show.blade.php
@@ -222,7 +222,7 @@ new class extends Component {
 };
 ?>
 
-<section class="-m-6 lg:-m-8 flex h-[calc(100vh-3rem)] lg:h-[calc(100vh-4rem)] min-h-0">
+<section class="-m-6 lg:-m-8 flex h-[calc(100vh-3rem)] lg:h-screen min-h-0">
     {{-- Conversation column --}}
     <div class="flex min-w-0 flex-1 flex-col bg-white dark:bg-zinc-800">
         {{-- Header --}}


### PR DESCRIPTION
## Summary
- The group conversation page's section used `lg:h-[calc(100vh-4rem)]`, which left a ~4rem strip at the bottom of the viewport below the composer and right rail on desktop.
- The negative `lg:-m-8` margin already neutralizes `flux:main`'s `lg:p-8` padding, so subtracting it from the height was double-counting and shortening the section.
- Switched to `lg:h-screen` so the column and members rail reach the viewport bottom. Mobile (`h-[calc(100vh-3rem)]`) is unchanged because the visible `flux:header` consumes that 3rem.

## Test plan
- [ ] Open a group conversation at desktop width — composer and "In Conversation" rail touch the viewport bottom with no gap.
- [ ] Resize below `lg` — mobile layout still fits under the Flux header, composer reaches the bottom.
- [ ] Messages list still scrolls internally while header + composer stay fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)