### PR TITLE
Use flux:avatar.group in group conversation header

### DIFF
--- a/resources/views/pages/groups/conversations/show.blade.php
+++ b/resources/views/pages/groups/conversations/show.blade.php
@@ -254,19 +254,20 @@ new class extends Component {
                 </div>
 
                 <div class="flex items-center gap-2">
-                    {{-- Stacked avatar group --}}
-                    <div class="flex -space-x-2">
+                    <flux:avatar.group class="dark:**:ring-zinc-800">
                         @foreach ($this->displayedMembers as $member)
-                            <div class="ring-2 ring-white dark:ring-zinc-800 rounded-lg" wire:key="header-avatar-{{ $member->id }}">
-                                <flux:avatar size="xs" name="{{ $member->name }}" src="{{ $member->gravatar }}" color="auto" />
-                            </div>
+                            <flux:avatar
+                                wire:key="header-avatar-{{ $member->id }}"
+                                size="xs"
+                                name="{{ $member->name }}"
+                                src="{{ $member->gravatar }}"
+                                color="auto"
+                            />
                         @endforeach
                         @if ($this->memberCount() > 4)
-                            <div class="flex size-7 items-center justify-center rounded-lg bg-zinc-200 text-xs font-semibold text-zinc-600 ring-2 ring-white dark:bg-zinc-700 dark:text-zinc-300 dark:ring-zinc-800">
-                                +{{ $this->memberCount() - 4 }}
-                            </div>
+                            <flux:avatar size="xs">+{{ $this->memberCount() - 4 }}</flux:avatar>
                         @endif
-                    </div>
+                    </flux:avatar.group>
 
                     <flux:tooltip content="Search (coming soon)">
                         <flux:button variant="ghost" size="sm" icon="magnifying-glass" square disabled />


### PR DESCRIPTION
## Summary
- Replace the hand-rolled stacked avatar markup in the group conversation header with `flux:avatar.group`, so Flux handles overlap spacing and ring styling.
- The `+N` overflow chip is now a plain `<flux:avatar>` instead of a custom `<div>`; the group applies a `dark:**:ring-zinc-800` override to keep the ring matched to the header background.

## Test plan
- [ ] Open a group conversation with > 4 members at `https://stave.test` and confirm the avatar stack still overlaps and the `+N` chip appears.
- [ ] Verify rings match the header background in both light and dark mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Updated member avatars in conversation headers to display as a group layout, with a "+N" indicator when there are more than four members.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jpangborn/stave/pull/93?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->