### PR TITLE
Fix mobile message action sheet not opening on 3-dot tap

### DIFF
--- a/resources/views/pages/groups/conversations/show.blade.php
+++ b/resources/views/pages/groups/conversations/show.blade.php
@@ -221,6 +221,8 @@ new class extends Component {
     public function openActions(int $commentId): void
     {
         $this->sheetCommentId = $commentId;
+
+        Flux::modal('message-actions')->show();
     }
 
     public function closeActions(): void
@@ -993,14 +995,4 @@ new class extends Component {
             </div>
         @endif
     </flux:modal>
-
-    {{-- Open the sheet whenever sheetCommentId becomes non-null --}}
-    <div
-        x-data
-        x-init="$wire.$watch('sheetCommentId', value => {
-            if (value !== null) {
-                $nextTick(() => $flux.modal('message-actions').show());
-            }
-        })"
-    ></div>
 </section>


### PR DESCRIPTION
## Summary
- The per-message 3-dot button on mobile (`data-test="message-actions-trigger"`) did nothing because the Alpine sentinel bridging `sheetCommentId` → `$flux.modal('message-actions').show()` silently failed under Livewire 4 + Flux 2.
- Replaced the sentinel with a server-side `Flux::modal('message-actions')->show()` call inside `openActions()`, matching the pattern already used by every other modal in this codebase.

## Test plan
- [x] `php artisan test --compact --filter=ConversationMobileEnhancements` (12 passed)
- [ ] Manually tap the 3-dot icon on a message at a mobile viewport and confirm the bottom sheet slides up with reaction row + Mark-as-prayer / Pin-to-top / Copy-text / Cancel rows
- [ ] Confirm the mobile reaction-picker chip also opens the same sheet and that Cancel / swipe-down still closes it

🤖 Generated with [Claude Code](https://claude.com/claude-code)