### PR TITLE
Fix pinned message banner double-encoding HTML entities

### DIFF
--- a/resources/views/pages/groups/conversations/show.blade.php
+++ b/resources/views/pages/groups/conversations/show.blade.php
@@ -303,7 +303,7 @@ new class extends Component {
                         Pinned by {{ $firstPinned->pinnedBy?->name ?? 'Unknown' }}
                     </div>
                     <div class="mt-0.5 truncate text-sm text-zinc-700 dark:text-zinc-200">
-                        {{ Str::limit(strip_tags($firstPinned->text), 140) }}
+                        {{ Str::limit(html_entity_decode(strip_tags($firstPinned->text), ENT_QUOTES | ENT_HTML5), 140) }}
                     </div>
                 </div>
                 <flux:button wire:click="dismissPinnedStrip" variant="ghost" size="sm" icon="x-mark" square aria-label="Dismiss pinned message" />

--- a/tests/Feature/GroupConversationLayoutTest.php
+++ b/tests/Feature/GroupConversationLayoutTest.php
@@ -135,6 +135,18 @@ test('pinned strip renders when there is a pinned comment and dismisses on click
         ->assertDontSeeHtml('data-test="pinned-strip"');
 });
 
+test('pinned strip decodes HTML entities in the comment preview', function (): void {
+    [$group, $conversation, $viewer] = buildLayoutScenario();
+    $comment = $conversation->postComment("What's missing?", $viewer);
+    $comment->fresh()->pin($viewer);
+
+    Livewire::actingAs($viewer)
+        ->test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->assertSeeHtml('data-test="pinned-strip"')
+        ->assertSee("What's missing?")
+        ->assertDontSeeHtml('What&amp;#039;s');
+});
+
 test('pinned strip does not render when there are no pinned comments', function (): void {
     [$group, $conversation, $viewer] = buildLayoutScenario();
     $conversation->postComment('Just a normal message.', $viewer);


### PR DESCRIPTION
## Summary
- The pinned-message banner was rendering text like `What&#039;s missing?` because `comments.text` already contains HTML-encoded entities (produced by Spatie's sanitizer) and Blade's `{{ }}` escape was re-encoding the `&`. Wrapped the preview in `html_entity_decode(..., ENT_QUOTES | ENT_HTML5)` so the auto-escape produces a single, correct layer.
- Added a regression test covering an apostrophe in a pinned comment preview.

## Test plan
- [x] `php artisan test --filter='pinned strip decodes HTML entities'`
- [x] `php artisan test --filter=GroupConversationLayoutTest` (18/18)
- [x] `php artisan test --filter=CommentPinPrayer` (24/24)
- [ ] Manual smoke at https://stave.test: pin a comment containing `'`, `"`, and `&` — banner matches the message body below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)