### PR TITLE
Add delete comment support for group conversations

### DIFF
--- a/app/Policies/CommentPolicy.php
+++ b/app/Policies/CommentPolicy.php
@@ -36,6 +36,18 @@ class CommentPolicy
         return $conversation->group->hasActiveMember($user);
     }
 
+    public function delete(User $user, Comment $comment): bool
+    {
+        $conversation = $this->conversationFor($comment);
+
+        if (! $conversation instanceof Conversation) {
+            return false;
+        }
+
+        return $this->isAuthor($user, $comment)
+            || $conversation->group->hasLeader($user);
+    }
+
     private function conversationFor(Comment $comment): ?Conversation
     {
         $commentable = $comment->commentable;

--- a/resources/views/pages/groups/conversations/show.blade.php
+++ b/resources/views/pages/groups/conversations/show.blade.php
@@ -36,6 +36,8 @@ new class extends Component {
 
     public ?int $sheetCommentId = null;
 
+    public ?int $commentToDeleteId = null;
+
     public ?TemporaryUploadedFile $newImage = null;
 
     public ?TemporaryUploadedFile $newAttachment = null;
@@ -463,6 +465,47 @@ new class extends Component {
         $comment->togglePrayer();
 
         unset($this->comments);
+    }
+
+    public function confirmDeleteComment(int $commentId): void
+    {
+        /** @var Comment $comment */
+        $comment = $this->conversation->comments()->findOrFail($commentId);
+
+        $this->authorize('delete', $comment);
+
+        $this->commentToDeleteId = $commentId;
+
+        Flux::modal('message-actions')->close();
+        Flux::modal('delete-comment')->show();
+    }
+
+    public function deleteComment(): void
+    {
+        if ($this->commentToDeleteId === null) {
+            return;
+        }
+
+        /** @var Comment $comment */
+        $comment = $this->conversation->comments()->findOrFail($this->commentToDeleteId);
+
+        $this->authorize('delete', $comment);
+
+        ConversationFile::where('comment_id', $comment->id)->get()
+            ->each(fn (ConversationFile $file) => $file->delete());
+
+        $comment->delete();
+
+        if ($this->sheetCommentId === $comment->id) {
+            $this->sheetCommentId = null;
+        }
+
+        $this->commentToDeleteId = null;
+
+        unset($this->comments, $this->pinnedComments);
+
+        Flux::modal('delete-comment')->close();
+        Flux::toast(variant: 'success', text: 'Message deleted.');
     }
 
     public function dismissPinnedStrip(): void
@@ -945,6 +988,20 @@ new class extends Component {
                                             </button>
                                         </flux:tooltip>
                                     @endcan
+
+                                    @can('delete', $comment)
+                                        <flux:tooltip content="Delete message">
+                                            <button
+                                                type="button"
+                                                wire:click="confirmDeleteComment({{ $comment->id }})"
+                                                aria-label="Delete message"
+                                                class="flex size-[26px] cursor-pointer items-center justify-center rounded-md text-zinc-500 transition-colors duration-[120ms] hover:bg-red-50 hover:text-red-600 focus-visible:bg-red-50 focus-visible:text-red-600 focus-visible:outline-none dark:hover:bg-red-950/40 dark:hover:text-red-400 dark:focus-visible:bg-red-950/40 dark:focus-visible:text-red-400"
+                                                data-test="delete-toggle"
+                                            >
+                                                <flux:icon.trash variant="micro" class="size-3.5" />
+                                            </button>
+                                        </flux:tooltip>
+                                    @endcan
                                 </div>
                             @endif
                         </div>
@@ -1395,6 +1452,20 @@ new class extends Component {
                         </span>
                         Copy text
                     </button>
+
+                    @can('delete', $sheetComment)
+                        <button
+                            type="button"
+                            wire:click="confirmDeleteComment({{ $sheetComment->id }})"
+                            class="flex w-full items-center gap-3.5 border-b border-zinc-100 px-5 py-3.5 text-left text-[15px] font-medium text-red-600 dark:border-zinc-800 dark:text-red-400"
+                            data-test="sheet-delete"
+                        >
+                            <span class="grid size-8 shrink-0 place-items-center rounded-md bg-red-50 text-red-600 dark:bg-red-950/40 dark:text-red-400">
+                                <flux:icon.trash variant="micro" />
+                            </span>
+                            Delete message
+                        </button>
+                    @endcan
                 </div>
 
                 {{-- Cancel --}}
@@ -1411,5 +1482,25 @@ new class extends Component {
                 </div>
             </div>
         @endif
+    </flux:modal>
+
+    <flux:modal name="delete-comment" class="min-w-[22rem]">
+        <form wire:submit="deleteComment" class="space-y-6">
+            <div>
+                <flux:heading size="lg">Delete message?</flux:heading>
+                <flux:subheading>
+                    This permanently removes the message, its reactions, and any attachments. This cannot be undone.
+                </flux:subheading>
+            </div>
+            <div class="flex gap-2">
+                <flux:spacer />
+                <flux:modal.close>
+                    <flux:button variant="ghost" type="button">Cancel</flux:button>
+                </flux:modal.close>
+                <flux:button type="submit" variant="danger" data-test="confirm-delete-comment">
+                    Delete message
+                </flux:button>
+            </div>
+        </form>
     </flux:modal>
 </section>

--- a/tests/Feature/CommentPinPrayerInteractionTest.php
+++ b/tests/Feature/CommentPinPrayerInteractionTest.php
@@ -5,9 +5,12 @@ use App\Enums\GroupRole;
 use App\Enums\GroupVisibility;
 use App\Enums\MembershipStatus;
 use App\Models\Conversation;
+use App\Models\ConversationFile;
 use App\Models\Group;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
 use Livewire\Livewire;
 
 uses(RefreshDatabase::class);
@@ -186,4 +189,131 @@ test('the prayer toggle button is rendered for active group members', function (
     Livewire::actingAs($member)
         ->test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
         ->assertSeeHtml('data-test="prayer-toggle"');
+});
+
+// --- deleteComment ---
+
+test('confirmDeleteComment stages the comment id when authorized', function (): void {
+    [$group, $conversation, $author] = buildInteractionScenario();
+    $comment = $conversation->postComment('delete me', $author);
+
+    Livewire::actingAs($author)
+        ->test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->call('confirmDeleteComment', $comment->id)
+        ->assertSet('commentToDeleteId', $comment->id);
+});
+
+test('an author can delete their own comment via deleteComment', function (): void {
+    [$group, $conversation, $author] = buildInteractionScenario();
+    $comment = $conversation->postComment('delete me', $author);
+
+    Livewire::actingAs($author)
+        ->test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->call('confirmDeleteComment', $comment->id)
+        ->call('deleteComment')
+        ->assertSet('commentToDeleteId', null);
+
+    expect($conversation->fresh()->comments()->whereKey($comment->id)->exists())->toBeFalse();
+});
+
+test('a group leader can delete any comment', function (): void {
+    [$group, $conversation, $author] = buildInteractionScenario();
+    $member = User::factory()->create();
+    $group->allUsers()->attach($member, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+
+    $comment = $conversation->postComment('member message', $member);
+
+    Livewire::actingAs($author)
+        ->test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->call('confirmDeleteComment', $comment->id)
+        ->call('deleteComment');
+
+    expect($conversation->fresh()->comments()->whereKey($comment->id)->exists())->toBeFalse();
+});
+
+test('a non-author non-leader member cannot delete a comment', function (): void {
+    [$group, $conversation, $author] = buildInteractionScenario();
+    $other = User::factory()->create();
+    $group->allUsers()->attach($other, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+
+    $comment = $conversation->postComment('not yours', $author);
+
+    Livewire::actingAs($other)
+        ->test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->call('confirmDeleteComment', $comment->id)
+        ->assertForbidden();
+
+    expect($conversation->fresh()->comments()->whereKey($comment->id)->exists())->toBeTrue();
+});
+
+test('deleteComment removes the comment files from storage', function (): void {
+    Storage::fake('digital-ocean', ['url' => 'https://stave.atl1.digitaloceanspaces.com']);
+
+    [$group, $conversation, $author] = buildInteractionScenario();
+
+    Livewire::actingAs($author)
+        ->test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->set('newAttachment', UploadedFile::fake()->create('notes.pdf', 100, 'application/pdf'))
+        ->set('reply', '<p>with file</p>')
+        ->call('postReply')
+        ->assertHasNoErrors();
+
+    $comment = $conversation->fresh()->comments()->first();
+    $file = ConversationFile::where('comment_id', $comment->id)->firstOrFail();
+
+    Storage::disk('digital-ocean')->assertExists($file->path);
+
+    Livewire::actingAs($author)
+        ->test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->call('confirmDeleteComment', $comment->id)
+        ->call('deleteComment');
+
+    Storage::disk('digital-ocean')->assertMissing($file->path);
+    expect(ConversationFile::query()->whereKey($file->id)->exists())->toBeFalse();
+});
+
+test('deleting a pinned comment removes it from the pinned strip', function (): void {
+    [$group, $conversation, $author] = buildInteractionScenario();
+    $comment = $conversation->postComment('pinned then deleted', $author);
+    $comment->fresh()->pin($author);
+
+    Livewire::actingAs($author)
+        ->test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->assertSeeHtml('data-test="pinned-strip"')
+        ->call('confirmDeleteComment', $comment->id)
+        ->call('deleteComment')
+        ->assertDontSeeHtml('data-test="pinned-strip"');
+});
+
+test('deleting the active mobile-sheet comment clears sheetCommentId', function (): void {
+    [$group, $conversation, $author] = buildInteractionScenario();
+    $comment = $conversation->postComment('sheet target', $author);
+
+    Livewire::actingAs($author)
+        ->test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->call('openActions', $comment->id)
+        ->assertSet('sheetCommentId', $comment->id)
+        ->call('confirmDeleteComment', $comment->id)
+        ->call('deleteComment')
+        ->assertSet('sheetCommentId', null);
+});
+
+test('the delete toggle is rendered for the comment author', function (): void {
+    [$group, $conversation, $author] = buildInteractionScenario();
+    $conversation->postComment('mine', $author);
+
+    Livewire::actingAs($author)
+        ->test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->assertSeeHtml('data-test="delete-toggle"');
+});
+
+test('the delete toggle is hidden for a member who cannot delete', function (): void {
+    [$group, $conversation, $author] = buildInteractionScenario();
+    $other = User::factory()->create();
+    $group->allUsers()->attach($other, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+    $conversation->postComment('not yours', $author);
+
+    Livewire::actingAs($other)
+        ->test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->assertDontSeeHtml('data-test="delete-toggle"');
 });

--- a/tests/Feature/CommentPinPrayerTest.php
+++ b/tests/Feature/CommentPinPrayerTest.php
@@ -153,3 +153,37 @@ test('a pending member cannot mark prayer', function (): void {
 
     expect($pending->can('markPrayer', $comment))->toBeFalse();
 });
+
+// --- Policy: delete ---
+
+test('author of the comment can delete their own comment', function (): void {
+    [$group, $conversation, $comment, $author] = makeGroupConversation();
+
+    expect($author->can('delete', $comment))->toBeTrue();
+});
+
+test('group leader can delete any comment in the conversation', function (): void {
+    [$group, $conversation, $comment] = makeGroupConversation();
+
+    $leader = User::factory()->create();
+    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => MembershipStatus::ACTIVE]);
+
+    expect($leader->can('delete', $comment))->toBeTrue();
+});
+
+test('a non-leader member who did not author the comment cannot delete it', function (): void {
+    [$group, $conversation, $comment] = makeGroupConversation();
+
+    $otherMember = User::factory()->create();
+    $group->allUsers()->attach($otherMember, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+
+    expect($otherMember->can('delete', $comment))->toBeFalse();
+});
+
+test('a user outside the group cannot delete a comment', function (): void {
+    [$group, $conversation, $comment] = makeGroupConversation();
+
+    $outsider = User::factory()->create();
+
+    expect($outsider->can('delete', $comment))->toBeFalse();
+});


### PR DESCRIPTION
## Summary

- Adds the ability for comment authors and group leaders to delete messages in group conversations
- Deletes associated file attachments from storage via the existing `ConversationFileObserver`
- Includes delete button on desktop hover actions and mobile action sheet, with a confirmation modal
- Adds `CommentPolicy::delete` authorization following the existing pin/unpin pattern
- Comprehensive test coverage for policy rules, Livewire interactions, file cleanup, and UI rendering

## Test plan

- [ ] Verify comment author can delete their own message via desktop hover trash icon
- [ ] Verify group leader can delete any member's message
- [ ] Verify non-author/non-leader members do not see the delete button
- [ ] Verify file attachments are removed from storage when a comment with files is deleted
- [ ] Verify deleting a pinned comment removes it from the pinned strip
- [ ] Verify the mobile action sheet delete option works and shows the confirmation modal
- [ ] Run `npm run pest` to confirm all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)