### PR TITLE
Recognize Bible book abbreviations in scripture linker

### DIFF
--- a/app/Services/ScriptureLinker.php
+++ b/app/Services/ScriptureLinker.php
@@ -19,7 +19,7 @@ class ScriptureLinker
      * Restricting the book to one token prevents an adjacent capitalized word
      * ("See Romans 8:31") from being swept into the match.
      */
-    private const SCRIPTURE_REGEX = '/\b((?:1|2|3|I|II|III)\s+)?([A-Z][a-z]+)\s(\d+):(\d+(?:[\x{2013}-]\d+)?)\b/u';
+    private const SCRIPTURE_REGEX = '/\b((?:1|2|3|I|II|III)\s+)?([A-Z][a-z]+)\.?\s(\d+):(\d+(?:[\x{2013}-]\d+)?)\b/u';
 
     /** @var array<int, string> Canonical book names. The captured book token must appear here for the ref to link. */
     private const CANONICAL_BOOKS = [
@@ -31,6 +31,25 @@ class ScriptureLinker
         'Romans', 'Corinthians', 'Galatians', 'Ephesians', 'Philippians', 'Colossians',
         'Thessalonians', 'Timothy', 'Titus', 'Philemon', 'Hebrews', 'James', 'Peter', 'Jude',
         'Revelation',
+    ];
+
+    /** @var array<string, string> Abbreviation → canonical book token. */
+    private const ABBREVIATIONS = [
+        'Gen' => 'Genesis', 'Exod' => 'Exodus', 'Lev' => 'Leviticus', 'Num' => 'Numbers',
+        'Deut' => 'Deuteronomy', 'Josh' => 'Joshua', 'Judg' => 'Judges',
+        'Sam' => 'Samuel', 'Kgs' => 'Kings', 'Chr' => 'Chronicles',
+        'Neh' => 'Nehemiah', 'Esth' => 'Esther',
+        'Ps' => 'Psalms', 'Pss' => 'Psalms',
+        'Prov' => 'Proverbs', 'Eccl' => 'Ecclesiastes',
+        'Isa' => 'Isaiah', 'Jer' => 'Jeremiah', 'Lam' => 'Lamentations', 'Ezek' => 'Ezekiel',
+        'Dan' => 'Daniel', 'Hos' => 'Hosea', 'Obad' => 'Obadiah', 'Mic' => 'Micah',
+        'Nah' => 'Nahum', 'Hab' => 'Habakkuk', 'Zeph' => 'Zephaniah', 'Hag' => 'Haggai',
+        'Zech' => 'Zechariah', 'Mal' => 'Malachi',
+        'Matt' => 'Matthew', 'Mt' => 'Matthew', 'Mk' => 'Mark', 'Lk' => 'Luke', 'Jn' => 'John',
+        'Rom' => 'Romans', 'Cor' => 'Corinthians', 'Gal' => 'Galatians', 'Eph' => 'Ephesians',
+        'Phil' => 'Philippians', 'Phlm' => 'Philemon', 'Col' => 'Colossians',
+        'Thess' => 'Thessalonians', 'Tim' => 'Timothy',
+        'Heb' => 'Hebrews', 'Jas' => 'James', 'Pet' => 'Peter', 'Rev' => 'Revelation',
     ];
 
     /** @var array<string, string> Overrides for book tokens whose MereBible slug differs from a simple lowercase. */
@@ -97,7 +116,8 @@ class ScriptureLinker
         $emitted = false;
 
         foreach ($matches[0] as $i => [$full, $offset]) {
-            $book = $matches[2][$i][0];
+            $token = $matches[2][$i][0];
+            $book = self::ABBREVIATIONS[$token] ?? $token;
 
             if (! in_array($book, self::CANONICAL_BOOKS, true)) {
                 continue;

--- a/tests/Unit/ScriptureLinkerTest.php
+++ b/tests/Unit/ScriptureLinkerTest.php
@@ -125,3 +125,99 @@ test('handles a numeric-prefixed book whose last token is canonical', function (
 
     expect($result)->toContain('>1 John 1:14</a>');
 });
+
+test('wraps an abbreviated single reference', function (): void {
+    $result = linkify('<p>Rom 3:23 is sobering.</p>');
+
+    expect($result)->toContain('>Rom 3:23</a>')
+        ->and($result)->toContain('href="https://www.merebible.app/read/csb/romans/3?verse=23"');
+});
+
+test('wraps an abbreviated numeric-prefixed reference', function (): void {
+    $result = linkify('<p>1 Cor 1:1 opens the letter.</p>');
+
+    expect($result)->toContain('>1 Cor 1:1</a>')
+        ->and($result)->toContain('href="https://www.merebible.app/read/csb/1-corinthians/1?verse=1"');
+});
+
+test('wraps an abbreviation with a trailing period', function (): void {
+    $result = linkify('<p>Rom. 8:31 is the closer.</p>');
+
+    expect($result)->toContain('>Rom. 8:31</a>')
+        ->and($result)->toContain('href="https://www.merebible.app/read/csb/romans/8?verse=31"');
+});
+
+test('wraps an abbreviated verse range with a hyphen', function (): void {
+    $result = linkify('<p>Rom 8:31-39 is the arc.</p>');
+
+    expect($result)->toContain('>Rom 8:31-39</a>')
+        ->and($result)->toContain('href="https://www.merebible.app/read/csb/romans/8?verse=31&amp;endVerse=39"');
+});
+
+test('wraps an abbreviated verse range with an en-dash', function (): void {
+    $result = linkify('<p>Rom 8:31–39 is the arc.</p>');
+
+    expect($result)->toContain('>Rom 8:31–39</a>')
+        ->and($result)->toContain('href="https://www.merebible.app/read/csb/romans/8?verse=31&amp;endVerse=39"');
+});
+
+test('disambiguates Phil as Philippians', function (): void {
+    $result = linkify('<p>Phil 4:13 reframes strength.</p>');
+
+    expect($result)->toContain('>Phil 4:13</a>')
+        ->and($result)->toContain('href="https://www.merebible.app/read/csb/philippians/4?verse=13"');
+});
+
+test('disambiguates Phlm as Philemon', function (): void {
+    $result = linkify('<p>Phlm 1:6 ties faith to action.</p>');
+
+    expect($result)->toContain('>Phlm 1:6</a>')
+        ->and($result)->toContain('href="https://www.merebible.app/read/csb/philemon/1?verse=6"');
+});
+
+test('maps the Ps abbreviation through to the psalms slug', function (): void {
+    $result = linkify('<p>Ps 23:1 echoes the same.</p>');
+
+    expect($result)->toContain('>Ps 23:1</a>')
+        ->and($result)->toContain('href="https://www.merebible.app/read/csb/psalms/23?verse=1"');
+});
+
+test('wraps gospel abbreviation Mt', function (): void {
+    $result = linkify('<p>Mt 5:3 opens the sermon.</p>');
+
+    expect($result)->toContain('>Mt 5:3</a>')
+        ->and($result)->toContain('href="https://www.merebible.app/read/csb/matthew/5?verse=3"');
+});
+
+test('wraps gospel abbreviation Mk', function (): void {
+    $result = linkify('<p>Mk 1:1 starts the gospel.</p>');
+
+    expect($result)->toContain('>Mk 1:1</a>')
+        ->and($result)->toContain('href="https://www.merebible.app/read/csb/mark/1?verse=1"');
+});
+
+test('wraps gospel abbreviation Lk', function (): void {
+    $result = linkify('<p>Lk 2:11 announces the birth.</p>');
+
+    expect($result)->toContain('>Lk 2:11</a>')
+        ->and($result)->toContain('href="https://www.merebible.app/read/csb/luke/2?verse=11"');
+});
+
+test('wraps gospel abbreviation Jn', function (): void {
+    $result = linkify('<p>Jn 3:16 is the line.</p>');
+
+    expect($result)->toContain('>Jn 3:16</a>')
+        ->and($result)->toContain('href="https://www.merebible.app/read/csb/john/3?verse=16"');
+});
+
+test('does not link an unrecognized abbreviation', function (): void {
+    $result = linkify('<p>Xyz 1:1 and Foo. 2:2 should not link.</p>');
+
+    expect($result)->not->toContain('scripture-ref');
+});
+
+test('does not false-positive on a non-book period token', function (): void {
+    $result = linkify('<p>Mr. 8:31 should not link.</p>');
+
+    expect($result)->not->toContain('scripture-ref');
+});


### PR DESCRIPTION
## Summary
- Adds an `ABBREVIATIONS` map in `ScriptureLinker` so common shortened forms (`Rom`, `1 Cor`, `Phil`, `Phlm`, `Ps`, `Mt`/`Mk`/`Lk`/`Jn`, etc.) resolve to canonical book names and get linkified to MereBible like the spelled-out versions.
- Relaxes the regex to accept an optional trailing period on the book token, so references written as `Rom. 8:31` also link correctly. The anchor's display text continues to mirror what the user typed.
- Covers the new behavior with 14 Pest tests in `tests/Unit/ScriptureLinkerTest.php`, including verse ranges, the `Phil`/`Phlm` disambiguation, the `Ps`→`psalms` slug path, and false-positive guards (`Mr. 8:31` stays unlinked).

## Test plan
- [x] \`php artisan test --compact --filter=ScriptureLinker\` (32 passed)
- [ ] Spot-check rendered comments containing \`Rom 3:23\`, \`1 Cor 1:1\`, \`Phil 4:13\`, \`Phlm 1:6\`, and \`Rom. 8:31\`