### PR TITLE
Add top spacing for block elements in group conversation comments

### DIFF
--- a/resources/views/pages/groups/conversations/show.blade.php
+++ b/resources/views/pages/groups/conversations/show.blade.php
@@ -386,7 +386,11 @@ new class extends Component {
                                     **:[ol]:list-decimal **:[ol]:ml-5 **:[ul]:list-disc **:[ul]:ml-5
                                     **:[a]:underline
                                     **:[blockquote]:border-l-4 **:[blockquote]:pl-2
-                                    **:[p]:not-first:mt-3">
+                                    **:[h1]:not-first:mt-3 **:[h2]:not-first:mt-3 **:[h3]:not-first:mt-3
+                                    **:[ul]:not-first:mt-3 **:[ol]:not-first:mt-3
+                                    **:[blockquote]:not-first:mt-3
+                                    **:[p]:not-first:mt-3
+                                    **:[h1+p]:mt-0 **:[h2+p]:mt-0 **:[h3+p]:mt-0">
                                     {!! app(ScriptureLinker::class)->linkify($comment->text) !!}
                                 </div>
 


### PR DESCRIPTION
## Summary
- Extends the paragraph spacing added in #99 to other block elements (h1/h2/h3, ul/ol, blockquote) in the group conversation comment body so multi-block comments don't run together.
- Adds an `h{1,2,3}+p:mt-0` override so a paragraph that immediately follows a heading doesn't get an extra gap on top of the heading's own margin.
- Scope is intentionally limited to `resources/views/pages/groups/conversations/show.blade.php`; the service discussion view is unchanged.

## Test plan
- [ ] Load a group conversation with a comment containing headings, lists, and a blockquote between paragraphs; confirm each block element gets a small top gap from the preceding content.
- [ ] Confirm the very first element in a comment has no extra top margin.
- [ ] Confirm a `<p>` directly after an `<h1>/<h2>/<h3>` does not have extra top spacing.
- [ ] Confirm service discussion comments render unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined message spacing in conversations by improving how margins are applied between rich-text blocks. Spacing now adjusts intelligently based on element types and positioning for enhanced visual clarity and readability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jpangborn/stave/pull/100?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->