### PR TITLE
Keep hover toolbar visible while reaction popover is open

### DIFF
--- a/resources/views/pages/groups/conversations/show.blade.php
+++ b/resources/views/pages/groups/conversations/show.blade.php
@@ -461,7 +461,7 @@ new class extends Component {
                             {{-- Hover toolbar --}}
                             @if ($canComment)
                                 <div
-                                    class="absolute right-3 top-2.5 z-10 hidden gap-0.5 group-hover/row:flex group-focus-within/row:flex"
+                                    class="absolute right-3 top-2.5 z-10 hidden gap-0.5 group-hover/row:flex group-focus-within/row:flex group-has-[[data-flux-popover][data-open]]/row:flex"
                                     data-test="hover-toolbar"
                                     role="toolbar"
                                     aria-label="Message actions"


### PR DESCRIPTION
## Summary
- The message hover toolbar on the group conversation page was gated only by `group-hover` / `group-focus-within` on the row, so clicking the reaction trigger (which opens a `flux:popover` in the browser's top layer, anchored below the row) moved the cursor outside the hover region, hiding the toolbar — which unmounted the trigger and collapsed the popover with it.
- Added a `group-has-[[data-flux-popover][data-open]]/row:flex` variant so the toolbar stays visible whenever any Flux popover inside the row is open, using the `data-open` hook Flux already toggles.

## Test plan
- [ ] Hover a message on a group conversation, click the smile icon, confirm the popover opens and the toolbar stays visible
- [ ] Click a quick-reaction emoji and confirm the reaction is recorded and the popover closes
- [ ] Move the cursor away and confirm the toolbar hides again
- [ ] Confirm prayer/pin toggles still hide normally when no popover is open
- [ ] Re-check the reactions-row trigger (always-visible smile icon under the message) still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)