### PR TITLE
Add file attachments to group conversation comments

### DIFF
--- a/app/Models/Comment.php
+++ b/app/Models/Comment.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Carbon;
 use Spatie\Comments\Models\Comment as SpatieComment;
 
@@ -26,6 +27,12 @@ class Comment extends SpatieComment
     public function pinnedBy(): BelongsTo
     {
         return $this->belongsTo(User::class, 'pinned_by_user_id');
+    }
+
+    /** @return HasMany<ConversationFile, $this> */
+    public function attachments(): HasMany
+    {
+        return $this->hasMany(ConversationFile::class)->where('is_inline_image', false);
     }
 
     public function isPinned(): bool

--- a/app/Models/Conversation.php
+++ b/app/Models/Conversation.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Support\Carbon;
 use Spatie\Comments\Models\Concerns\HasComments;
@@ -47,6 +48,18 @@ class Conversation extends Model
         return $this->morphMany(Comment::class, 'commentable')
             ->whereNotNull('pinned_at')
             ->orderByDesc('pinned_at');
+    }
+
+    /** @return HasMany<ConversationFile, $this> */
+    public function files(): HasMany
+    {
+        return $this->hasMany(ConversationFile::class);
+    }
+
+    /** @return HasMany<ConversationFile, $this> */
+    public function attachments(): HasMany
+    {
+        return $this->hasMany(ConversationFile::class)->where('is_inline_image', false);
     }
 
     public function postComment(string $text, ?CanComment $commentator = null, bool $isPrayer = false): Comment

--- a/app/Models/ConversationFile.php
+++ b/app/Models/ConversationFile.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Models;
+
+use App\Observers\ConversationFileObserver;
+use Database\Factories\ConversationFileFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+
+/**
+ * @property int $id
+ * @property string $ulid
+ * @property int $conversation_id
+ * @property ?int $comment_id
+ * @property int $uploader_id
+ * @property string $disk
+ * @property string $path
+ * @property string $original_name
+ * @property string $mime_type
+ * @property int $size
+ * @property bool $is_inline_image
+ */
+#[ObservedBy([ConversationFileObserver::class])]
+#[Fillable([
+    'ulid',
+    'conversation_id',
+    'comment_id',
+    'uploader_id',
+    'disk',
+    'path',
+    'original_name',
+    'mime_type',
+    'size',
+    'is_inline_image',
+])]
+class ConversationFile extends Model
+{
+    /** @use HasFactory<ConversationFileFactory> */
+    use HasFactory;
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return [
+            'size' => 'integer',
+            'is_inline_image' => 'boolean',
+        ];
+    }
+
+    protected static function booted(): void
+    {
+        static::creating(function (self $file): void {
+            if (blank($file->ulid)) {
+                $file->ulid = (string) Str::ulid();
+            }
+        });
+    }
+
+    /** @return BelongsTo<Conversation, $this> */
+    public function conversation(): BelongsTo
+    {
+        return $this->belongsTo(Conversation::class);
+    }
+
+    /** @return BelongsTo<Comment, $this> */
+    public function comment(): BelongsTo
+    {
+        return $this->belongsTo(Comment::class);
+    }
+
+    /** @return BelongsTo<User, $this> */
+    public function uploader(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'uploader_id');
+    }
+
+    public function isImage(): bool
+    {
+        return str_starts_with($this->mime_type, 'image/');
+    }
+
+    public function isAudio(): bool
+    {
+        return str_starts_with($this->mime_type, 'audio/');
+    }
+
+    /** @return Attribute<string, never> */
+    protected function url(): Attribute
+    {
+        return Attribute::get(fn (): string => Storage::disk($this->disk)->url($this->path));
+    }
+}

--- a/app/Observers/ConversationFileObserver.php
+++ b/app/Observers/ConversationFileObserver.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\ConversationFile;
+use Illuminate\Support\Facades\Storage;
+
+class ConversationFileObserver
+{
+    public function deleted(ConversationFile $file): void
+    {
+        if (Storage::disk($file->disk)->exists($file->path)) {
+            Storage::disk($file->disk)->delete($file->path);
+        }
+    }
+}

--- a/app/Policies/ConversationFilePolicy.php
+++ b/app/Policies/ConversationFilePolicy.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Conversation;
+use App\Models\ConversationFile;
+use App\Models\User;
+
+class ConversationFilePolicy
+{
+    public function __construct(private ConversationPolicy $conversations) {}
+
+    public function view(User $user, ConversationFile $file): bool
+    {
+        return $this->conversations->view($user, $file->conversation);
+    }
+
+    public function create(User $user, Conversation $conversation): bool
+    {
+        return $this->conversations->comment($user, $conversation);
+    }
+
+    public function delete(User $user, ConversationFile $file): bool
+    {
+        return $file->uploader_id === $user->id
+            || $file->conversation->group->hasLeader($user);
+    }
+}

--- a/app/Support/CommentBodySanitizer.php
+++ b/app/Support/CommentBodySanitizer.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Support;
+
+use Mews\Purifier\Facades\Purifier;
+use Spatie\Comments\Support\CommentSanitizer;
+
+class CommentBodySanitizer extends CommentSanitizer
+{
+    public function sanitize(string $text): string
+    {
+        return Purifier::clean($text, 'comment_body');
+    }
+}

--- a/config/comments.php
+++ b/config/comments.php
@@ -3,6 +3,7 @@
 use App\Models\Comment;
 use App\Models\User;
 use App\Notifications\ServiceCommentNotification;
+use App\Support\CommentBodySanitizer;
 use Spatie\Comments\Actions\ApproveCommentAction;
 use Spatie\Comments\Actions\ProcessCommentAction;
 use Spatie\Comments\Actions\RejectCommentAction;
@@ -12,7 +13,6 @@ use Spatie\Comments\Actions\SendNotificationsForPendingCommentAction;
 use Spatie\Comments\Models\CommentNotificationSubscription;
 use Spatie\Comments\Models\Reaction;
 use Spatie\Comments\Notifications\PendingCommentNotification;
-use Spatie\Comments\Support\CommentSanitizer;
 
 return [
     /*
@@ -40,7 +40,7 @@ return [
      * After all transformers have transformed the comment text, it will
      * be passed to this class to sanitize it
      */
-    'comment_sanitizer' => CommentSanitizer::class,
+    'comment_sanitizer' => CommentBodySanitizer::class,
 
     /*
      * These attributes will be allowed in the comment text. All other

--- a/config/purifier.php
+++ b/config/purifier.php
@@ -37,6 +37,13 @@ return [
             'CSS.AllowedProperties' => '',
             'AutoFormat.RemoveEmpty' => true,
         ],
+        'comment_body' => [
+            'HTML.Doctype' => 'HTML 4.01 Transitional',
+            'HTML.Allowed' => 'p,br,strong,b,em,i,u,s,h1,h2,h3,ul,ol,li,blockquote,a[href|title|target|rel],img[src|alt|width|height|data-conversation-file-id]',
+            'URI.AllowedSchemes' => ['https' => true],
+            'AutoFormat.RemoveEmpty' => true,
+            'Attr.AllowedFrameTargets' => ['_blank'],
+        ],
         'test' => [
             'Attr.EnableID' => 'true',
         ],
@@ -46,7 +53,7 @@ return [
         ],
         'custom_definition' => [
             'id' => 'html5-definitions',
-            'rev' => 1,
+            'rev' => 2,
             'debug' => false,
             'elements' => [
                 // http://developers.whatwg.org/sections.html
@@ -104,6 +111,7 @@ return [
         ],
         'custom_attributes' => [
             ['a', 'target', 'Enum#_blank,_self,_target,_top'],
+            ['img', 'data-conversation-file-id', 'Text'],
         ],
         'custom_elements' => [
             ['u', 'Inline', 'Inline', 'Common'],

--- a/config/purifier.php
+++ b/config/purifier.php
@@ -39,7 +39,7 @@ return [
         ],
         'comment_body' => [
             'HTML.Doctype' => 'HTML 4.01 Transitional',
-            'HTML.Allowed' => 'p,br,strong,b,em,i,u,s,h1,h2,h3,ul,ol,li,blockquote,a[href|title|target|rel],img[src|alt|width|height|data-conversation-file-id]',
+            'HTML.Allowed' => 'p,br,strong,b,em,i,u,s,h1,h2,h3,ul,ol,li,blockquote,a[href|title|target|rel],img[src|alt|width|height|data-conversation-file-id],span[class|data-mention]',
             'URI.AllowedSchemes' => ['https' => true],
             'AutoFormat.RemoveEmpty' => true,
             'Attr.AllowedFrameTargets' => ['_blank'],
@@ -112,6 +112,7 @@ return [
         'custom_attributes' => [
             ['a', 'target', 'Enum#_blank,_self,_target,_top'],
             ['img', 'data-conversation-file-id', 'Text'],
+            ['span', 'data-mention', 'Text'],
         ],
         'custom_elements' => [
             ['u', 'Inline', 'Inline', 'Common'],

--- a/database/factories/ConversationFileFactory.php
+++ b/database/factories/ConversationFileFactory.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Conversation;
+use App\Models\ConversationFile;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<ConversationFile>
+ */
+class ConversationFileFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $ulid = (string) Str::ulid();
+
+        return [
+            'ulid' => $ulid,
+            'conversation_id' => Conversation::factory(),
+            'comment_id' => null,
+            'uploader_id' => User::factory(),
+            'disk' => 'digital-ocean',
+            'path' => "conversations/test/{$ulid}.pdf",
+            'original_name' => $this->faker->word().'.pdf',
+            'mime_type' => 'application/pdf',
+            'size' => $this->faker->numberBetween(1024, 5_000_000),
+            'is_inline_image' => false,
+        ];
+    }
+
+    public function inlineImage(): self
+    {
+        return $this->state(function () {
+            $ulid = (string) Str::ulid();
+
+            return [
+                'ulid' => $ulid,
+                'path' => "conversations/test/{$ulid}.jpg",
+                'original_name' => $this->faker->word().'.jpg',
+                'mime_type' => 'image/jpeg',
+                'is_inline_image' => true,
+            ];
+        });
+    }
+
+    public function audio(): self
+    {
+        return $this->state(function () {
+            $ulid = (string) Str::ulid();
+
+            return [
+                'ulid' => $ulid,
+                'path' => "conversations/test/{$ulid}.mp3",
+                'original_name' => $this->faker->word().'.mp3',
+                'mime_type' => 'audio/mpeg',
+            ];
+        });
+    }
+}

--- a/database/migrations/2026_05_17_005937_create_conversation_files_table.php
+++ b/database/migrations/2026_05_17_005937_create_conversation_files_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use App\Models\Comment;
+use App\Models\Conversation;
+use App\Models\User;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('conversation_files', function (Blueprint $table) {
+            $table->id();
+            $table->ulid()->unique();
+            $table->foreignIdFor(Conversation::class)->constrained()->cascadeOnDelete();
+            $table->foreignIdFor(Comment::class)->nullable()->constrained()->cascadeOnDelete();
+            $table->foreignIdFor(User::class, 'uploader_id')->constrained('users');
+            $table->string('disk')->default('digital-ocean');
+            $table->string('path');
+            $table->string('original_name');
+            $table->string('mime_type');
+            $table->unsignedBigInteger('size');
+            $table->boolean('is_inline_image')->default(false);
+            $table->timestamps();
+
+            $table->index(['conversation_id', 'is_inline_image']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('conversation_files');
+    }
+};

--- a/resources/views/components/conversation-attachment-card.blade.php
+++ b/resources/views/components/conversation-attachment-card.blade.php
@@ -1,0 +1,54 @@
+@props([
+    'attachment',
+    'compact' => false,
+])
+
+@php
+    $iconName = match (true) {
+        $attachment->isImage() => 'photo',
+        $attachment->isAudio() => 'musical-note',
+        str_starts_with($attachment->mime_type, 'video/') => 'film',
+        $attachment->mime_type === 'text/markdown' => 'document-text',
+        default => 'document',
+    };
+@endphp
+
+<div
+    @class([
+        'group/attachment flex items-center gap-2.5 rounded-md border border-zinc-200 bg-white px-2.5 py-2 dark:border-zinc-700 dark:bg-zinc-900',
+        'text-xs' => $compact,
+        'text-sm' => ! $compact,
+    ])
+    data-test="conversation-attachment"
+    wire:key="attachment-{{ $attachment->id }}"
+>
+    <span @class([
+        'grid shrink-0 place-items-center rounded-md text-zinc-500 dark:text-zinc-400',
+        'size-7 bg-zinc-100 dark:bg-zinc-800' => ! $compact,
+        'size-6 bg-zinc-100 dark:bg-zinc-800' => $compact,
+    ])>
+        <flux:icon :name="$iconName" variant="micro" />
+    </span>
+    <a
+        href="{{ $attachment->url }}"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="min-w-0 flex-1"
+        data-test="conversation-attachment-link"
+    >
+        <div class="truncate font-medium text-zinc-800 dark:text-zinc-100">{{ $attachment->original_name }}</div>
+        <div class="text-xs text-zinc-500">{{ \Illuminate\Support\Number::fileSize($attachment->size) }}</div>
+    </a>
+    @can('delete', $attachment)
+        <button
+            type="button"
+            wire:click="deleteAttachment({{ $attachment->id }})"
+            wire:confirm="Delete {{ $attachment->original_name }}?"
+            class="grid size-7 shrink-0 place-items-center rounded-md text-zinc-400 opacity-0 transition-opacity hover:bg-zinc-100 hover:text-red-600 focus-visible:opacity-100 group-hover/attachment:opacity-100 dark:hover:bg-zinc-800"
+            aria-label="Delete attachment"
+            data-test="conversation-attachment-delete"
+        >
+            <flux:icon.trash variant="micro" />
+        </button>
+    @endcan
+</div>

--- a/resources/views/pages/groups/conversations/show.blade.php
+++ b/resources/views/pages/groups/conversations/show.blade.php
@@ -2,6 +2,7 @@
 
 use App\Models\Comment;
 use App\Models\Conversation;
+use App\Models\ConversationFile;
 use App\Models\Group;
 use App\Models\User;
 use App\Services\ScriptureLinker;
@@ -10,12 +11,17 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Livewire\Attributes\Computed;
 use Livewire\Component;
+use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
+use Livewire\WithFileUploads;
 use Spatie\Comments\Support\Config;
 
 new class extends Component {
+    use WithFileUploads;
+
     public Group $group;
     public Conversation $conversation;
 
@@ -28,6 +34,22 @@ new class extends Component {
     public bool $headerExpanded = false;
 
     public ?int $sheetCommentId = null;
+
+    public ?TemporaryUploadedFile $newImage = null;
+
+    public ?TemporaryUploadedFile $newAttachment = null;
+
+    public ?TemporaryUploadedFile $standaloneUpload = null;
+
+    /** @var array<int> ConversationFile IDs of images staged for the next reply. */
+    public array $pendingImageIds = [];
+
+    /** @var array<int> ConversationFile IDs of attachments staged for the next reply. */
+    public array $pendingAttachmentIds = [];
+
+    private const IMAGE_RULES = ['image', 'mimes:jpg,jpeg,png,gif,webp', 'max:5120'];
+
+    private const ATTACHMENT_RULES = ['file', 'mimes:pdf,md,txt,mp3,m4a,aac,wav', 'max:25600'];
 
     public function mount(Group $group, Conversation $conversation): void
     {
@@ -45,9 +67,58 @@ new class extends Component {
     {
         /** @var Collection<int, Comment> */
         return $this->conversation->comments()
-            ->with(['commentator', 'reactions.commentator'])
+            ->with(['commentator', 'reactions.commentator', 'attachments'])
             ->orderBy('created_at')
             ->get();
+    }
+
+    /** @return Collection<int, ConversationFile> */
+    #[Computed]
+    public function attachments(): Collection
+    {
+        /** @var Collection<int, ConversationFile> */
+        return $this->conversation->attachments()
+            ->with('uploader')
+            ->latest()
+            ->get();
+    }
+
+    /** @return Collection<int, ConversationFile> */
+    #[Computed]
+    public function pendingImages(): Collection
+    {
+        return $this->loadPending($this->pendingImageIds);
+    }
+
+    /** @return Collection<int, ConversationFile> */
+    #[Computed]
+    public function pendingAttachments(): Collection
+    {
+        return $this->loadPending($this->pendingAttachmentIds);
+    }
+
+    /**
+     * @param  array<int>  $ids
+     * @return Collection<int, ConversationFile>
+     */
+    private function loadPending(array $ids): Collection
+    {
+        if ($ids === []) {
+            return new Collection;
+        }
+
+        /** @var Collection<int, ConversationFile> $files */
+        $files = ConversationFile::query()
+            ->whereIn('id', $ids)
+            ->where('conversation_id', $this->conversation->id)
+            ->get()
+            ->keyBy('id');
+
+        /** @var Collection<int, ConversationFile> */
+        return (new Collection(array_map(
+            fn (int $id): ?ConversationFile => $files->get($id),
+            $ids,
+        )))->filter()->values();
     }
 
     /** @return Collection<int, Comment> */
@@ -136,20 +207,162 @@ new class extends Component {
     {
         $this->authorize('comment', $this->conversation);
 
-        $validated = $this->validate([
-            'reply' => ['required', 'string'],
-        ]);
+        $hasText = trim(strip_tags($this->reply)) !== '';
+        $hasMedia = $this->pendingImageIds !== [] || $this->pendingAttachmentIds !== [];
 
-        if (trim(strip_tags($validated['reply'])) === '') {
-            $this->addError('reply', 'Please write a reply.');
+        if (! $hasText && ! $hasMedia) {
+            $this->addError('reply', 'Write a message or attach a file.');
 
             return;
         }
 
-        $this->conversation->postComment($validated['reply'], Auth::user(), $this->replyIsPrayer);
+        $text = $this->buildReplyHtml();
 
-        $this->reset('reply', 'replyIsPrayer');
-        unset($this->comments, $this->contributors, $this->nonContributors);
+        /** @var Comment $comment */
+        $comment = $this->conversation->postComment($text, Auth::user(), $this->replyIsPrayer);
+
+        ConversationFile::query()
+            ->whereIn('id', array_merge($this->pendingImageIds, $this->pendingAttachmentIds))
+            ->where('conversation_id', $this->conversation->id)
+            ->update(['comment_id' => $comment->id]);
+
+        $this->reset('reply', 'replyIsPrayer', 'pendingImageIds', 'pendingAttachmentIds');
+        unset(
+            $this->comments,
+            $this->contributors,
+            $this->nonContributors,
+            $this->attachments,
+            $this->pendingImages,
+            $this->pendingAttachments,
+        );
+    }
+
+    private function buildReplyHtml(): string
+    {
+        $imagesHtml = $this->pendingImages
+            ->map(fn (ConversationFile $file): string => sprintf(
+                '<p><img src="%s" alt="%s" data-conversation-file-id="%d"></p>',
+                e($file->url),
+                e($file->original_name),
+                $file->id,
+            ))
+            ->implode('');
+
+        $body = trim($this->reply);
+
+        return $imagesHtml.$body;
+    }
+
+    public function updatedNewImage(): void
+    {
+        $this->authorize('comment', $this->conversation);
+
+        $this->validate(['newImage' => self::IMAGE_RULES]);
+
+        $file = $this->storeUpload($this->newImage, isInlineImage: true);
+
+        $this->pendingImageIds[] = $file->id;
+        $this->newImage = null;
+        unset($this->pendingImages);
+    }
+
+    public function updatedNewAttachment(): void
+    {
+        $this->authorize('comment', $this->conversation);
+
+        $this->validate(['newAttachment' => self::ATTACHMENT_RULES]);
+
+        $file = $this->storeUpload($this->newAttachment, isInlineImage: false);
+
+        $this->pendingAttachmentIds[] = $file->id;
+        $this->newAttachment = null;
+        unset($this->pendingAttachments);
+    }
+
+    public function updatedStandaloneUpload(): void
+    {
+        $this->authorize('comment', $this->conversation);
+
+        $this->validate(['standaloneUpload' => self::ATTACHMENT_RULES]);
+
+        $this->storeUpload($this->standaloneUpload, isInlineImage: false);
+
+        $this->standaloneUpload = null;
+        unset($this->attachments);
+
+        Flux::modal('add-file')->close();
+        Flux::toast(variant: 'success', text: 'File added.');
+    }
+
+    public function removePendingImage(int $id): void
+    {
+        $this->discardPending($id, $this->pendingImageIds);
+        unset($this->pendingImages);
+    }
+
+    public function removePendingAttachment(int $id): void
+    {
+        $this->discardPending($id, $this->pendingAttachmentIds);
+        unset($this->pendingAttachments);
+    }
+
+    /** @param  array<int>  $ids */
+    private function discardPending(int $id, array &$ids): void
+    {
+        if (! in_array($id, $ids, true)) {
+            return;
+        }
+
+        $file = ConversationFile::query()
+            ->where('conversation_id', $this->conversation->id)
+            ->find($id);
+
+        if ($file && $file->uploader_id === Auth::id() && $file->comment_id === null) {
+            $file->delete();
+        }
+
+        $ids = array_values(array_filter($ids, fn (int $existing): bool => $existing !== $id));
+    }
+
+    public function deleteAttachment(int $id): void
+    {
+        /** @var ConversationFile $file */
+        $file = ConversationFile::query()
+            ->where('conversation_id', $this->conversation->id)
+            ->findOrFail($id);
+
+        $this->authorize('delete', $file);
+
+        $file->delete();
+
+        unset($this->attachments, $this->comments);
+        Flux::toast(variant: 'success', text: 'File deleted.');
+    }
+
+    private function storeUpload(TemporaryUploadedFile $upload, bool $isInlineImage): ConversationFile
+    {
+        $ulid = (string) Str::ulid();
+        $extension = strtolower($upload->getClientOriginalExtension() ?: 'bin');
+        $path = "conversations/{$this->conversation->id}/{$ulid}.{$extension}";
+
+        Storage::disk('digital-ocean')->putFileAs(
+            "conversations/{$this->conversation->id}",
+            $upload,
+            "{$ulid}.{$extension}",
+            ['visibility' => 'public'],
+        );
+
+        return ConversationFile::create([
+            'ulid' => $ulid,
+            'conversation_id' => $this->conversation->id,
+            'uploader_id' => Auth::id(),
+            'disk' => 'digital-ocean',
+            'path' => $path,
+            'original_name' => $upload->getClientOriginalName(),
+            'mime_type' => $upload->getMimeType() ?: 'application/octet-stream',
+            'size' => $upload->getSize() ?: 0,
+            'is_inline_image' => $isInlineImage,
+        ]);
     }
 
     public function react(int $commentId, string $reaction): void
@@ -490,6 +703,7 @@ new class extends Component {
                                     **:[ol]:list-decimal **:[ol]:ml-5 **:[ul]:list-disc **:[ul]:ml-5
                                     **:[a]:underline
                                     **:[blockquote]:border-l-4 **:[blockquote]:pl-2
+                                    **:[img]:my-2 **:[img]:max-w-full **:[img]:rounded-lg **:[img]:border **:[img]:border-zinc-200 dark:**:[img]:border-zinc-700
                                     **:[h1]:not-first:mt-3 **:[h2]:not-first:mt-3 **:[h3]:not-first:mt-3
                                     **:[ul]:not-first:mt-3 **:[ol]:not-first:mt-3
                                     **:[blockquote]:not-first:mt-3
@@ -497,6 +711,14 @@ new class extends Component {
                                     **:[h1+p]:mt-0 **:[h2+p]:mt-0 **:[h3+p]:mt-0">
                                     {!! app(ScriptureLinker::class)->linkify($comment->text) !!}
                                 </div>
+
+                                @if ($comment->attachments->isNotEmpty())
+                                    <div class="mt-2 grid gap-1.5 sm:grid-cols-2" data-test="comment-attachments">
+                                        @foreach ($comment->attachments as $attachment)
+                                            <x-conversation-attachment-card :attachment="$attachment" />
+                                        @endforeach
+                                    </div>
+                                @endif
 
                                 {{-- Reactions row --}}
                                 @php($summary = $comment->reactions->summary($currentUser))
@@ -688,9 +910,10 @@ new class extends Component {
         {{-- Composer --}}
         @can('comment', $conversation)
             <div
-                class="border-t border-zinc-200 px-3.5 py-2.5 lg:px-6 lg:py-4 dark:border-zinc-700"
+                class="relative border-t border-zinc-200 px-3.5 py-2.5 lg:px-6 lg:py-4 dark:border-zinc-700"
                 x-data="{
                     expanded: false,
+                    isDragging: false,
                     get hasDraft() { return (this.$wire.reply ?? '').replace(/<[^>]*>/g, '').trim().length > 0; },
                     expand() {
                         this.expanded = true;
@@ -705,8 +928,34 @@ new class extends Component {
                         if (next && this.$root.contains(next)) return;
                         this.collapse();
                     },
+                    handleDrop(event) {
+                        this.isDragging = false;
+                        const files = Array.from(event.dataTransfer?.files ?? []);
+                        if (!files.length) return;
+                        this.expand();
+                        for (const file of files) {
+                            const isImage = (file.type || '').startsWith('image/');
+                            const input = isImage ? this.$refs.imageInput : this.$refs.attachInput;
+                            if (!input) continue;
+                            const dt = new DataTransfer();
+                            dt.items.add(file);
+                            input.files = dt.files;
+                            input.dispatchEvent(new Event('change', { bubbles: true }));
+                        }
+                    },
                 }"
+                x-on:dragover.prevent="isDragging = true"
+                x-on:dragleave.prevent="isDragging = false"
+                x-on:drop.prevent="handleDrop($event)"
             >
+                <div
+                    x-show="isDragging"
+                    x-cloak
+                    class="pointer-events-none absolute inset-1 z-10 flex items-center justify-center rounded-lg border-2 border-dashed border-accent bg-accent/10 text-sm font-semibold text-accent"
+                    data-test="composer-drop-overlay"
+                >
+                    Drop to attach
+                </div>
                 {{-- Mobile collapsed pill — invisible on desktop --}}
                 <button
                     type="button"
@@ -728,6 +977,9 @@ new class extends Component {
                         wire:submit="postReply"
                         x-on:keydown.enter="if ($event.metaKey || $event.ctrlKey) { $event.preventDefault(); $el.requestSubmit() }"
                     >
+                        <input type="file" x-ref="imageInput" wire:model="newImage" accept="image/jpeg,image/png,image/gif,image/webp" class="hidden" data-test="composer-image-input" />
+                        <input type="file" x-ref="attachInput" wire:model="newAttachment" accept=".pdf,.md,.txt,audio/*" class="hidden" data-test="composer-attach-input" />
+
                         <flux:composer wire:model="reply" label="Reply" label:sr-only placeholder="Write a reply…  (try mentioning Romans 8:31)">
                             <x-slot name="input">
                                 <flux:editor
@@ -735,9 +987,88 @@ new class extends Component {
                                     toolbar="heading | bold italic underline strike | bullet ordered blockquote | link ~ undo redo"
                                     class="**:data-[slot=content]:min-h-[100px]!"
                                 />
+
+                                @php($pendingImages = $this->pendingImages)
+                                @php($pendingAttachments = $this->pendingAttachments)
+                                @if ($pendingImages->isNotEmpty() || $pendingAttachments->isNotEmpty())
+                                    <div class="mt-2 space-y-2" data-test="composer-pending">
+                                        @if ($pendingImages->isNotEmpty())
+                                            <div class="flex flex-wrap gap-2">
+                                                @foreach ($pendingImages as $image)
+                                                    <div
+                                                        class="group/pending relative size-20 overflow-hidden rounded-md border border-zinc-200 dark:border-zinc-700"
+                                                        wire:key="pending-image-{{ $image->id }}"
+                                                        data-test="pending-image"
+                                                    >
+                                                        <img src="{{ $image->url }}" alt="{{ $image->original_name }}" class="size-full object-cover" />
+                                                        <button
+                                                            type="button"
+                                                            wire:click="removePendingImage({{ $image->id }})"
+                                                            class="absolute right-1 top-1 grid size-5 place-items-center rounded-full bg-zinc-900/70 text-white opacity-0 transition-opacity hover:bg-zinc-900 focus-visible:opacity-100 group-hover/pending:opacity-100"
+                                                            aria-label="Remove image"
+                                                            data-test="pending-image-remove"
+                                                        >
+                                                            <flux:icon.x-mark variant="micro" class="size-3" />
+                                                        </button>
+                                                    </div>
+                                                @endforeach
+                                            </div>
+                                        @endif
+
+                                        @if ($pendingAttachments->isNotEmpty())
+                                            <div class="flex flex-wrap gap-1.5">
+                                                @foreach ($pendingAttachments as $attachment)
+                                                    <span
+                                                        class="inline-flex items-center gap-1.5 rounded-full border border-zinc-200 bg-zinc-50 py-1 pl-2.5 pr-1 text-xs dark:border-zinc-700 dark:bg-zinc-800"
+                                                        wire:key="pending-attachment-{{ $attachment->id }}"
+                                                        data-test="pending-attachment"
+                                                    >
+                                                        <flux:icon.paper-clip variant="micro" class="text-zinc-500" />
+                                                        <span class="max-w-[16ch] truncate font-medium text-zinc-700 dark:text-zinc-200">{{ $attachment->original_name }}</span>
+                                                        <button
+                                                            type="button"
+                                                            wire:click="removePendingAttachment({{ $attachment->id }})"
+                                                            class="grid size-4 place-items-center rounded-full text-zinc-400 hover:bg-zinc-200 hover:text-zinc-700 dark:hover:bg-zinc-700"
+                                                            aria-label="Remove attachment"
+                                                            data-test="pending-attachment-remove"
+                                                        >
+                                                            <flux:icon.x-mark variant="micro" class="size-3" />
+                                                        </button>
+                                                    </span>
+                                                @endforeach
+                                            </div>
+                                        @endif
+                                    </div>
+                                @endif
                             </x-slot>
 
                             <x-slot name="footer">
+                                <flux:tooltip content="Attach image">
+                                    <button
+                                        type="button"
+                                        x-on:click="$refs.imageInput.click()"
+                                        class="inline-flex h-7 items-center gap-1.5 rounded-md px-2 text-xs font-semibold text-zinc-500 hover:bg-zinc-100 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-white"
+                                        aria-label="Attach image"
+                                        data-test="composer-image-button"
+                                    >
+                                        <flux:icon.photo variant="micro" wire:loading.remove wire:target="newImage" />
+                                        <flux:icon.arrow-path variant="micro" class="animate-spin" wire:loading wire:target="newImage" />
+                                    </button>
+                                </flux:tooltip>
+
+                                <flux:tooltip content="Attach file">
+                                    <button
+                                        type="button"
+                                        x-on:click="$refs.attachInput.click()"
+                                        class="inline-flex h-7 items-center gap-1.5 rounded-md px-2 text-xs font-semibold text-zinc-500 hover:bg-zinc-100 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-white"
+                                        aria-label="Attach file"
+                                        data-test="composer-attach-button"
+                                    >
+                                        <flux:icon.paper-clip variant="micro" wire:loading.remove wire:target="newAttachment" />
+                                        <flux:icon.arrow-path variant="micro" class="animate-spin" wire:loading wire:target="newAttachment" />
+                                    </button>
+                                </flux:tooltip>
+
                                 <button
                                     type="button"
                                     wire:click="$toggle('replyIsPrayer')"
@@ -799,16 +1130,27 @@ new class extends Component {
         aria-label="Members"
         data-test="members-rail"
     >
+        @php($railAttachments = $this->attachments)
         <section class="mb-6" data-test="rail-files">
             <div class="mb-2 flex items-center justify-between text-xs font-semibold uppercase tracking-wider text-zinc-500">
-                <span>Files · 0</span>
-                <flux:tooltip content="Coming soon">
-                    <flux:button size="xs" variant="ghost" icon="arrow-up-tray" disabled data-test="rail-files-add">Add</flux:button>
-                </flux:tooltip>
+                <span>Files · {{ $railAttachments->count() }}</span>
+                @can('comment', $conversation)
+                    <flux:modal.trigger name="add-file">
+                        <flux:button size="xs" variant="ghost" icon="arrow-up-tray" data-test="rail-files-add">Add</flux:button>
+                    </flux:modal.trigger>
+                @endcan
             </div>
-            <p class="px-1 py-2 text-xs text-zinc-500">
-                No files yet. Drag a PDF or sheet music here to attach it to this conversation.
-            </p>
+            @if ($railAttachments->isEmpty())
+                <p class="px-1 py-2 text-xs text-zinc-500">
+                    No files yet. Use the Add button or the paperclip in the composer.
+                </p>
+            @else
+                <div class="space-y-1.5">
+                    @foreach ($railAttachments as $attachment)
+                        <x-conversation-attachment-card :attachment="$attachment" compact />
+                    @endforeach
+                </div>
+            @endif
         </section>
 
         <div class="mb-4 text-xs font-semibold uppercase tracking-wider text-zinc-500">
@@ -855,6 +1197,33 @@ new class extends Component {
             </section>
         @endif
     </aside>
+
+    {{-- Add-file modal (triggered from the files rail) --}}
+    @can('comment', $conversation)
+        <flux:modal name="add-file" class="md:w-96" data-test="add-file-modal">
+            <div class="space-y-4">
+                <div>
+                    <flux:heading size="lg">Add a file</flux:heading>
+                    <flux:subheading>PDF, markdown, text, or audio up to 25 MB.</flux:subheading>
+                </div>
+
+                <input
+                    type="file"
+                    wire:model="standaloneUpload"
+                    accept=".pdf,.md,.txt,audio/*"
+                    class="block w-full text-sm text-zinc-700 file:mr-3 file:rounded-md file:border-0 file:bg-accent file:px-3 file:py-1.5 file:text-sm file:font-semibold file:text-white hover:file:cursor-pointer dark:text-zinc-200"
+                    data-test="add-file-input"
+                />
+
+                <div wire:loading wire:target="standaloneUpload" class="flex items-center gap-2 text-sm text-zinc-500">
+                    <flux:icon.arrow-path variant="micro" class="animate-spin" />
+                    Uploading…
+                </div>
+
+                <flux:error name="standaloneUpload" />
+            </div>
+        </flux:modal>
+    @endcan
 
     {{-- Mobile action sheet --}}
     @php($sheetComment = $this->sheetComment)

--- a/resources/views/pages/groups/conversations/show.blade.php
+++ b/resources/views/pages/groups/conversations/show.blade.php
@@ -1086,6 +1086,9 @@ new class extends Component {
                                         @endif
                                     </div>
                                 @endif
+
+                                <flux:error name="newImage" />
+                                <flux:error name="newAttachment" />
                             </x-slot>
 
                             <x-slot name="footer">

--- a/tests/Feature/ConversationAttachmentsTest.php
+++ b/tests/Feature/ConversationAttachmentsTest.php
@@ -1,0 +1,287 @@
+<?php
+
+use App\Enums\GroupMessaging;
+use App\Enums\GroupRole;
+use App\Enums\GroupVisibility;
+use App\Enums\MembershipStatus;
+use App\Models\Conversation;
+use App\Models\ConversationFile;
+use App\Models\Group;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Testing\File;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Livewire\Livewire;
+use Mews\Purifier\Facades\Purifier;
+
+uses(RefreshDatabase::class);
+
+function makeConversation(GroupMessaging $messaging = GroupMessaging::ALL_MEMBERS): array
+{
+    $author = User::factory()->create();
+    $member = User::factory()->create();
+    $leader = User::factory()->create();
+    $outsider = User::factory()->create();
+
+    $group = Group::factory()->create([
+        'visibility' => GroupVisibility::PUBLIC,
+        'messaging' => $messaging,
+    ]);
+
+    $group->allUsers()->attach($author, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($member, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => MembershipStatus::ACTIVE]);
+
+    $conversation = Conversation::factory()->create([
+        'group_id' => $group->id,
+        'user_id' => $author->id,
+    ]);
+
+    return compact('group', 'conversation', 'author', 'member', 'leader', 'outsider');
+}
+
+function pdfFile(int $sizeInKb = 4): File
+{
+    $content = "%PDF-1.4\n".str_repeat("\x00", max(0, ($sizeInKb * 1024) - 9));
+
+    return File::createWithContent('handout.pdf', $content)->mimeType('application/pdf');
+}
+
+beforeEach(function (): void {
+    Storage::fake('digital-ocean', ['url' => 'https://stave.atl1.digitaloceanspaces.com']);
+});
+
+it('uploads an inline image and stages it for the next reply', function (): void {
+    ['group' => $group, 'conversation' => $conversation, 'author' => $author] = makeConversation();
+
+    Livewire::actingAs($author)
+        ->test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->set('newImage', UploadedFile::fake()->image('photo.jpg', 200, 200))
+        ->assertHasNoErrors();
+
+    expect(ConversationFile::query()->count())->toBe(1);
+    expect(ConversationFile::query()->first()->is_inline_image)->toBeTrue();
+    expect(ConversationFile::query()->first()->comment_id)->toBeNull();
+});
+
+it('links a staged inline image to the comment on send and embeds it in the body', function (): void {
+    ['group' => $group, 'conversation' => $conversation, 'author' => $author] = makeConversation();
+
+    Livewire::actingAs($author)
+        ->test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->set('newImage', UploadedFile::fake()->image('photo.jpg'))
+        ->set('reply', '<p>Check this out</p>')
+        ->call('postReply')
+        ->assertHasNoErrors();
+
+    $comment = $conversation->fresh()->comments()->first();
+    expect($comment)->not->toBeNull();
+    expect($comment->text)->toContain('data-conversation-file-id=');
+
+    $file = ConversationFile::query()->first();
+    expect($file->comment_id)->toBe($comment->id);
+    expect($file->is_inline_image)->toBeTrue();
+});
+
+it('excludes inline images from the sidebar attachments list', function (): void {
+    ['conversation' => $conversation, 'author' => $author] = makeConversation();
+
+    ConversationFile::factory()->inlineImage()->for($conversation)->create(['uploader_id' => $author->id]);
+    $attachment = ConversationFile::factory()->for($conversation)->create(['uploader_id' => $author->id]);
+
+    expect($conversation->attachments()->pluck('id')->all())->toBe([$attachment->id]);
+});
+
+it('attaches non-image files via the composer and shows them under the comment and in the sidebar', function (): void {
+    ['group' => $group, 'conversation' => $conversation, 'author' => $author] = makeConversation();
+
+    Livewire::actingAs($author)
+        ->test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->set('newAttachment', pdfFile())
+        ->set('reply', '<p>Here is the handout</p>')
+        ->call('postReply')
+        ->assertHasNoErrors();
+
+    $comment = $conversation->fresh()->comments()->first();
+    expect($comment->attachments)->toHaveCount(1);
+    expect($comment->attachments->first()->original_name)->toBe('handout.pdf');
+
+    expect($conversation->attachments)->toHaveCount(1);
+});
+
+it('uploads a standalone file from the sidebar with no comment', function (): void {
+    ['group' => $group, 'conversation' => $conversation, 'author' => $author] = makeConversation();
+
+    Livewire::actingAs($author)
+        ->test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->set('standaloneUpload', pdfFile())
+        ->assertHasNoErrors();
+
+    expect($conversation->fresh()->comments()->count())->toBe(0);
+    expect($conversation->attachments)->toHaveCount(1);
+    expect($conversation->attachments->first()->comment_id)->toBeNull();
+});
+
+it('does not let users without comment permission upload to the sidebar', function (): void {
+    // Members of a leader-only-messaging group can VIEW but cannot COMMENT.
+    ['group' => $group, 'conversation' => $conversation, 'member' => $reader] = makeConversation(GroupMessaging::ONLY_LEADERS);
+
+    Livewire::actingAs($reader)
+        ->test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->set('standaloneUpload', pdfFile())
+        ->assertForbidden();
+});
+
+it('allows the uploader to delete their own attachment', function (): void {
+    ['group' => $group, 'conversation' => $conversation, 'member' => $member] = makeConversation();
+    $file = ConversationFile::factory()->for($conversation)->create(['uploader_id' => $member->id]);
+
+    Livewire::actingAs($member)
+        ->test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->call('deleteAttachment', $file->id)
+        ->assertHasNoErrors();
+
+    expect(ConversationFile::query()->find($file->id))->toBeNull();
+});
+
+it('allows a group leader to delete any attachment', function (): void {
+    ['group' => $group, 'conversation' => $conversation, 'member' => $member, 'leader' => $leader] = makeConversation();
+    $file = ConversationFile::factory()->for($conversation)->create(['uploader_id' => $member->id]);
+
+    Livewire::actingAs($leader)
+        ->test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->call('deleteAttachment', $file->id)
+        ->assertHasNoErrors();
+
+    expect(ConversationFile::query()->find($file->id))->toBeNull();
+});
+
+it('forbids deleting an attachment uploaded by someone else when the user is not a leader', function (): void {
+    ['group' => $group, 'conversation' => $conversation, 'author' => $author, 'member' => $member] = makeConversation();
+    $file = ConversationFile::factory()->for($conversation)->create(['uploader_id' => $author->id]);
+
+    Livewire::actingAs($member)
+        ->test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->call('deleteAttachment', $file->id)
+        ->assertForbidden();
+
+    expect(ConversationFile::query()->find($file->id))->not->toBeNull();
+});
+
+it('removes the S3 object when a ConversationFile is deleted', function (): void {
+    ['conversation' => $conversation, 'author' => $author] = makeConversation();
+
+    Storage::disk('digital-ocean')->put('conversations/x/test.pdf', 'pdf-bytes');
+    $file = ConversationFile::factory()->for($conversation)->create([
+        'uploader_id' => $author->id,
+        'path' => 'conversations/x/test.pdf',
+    ]);
+
+    Storage::disk('digital-ocean')->assertExists('conversations/x/test.pdf');
+
+    $file->delete();
+
+    Storage::disk('digital-ocean')->assertMissing('conversations/x/test.pdf');
+});
+
+it('cascades attachment deletion when a comment is deleted', function (): void {
+    ['conversation' => $conversation, 'author' => $author] = makeConversation();
+
+    $comment = $conversation->postComment('<p>hello</p>', $author);
+    $file = ConversationFile::factory()->for($conversation)->create([
+        'comment_id' => $comment->id,
+        'uploader_id' => $author->id,
+    ]);
+
+    $comment->delete();
+
+    expect(ConversationFile::query()->find($file->id))->toBeNull();
+});
+
+it('image upload rules reject files over 5 MB', function (): void {
+    $oversized = UploadedFile::fake()->image('big.jpg')->size(6000);
+
+    $errors = validator(
+        ['file' => $oversized],
+        ['file' => ['image', 'mimes:jpg,jpeg,png,gif,webp', 'max:5120']],
+    )->errors()->all();
+
+    expect($errors)->not->toBeEmpty();
+    expect(implode(' ', $errors))->toContain('5120');
+});
+
+it('rejects disallowed file types in the composer', function (): void {
+    ['group' => $group, 'conversation' => $conversation, 'author' => $author] = makeConversation();
+
+    $exe = UploadedFile::fake()->create('virus.exe', 100, 'application/x-msdownload');
+
+    Livewire::actingAs($author)
+        ->test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->set('newAttachment', $exe)
+        ->assertHasErrors(['newAttachment']);
+
+    expect(ConversationFile::query()->count())->toBe(0);
+});
+
+it('blocks posting an empty reply with no attachments', function (): void {
+    ['group' => $group, 'conversation' => $conversation, 'author' => $author] = makeConversation();
+
+    Livewire::actingAs($author)
+        ->test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->set('reply', '<p>   </p>')
+        ->call('postReply')
+        ->assertHasErrors('reply');
+});
+
+it('allows posting a comment with only an attachment and no text', function (): void {
+    ['group' => $group, 'conversation' => $conversation, 'author' => $author] = makeConversation();
+
+    Livewire::actingAs($author)
+        ->test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->set('newAttachment', pdfFile())
+        ->set('reply', '')
+        ->call('postReply')
+        ->assertHasNoErrors();
+
+    expect($conversation->fresh()->comments()->count())->toBe(1);
+});
+
+it('removes a pending attachment when the user discards it before sending', function (): void {
+    ['group' => $group, 'conversation' => $conversation, 'author' => $author] = makeConversation();
+
+    $component = Livewire::actingAs($author)
+        ->test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->set('newAttachment', pdfFile());
+
+    $fileId = ConversationFile::query()->first()->id;
+
+    $component->call('removePendingAttachment', $fileId)
+        ->assertHasNoErrors();
+
+    expect(ConversationFile::query()->find($fileId))->toBeNull();
+});
+
+it('sanitizer keeps img tags and strips script tags', function (): void {
+    $dirty = '<p>hi <img src="https://stave.atl1.digitaloceanspaces.com/a.jpg" data-conversation-file-id="9"> <script>alert(1)</script></p>';
+    $clean = Purifier::clean($dirty, 'comment_body');
+
+    expect($clean)->toContain('<img');
+    expect($clean)->toContain('data-conversation-file-id="9"');
+    expect($clean)->not->toContain('<script');
+});
+
+it('sanitizer preserves external https links but strips javascript: hrefs', function (): void {
+    $dirty = '<p><a href="https://example.com">ok</a> <a href="javascript:alert(1)">bad</a></p>';
+    $clean = Purifier::clean($dirty, 'comment_body');
+
+    expect($clean)->toContain('href="https://example.com"');
+    expect($clean)->not->toContain('javascript:');
+});
+
+it('drops http img sources because comments only accept https', function (): void {
+    $dirty = '<img src="http://example.com/x.jpg">';
+    $clean = Purifier::clean($dirty, 'comment_body');
+
+    expect($clean)->not->toContain('http://example.com');
+});


### PR DESCRIPTION
## Summary

- Adds a `ConversationFile` model with migration, factory, policy, and observer for managing file uploads in group conversations
- Supports inline images (embedded in comment body via `<img>` tags) and document attachments (PDF, markdown, text, audio) shown as cards below comments and in the sidebar files rail
- Composer gains drag-and-drop, image/file toolbar buttons, and pending-attachment previews before sending
- Introduces a custom `CommentBodySanitizer` with a dedicated HTMLPurifier profile (`comment_body`) that allows `<img>` with `data-conversation-file-id` while enforcing HTTPS-only URIs
- Standalone file uploads from the sidebar rail (no comment required) and leader/uploader-based delete authorization

## Test plan

- [x] Inline image upload stages file and embeds in comment body on send
- [x] Non-image attachments display under comment and in sidebar
- [x] Standalone sidebar upload works without creating a comment
- [x] Authorization: non-commenters blocked, only uploader/leader can delete
- [x] Observer deletes S3 object on model deletion
- [x] Cascade: deleting a comment removes its attachments
- [x] Sanitizer allows img/data attributes, strips scripts and non-HTTPS sources
- [x] Rejects oversized and disallowed file types

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added file and image attachment support to conversations
  * Users can now attach files/images to messages and upload standalone files via a modal
  * Attachments display in conversation threads and a dedicated sidebar panel
  * Inline images embed directly in message bodies
  
* **Bug Fixes & Improvements**
  * Enhanced HTML sanitization for comment content
  
* **Tests**
  * Added comprehensive test suite for attachment functionality, permissions, and storage cleanup

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jpangborn/stave/pull/104?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->