### PR TITLE
Add spacing between paragraphs in rendered comments

### DIFF
--- a/resources/views/livewire/services/discussion.blade.php
+++ b/resources/views/livewire/services/discussion.blade.php
@@ -49,6 +49,7 @@ new class() extends Component
                 **:[ol]:list-decimal **:[ol]:ml-5 **:[ul]:list-disc **:[ul]:ml-5
                 **:[a]:underline
                 **:[blockquote]:border-l-4 **:[blockquote]:pl-2
+                **:[p]:not-first:mt-3
                 ">
             @php
                 $prevUser = null;

--- a/resources/views/pages/groups/conversations/show.blade.php
+++ b/resources/views/pages/groups/conversations/show.blade.php
@@ -385,7 +385,8 @@ new class extends Component {
                                     **:[strong]:font-semibold **:[em]:italic **:[u]:underline **:[s]:line-through
                                     **:[ol]:list-decimal **:[ol]:ml-5 **:[ul]:list-disc **:[ul]:ml-5
                                     **:[a]:underline
-                                    **:[blockquote]:border-l-4 **:[blockquote]:pl-2">
+                                    **:[blockquote]:border-l-4 **:[blockquote]:pl-2
+                                    **:[p]:not-first:mt-3">
                                     {!! app(ScriptureLinker::class)->linkify($comment->text) !!}
                                 </div>
 


### PR DESCRIPTION
## Summary
- Multi-paragraph comments rendered without any gap between `<p>` tags because the existing `**:[tag]:` typography wrapper had no rule for paragraphs. Adds `**:[p]:not-first:mt-3` to both comment render locations (group conversations and service discussions) so subsequent paragraphs get a small top margin without adding a leading gap above the first paragraph.

## Test plan
- [x] `php artisan test --compact --filter=ConversationMessageRowTest`
- [x] `php artisan test --compact --filter=ServiceDiscussionTest`
- [ ] Visually confirm multi-paragraph comments in a group conversation and a service discussion at https://stave.test

🤖 Generated with [Claude Code](https://claude.com/claude-code)