### PR TITLE
Replace tab bar with inline comment count and rail files section

### DIFF
--- a/resources/views/pages/groups/conversations/show.blade.php
+++ b/resources/views/pages/groups/conversations/show.blade.php
@@ -226,7 +226,7 @@ new class extends Component {
     {{-- Conversation column --}}
     <div class="flex min-w-0 flex-1 flex-col bg-white dark:bg-zinc-800">
         {{-- Header --}}
-        <header class="border-b border-zinc-200 px-6 pt-4 dark:border-zinc-700">
+        <header class="border-b border-zinc-200 px-6 py-4 dark:border-zinc-700">
             <flux:button :href="route('groups.show', $group)" variant="ghost" size="sm" icon="arrow-left" wire:navigate>
                 Back to {{ $group->name }}
             </flux:button>
@@ -242,6 +242,8 @@ new class extends Component {
                         · {{ $conversation->created_at->diffForHumans() }}
                         @php($memberCount = $this->memberCount())
                         · {{ $memberCount }} {{ str('member')->plural($memberCount) }}
+                        @php($commentCount = $this->comments->count())
+                        · {{ $commentCount }} {{ str('comment')->plural($commentCount) }}
                     </flux:subheading>
                 </div>
 
@@ -280,28 +282,6 @@ new class extends Component {
                 </div>
             </div>
 
-            {{-- Tab bar --}}
-            <nav class="mt-3 -mb-px flex gap-1" aria-label="Conversation views">
-                <span
-                    class="flex items-center gap-1.5 border-b-2 border-accent px-3 py-2 text-sm font-bold text-zinc-900 dark:text-white"
-                    aria-current="page"
-                >
-                    Conversation
-                    <flux:badge size="sm" inset="top bottom" data-test="comment-count-badge">{{ $this->comments->count() }}</flux:badge>
-                </span>
-                <flux:tooltip content="Coming soon">
-                    <button
-                        type="button"
-                        disabled
-                        class="cursor-not-allowed border-b-2 border-transparent px-3 py-2 text-sm font-medium text-zinc-400 dark:text-zinc-500"
-                    >Files</button>
-                </flux:tooltip>
-                <a
-                    href="{{ route('groups.show', ['group' => $group, 'tab' => 'members']) }}"
-                    wire:navigate
-                    class="border-b-2 border-transparent px-3 py-2 text-sm font-medium text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-white"
-                >Members</a>
-            </nav>
         </header>
 
         {{-- Pinned strip --}}
@@ -614,6 +594,18 @@ new class extends Component {
         aria-label="Members"
         data-test="members-rail"
     >
+        <section class="mb-6" data-test="rail-files">
+            <div class="mb-2 flex items-center justify-between text-xs font-semibold uppercase tracking-wider text-zinc-500">
+                <span>Files · 0</span>
+                <flux:tooltip content="Coming soon">
+                    <flux:button size="xs" variant="ghost" icon="arrow-up-tray" disabled data-test="rail-files-add">Add</flux:button>
+                </flux:tooltip>
+            </div>
+            <p class="px-1 py-2 text-xs text-zinc-500">
+                No files yet. Drag a PDF or sheet music here to attach it to this conversation.
+            </p>
+        </section>
+
         <div class="mb-4 text-xs font-semibold uppercase tracking-wider text-zinc-500">
             Members · {{ $this->memberCount() }}
         </div>

--- a/tests/Feature/GroupConversationLayoutTest.php
+++ b/tests/Feature/GroupConversationLayoutTest.php
@@ -37,28 +37,39 @@ function buildLayoutScenario(int $extraMembers = 0): array
     return [$group, $conversation, $viewer];
 }
 
-test('shows the tab bar with Conversation Files and Members tabs', function (): void {
-    [$group, $conversation, $viewer] = buildLayoutScenario();
-
-    $this->actingAs($viewer)
-        ->get(route('groups.conversations.show', ['group' => $group, 'conversation' => $conversation]))
-        ->assertSuccessful()
-        ->assertSee('Conversation', false)
-        ->assertSee('Files', false)
-        ->assertSee('Members', false)
-        ->assertSeeHtml('data-test="comment-count-badge"');
-});
-
-test('the conversation count badge reflects the number of comments', function (): void {
+test('the subheading shows the comment count', function (): void {
     [$group, $conversation, $viewer] = buildLayoutScenario();
     $conversation->postComment('first', $viewer);
     $conversation->postComment('second', $viewer);
 
+    $this->actingAs($viewer)
+        ->get(route('groups.conversations.show', ['group' => $group, 'conversation' => $conversation]))
+        ->assertSuccessful()
+        ->assertSee('2 comments');
+});
+
+test('the subheading singularises the comment count', function (): void {
+    [$group, $conversation, $viewer] = buildLayoutScenario();
+    $conversation->postComment('only one', $viewer);
+
+    $this->actingAs($viewer)
+        ->get(route('groups.conversations.show', ['group' => $group, 'conversation' => $conversation]))
+        ->assertSee('1 comment')
+        ->assertDontSee('1 comments');
+});
+
+test('the rail renders a Files section above Members', function (): void {
+    [$group, $conversation, $viewer] = buildLayoutScenario();
+
     Livewire::actingAs($viewer)
         ->test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->assertSeeHtml('data-test="rail-files"')
+        ->assertSeeHtml('data-test="rail-files-add"')
+        ->assertSee('Files · 0')
+        ->assertSee('No files yet')
         ->assertSeeHtmlInOrder([
-            'data-test="comment-count-badge"',
-            '2',
+            'data-test="rail-files"',
+            'Members ·',
         ]);
 });
 
@@ -140,14 +151,6 @@ test('back link points at the group page', function (): void {
         ->get(route('groups.conversations.show', ['group' => $group, 'conversation' => $conversation]))
         ->assertSee('Back to Elders')
         ->assertSee(route('groups.show', $group), false);
-});
-
-test('Members tab links to the groups page members tab', function (): void {
-    [$group, $conversation, $viewer] = buildLayoutScenario();
-
-    $this->actingAs($viewer)
-        ->get(route('groups.conversations.show', ['group' => $group, 'conversation' => $conversation]))
-        ->assertSee(route('groups.show', ['group' => $group, 'tab' => 'members']), false);
 });
 
 // --- Phase G: empty state ---


### PR DESCRIPTION
## Summary

- Removes the tab bar navigation from the conversation header — it added chrome without value on a single-view page.
- Moves the comment count inline into the subheading (with proper singular/plural handling).
- Adds a Files placeholder section to the right-side rail, positioned above Members, ready to grow into a full attachment panel.
- Updates tests to reflect the new layout structure.

## Test plan

- [ ] Verify comment count displays correctly in the subheading (singular and plural)
- [ ] Verify the Files section appears in the rail above Members
- [ ] Confirm no visual regression in the header spacing
- [ ] Run `php artisan test tests/Feature/GroupConversationLayoutTest.php`

🤖 Generated with [Claude Code](https://claude.com/claude-code)