### PR TITLE
Show all eight reactions in group conversation pickers

### DIFF
--- a/resources/views/pages/groups/conversations/show.blade.php
+++ b/resources/views/pages/groups/conversations/show.blade.php
@@ -315,7 +315,7 @@ new class extends Component {
             <div>
                 @php($currentUser = Auth::user())
                 @php($canComment = $currentUser?->can('comment', $conversation) ?? false)
-                @php($quickReactions = array_slice(Config::allowedReactions(), 0, 6))
+                @php($quickReactions = Config::allowedReactions())
 
                 @if ($this->comments->isEmpty())
                     <div class="flex flex-col items-center justify-center px-6 py-16 text-center" data-test="empty-state">

--- a/tests/Feature/ConversationMessageRowTest.php
+++ b/tests/Feature/ConversationMessageRowTest.php
@@ -183,7 +183,7 @@ test('clicking a reaction the viewer already gave removes it', function (): void
     expect($comment->fresh()->reactions()->count())->toBe(0);
 });
 
-test('reaction picker only renders the first six allowed reactions', function (): void {
+test('reaction picker renders all allowed reactions', function (): void {
     [$group, $conversation, $viewer] = buildRowScenario();
     $conversation->postComment('hi', $viewer);
 
@@ -192,7 +192,7 @@ test('reaction picker only renders the first six allowed reactions', function ()
         ->html();
 
     $allowed = config('comments.allowed_reactions');
-    foreach (array_slice($allowed, 0, 6) as $expected) {
+    foreach ($allowed as $expected) {
         expect($html)->toContain($expected);
     }
 });


### PR DESCRIPTION
## Summary
- Drop the `array_slice(..., 0, 6)` in the group conversation view so both the hover-toolbar smiley dropdown and the inline `+` picker render every emoji in `config('comments.allowed_reactions')` (now 👍 ✅ ❤️ 🔥 🙏 ❓ 🤯 🎉).
- Update the related Pest test to assert the full allowed-reactions list renders instead of just the first six.

## Test plan
- [x] `php artisan test tests/Feature/ConversationMessageRowTest.php`
- [ ] Open a group conversation, hover a message, and confirm both reaction popovers display all eight emoji.

🤖 Generated with [Claude Code](https://claude.com/claude-code)