### PR TITLE
Show Gravatar images on group conversation avatars

### DIFF
--- a/resources/views/pages/groups/conversations/show.blade.php
+++ b/resources/views/pages/groups/conversations/show.blade.php
@@ -250,7 +250,7 @@ new class extends Component {
                     <div class="flex -space-x-2">
                         @foreach ($this->displayedMembers as $member)
                             <div class="ring-2 ring-white dark:ring-zinc-800 rounded-lg" wire:key="header-avatar-{{ $member->id }}">
-                                <flux:avatar size="xs" name="{{ $member->name }}" color="auto" />
+                                <flux:avatar size="xs" name="{{ $member->name }}" src="{{ $member->gravatar }}" color="auto" />
                             </div>
                         @endforeach
                         @if ($this->memberCount() > 4)
@@ -367,7 +367,7 @@ new class extends Component {
                             data-test="message-row"
                             @if ($isMine) data-test-mine="true" @endif
                         >
-                            <flux:avatar size="md" name="{{ $comment->commentator?->name }}" color="auto" />
+                            <flux:avatar size="md" name="{{ $comment->commentator?->name }}" src="{{ $comment->commentator?->gravatar }}" color="auto" />
 
                             <div class="min-w-0 flex-1">
                                 {{-- Header line --}}
@@ -627,7 +627,7 @@ new class extends Component {
                 <div class="space-y-0.5">
                     @foreach ($this->contributors as $member)
                         <div class="flex items-center gap-2.5 rounded-md px-2 py-1.5 hover:bg-zinc-100 dark:hover:bg-zinc-800" wire:key="rail-contrib-{{ $member->id }}">
-                            <flux:avatar size="xs" name="{{ $member->name }}" color="auto" />
+                            <flux:avatar size="xs" name="{{ $member->name }}" src="{{ $member->gravatar }}" color="auto" />
                             <div class="min-w-0 flex-1">
                                 <div class="truncate text-sm font-semibold">{{ $member->name }}</div>
                                 <div class="text-xs text-zinc-500">{{ $member->pivot->role->label() }}</div>
@@ -647,7 +647,7 @@ new class extends Component {
                 <div class="space-y-0.5">
                     @foreach ($this->nonContributors as $member)
                         <div class="flex items-center gap-2.5 rounded-md px-2 py-1.5 hover:bg-zinc-100 dark:hover:bg-zinc-800" wire:key="rail-noncontrib-{{ $member->id }}">
-                            <flux:avatar size="xs" name="{{ $member->name }}" color="auto" />
+                            <flux:avatar size="xs" name="{{ $member->name }}" src="{{ $member->gravatar }}" color="auto" />
                             <div class="min-w-0 flex-1">
                                 <div class="truncate text-sm font-semibold">{{ $member->name }}</div>
                                 <div class="text-xs text-zinc-500">{{ $member->pivot->role->label() }}</div>


### PR DESCRIPTION
## Summary
- Pass the existing `User->gravatar` URL into the four `<flux:avatar>` instances in `resources/views/pages/groups/conversations/show.blade.php` (header stack, message rows, and both right-rail member lists), so each one renders an image instead of just initials. Flux still falls back to initials while the image loads or if the request fails.

## Test plan
- [x] `vendor/bin/pint --dirty --format agent`
- [x] `php artisan test --compact --filter="GroupConversation|ConversationMessageRow"` (55 passed)
- [ ] Open a group conversation at `https://stave.test` and confirm header, message-row, and right-rail avatars render Gravatar images

Generated with [Claude Code](https://claude.com/claude-code)