### PR TITLE
Restrict conversation deletion to group leaders only

### DIFF
--- a/app/Policies/ConversationPolicy.php
+++ b/app/Policies/ConversationPolicy.php
@@ -36,7 +36,7 @@ class ConversationPolicy
 
     public function delete(User $user, Conversation $conversation): bool
     {
-        return $this->isAuthorOrLeader($user, $conversation);
+        return $conversation->group->hasLeader($user);
     }
 
     private function isAuthorOrLeader(User $user, Conversation $conversation): bool

--- a/tests/Feature/GroupConversationsTest.php
+++ b/tests/Feature/GroupConversationsTest.php
@@ -386,12 +386,33 @@ test('reacting with a disallowed value is rejected', function (): void {
 
 // --- Delete (policy::delete) ---
 
-test('the author can delete their own conversation', function (): void {
+test('an author who is not a leader cannot delete their own conversation', function (): void {
     $author = User::factory()->create();
     $group = Group::factory()->create([
         'messaging' => GroupMessaging::ALL_MEMBERS,
     ]);
     attachMember($group, $author);
+
+    $conversation = Conversation::factory()->create([
+        'group_id' => $group->id,
+        'user_id' => $author->id,
+    ]);
+
+    $this->actingAs($author);
+
+    Livewire::test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->call('deleteConversation')
+        ->assertForbidden();
+
+    $this->assertDatabaseHas('conversations', ['id' => $conversation->id]);
+});
+
+test('an author who is also a leader can delete their own conversation', function (): void {
+    $author = User::factory()->create();
+    $group = Group::factory()->create([
+        'messaging' => GroupMessaging::ALL_MEMBERS,
+    ]);
+    attachMember($group, $author, GroupRole::LEADER);
 
     $conversation = Conversation::factory()->create([
         'group_id' => $group->id,


### PR DESCRIPTION
## Summary

Previously, both conversation authors and group leaders could delete conversations. This change restricts deletion to group leaders only — regular members can no longer delete their own conversations.

- Updates `ConversationPolicy::delete()` to check `hasLeader` instead of `isAuthorOrLeader`
- Converts the existing author-delete test to a negative case (`assertForbidden`)
- Adds a new test confirming an author who is also a leader can still delete

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated conversation deletion permissions to require group leader status. Non-leader members can no longer delete their conversations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jpangborn/stave/pull/105?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->