### PR TITLE
Add small gap between group conversation comment rows

### DIFF
--- a/resources/views/pages/groups/conversations/show.blade.php
+++ b/resources/views/pages/groups/conversations/show.blade.php
@@ -347,7 +347,7 @@ new class extends Component {
                         <div
                             wire:key="comment-{{ $comment->id }}"
                             @class([
-                                'group/row relative flex gap-3 rounded-md border-l-2 px-3 py-3 transition-colors',
+                                'group/row relative mt-1 flex gap-3 rounded-md border-l-2 px-3 py-3 transition-colors',
                                 'border-transparent hover:bg-zinc-50 dark:hover:bg-zinc-900/60' => ! $isMine,
                                 'border-accent bg-accent/5 hover:bg-accent/10' => $isMine,
                             ])


### PR DESCRIPTION
## Summary
- Adds `mt-1` to each comment row in the group conversation view so consecutive comments are visually distinct instead of merging into one block (most noticeable for your own messages, which share a `bg-accent/5` background).

## Test plan
- [ ] Open a group conversation with two consecutive comments from the same user and confirm a small gap is visible between rows.
- [ ] Confirm the spacing between a day divider and the first comment of that day still looks balanced.