### PR TITLE
Redesign group page with pinning, role management, and batch member add

### DIFF
--- a/app/Models/Conversation.php
+++ b/app/Models/Conversation.php
@@ -15,6 +15,8 @@ use Spatie\Comments\Models\Concerns\Interfaces\CanComment;
 
 /**
  * @property ?Carbon $last_comment_at
+ * @property ?Carbon $pinned_at
+ * @property ?int $pinned_by_user_id
  */
 #[Fillable(['group_id', 'user_id', 'title'])]
 class Conversation extends Model
@@ -27,6 +29,7 @@ class Conversation extends Model
     {
         return [
             'last_comment_at' => 'datetime',
+            'pinned_at' => 'datetime',
         ];
     }
 
@@ -42,12 +45,52 @@ class Conversation extends Model
         return $this->belongsTo(User::class, 'user_id');
     }
 
+    /** @return BelongsTo<User, $this> */
+    public function pinnedBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'pinned_by_user_id');
+    }
+
     /** @return MorphMany<Comment, $this> */
     public function pinnedComments(): MorphMany
     {
         return $this->morphMany(Comment::class, 'commentable')
             ->whereNotNull('pinned_at')
             ->orderByDesc('pinned_at');
+    }
+
+    /** @return MorphMany<Comment, $this> */
+    public function firstComment(): MorphMany
+    {
+        return $this->morphMany(Comment::class, 'commentable')
+            ->with('commentator')
+            ->oldest()
+            ->limit(1);
+    }
+
+    public function isPinned(): bool
+    {
+        return $this->pinned_at !== null;
+    }
+
+    public function pin(User $pinnedBy): self
+    {
+        $this->forceFill([
+            'pinned_at' => now(),
+            'pinned_by_user_id' => $pinnedBy->id,
+        ])->save();
+
+        return $this;
+    }
+
+    public function unpin(): self
+    {
+        $this->forceFill([
+            'pinned_at' => null,
+            'pinned_by_user_id' => null,
+        ])->save();
+
+        return $this;
     }
 
     /** @return HasMany<ConversationFile, $this> */

--- a/app/Policies/ConversationPolicy.php
+++ b/app/Policies/ConversationPolicy.php
@@ -39,6 +39,11 @@ class ConversationPolicy
         return $conversation->group->hasLeader($user);
     }
 
+    public function pin(User $user, Conversation $conversation): bool
+    {
+        return $conversation->group->hasLeader($user);
+    }
+
     private function isAuthorOrLeader(User $user, Conversation $conversation): bool
     {
         return $this->isAuthor($user, $conversation)

--- a/database/migrations/2026_05_17_202403_add_pin_columns_to_conversations_table.php
+++ b/database/migrations/2026_05_17_202403_add_pin_columns_to_conversations_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('conversations', function (Blueprint $table): void {
+            $table->timestamp('pinned_at')->nullable()->after('last_comment_at');
+            $table->foreignId('pinned_by_user_id')->nullable()->after('pinned_at')->constrained('users')->nullOnDelete();
+
+            $table->index(['group_id', 'pinned_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('conversations', function (Blueprint $table): void {
+            $table->dropIndex(['group_id', 'pinned_at']);
+            $table->dropConstrainedForeignId('pinned_by_user_id');
+            $table->dropColumn('pinned_at');
+        });
+    }
+};

--- a/resources/views/pages/groups/_partials/add-member-popover.blade.php
+++ b/resources/views/pages/groups/_partials/add-member-popover.blade.php
@@ -1,0 +1,132 @@
+@php
+    /** @var \App\Models\Group $group */
+    /** @var \Illuminate\Support\Collection $availableUsers */
+    /** @var \Illuminate\Support\Collection $pickedUsers */
+    /** @var string $memberSearch */
+    /** @var bool $addMemberOpen */
+@endphp
+
+<div class="relative" style="margin-left: auto;">
+    <flux:button type="button" variant="primary" icon="user-plus" wire:click="openAddMember">Add member</flux:button>
+
+    @if ($addMemberOpen)
+        {{-- Scrim --}}
+        <div wire:click="closeAddMember" class="fixed inset-0 z-[40] bg-black/10"></div>
+
+        {{-- Popover --}}
+        <div
+            x-data
+            @keydown.escape.window="$wire.closeAddMember()"
+            class="absolute right-0 top-[calc(100%+8px)] z-[50] overflow-hidden rounded-xl border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 shadow-lg"
+            style="width: min(420px, calc(100vw - 32px));">
+
+            {{-- Header --}}
+            <div class="border-b border-zinc-200 dark:border-zinc-700 px-4 pt-3.5 pb-2.5">
+                <div class="flex items-center justify-between">
+                    <div class="text-sm font-bold text-zinc-900 dark:text-zinc-100">Add members to {{ $group->name }}</div>
+                    <button
+                        type="button"
+                        wire:click="closeAddMember"
+                        class="flex size-6 items-center justify-center rounded-md text-zinc-500 hover:bg-zinc-100 hover:text-zinc-700 dark:hover:bg-zinc-800 dark:hover:text-zinc-200">
+                        <flux:icon.x-mark class="size-3.5" />
+                    </button>
+                </div>
+                <div class="mt-0.5 text-xs text-zinc-500 dark:text-zinc-400">
+                    Pick from your congregation. New members join as Member.
+                </div>
+
+                {{-- Chip input --}}
+                <div
+                    x-data
+                    @click="$refs.searchInput.focus()"
+                    class="mt-2.5 flex min-h-[38px] cursor-text flex-wrap items-center gap-1.5 rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-2 py-1.5">
+
+                    @foreach ($pickedUsers as $picked)
+                        <span wire:key="picked-chip-{{ $picked->id }}"
+                            class="inline-flex items-center gap-1.5 rounded-full bg-purple-100 dark:bg-purple-900/40 pl-1 pr-1 py-0.5 text-xs font-semibold text-purple-700 dark:text-purple-200">
+                            <img src="{{ $picked->gravatar }}" alt="{{ $picked->name }}" class="size-5 rounded-full object-cover" />
+                            <span>{{ $picked->name }}</span>
+                            <button
+                                type="button"
+                                wire:click="unpickUser({{ $picked->id }})"
+                                class="flex size-4 items-center justify-center rounded-full hover:bg-purple-200 dark:hover:bg-purple-800/60">
+                                <flux:icon.x-mark class="size-2.5" />
+                            </button>
+                        </span>
+                    @endforeach
+
+                    <input
+                        x-ref="searchInput"
+                        x-init="$el.focus()"
+                        type="text"
+                        wire:model.live.debounce.300ms="memberSearch"
+                        @if ($pickedUsers->isNotEmpty())
+                            @keydown.backspace="if ($event.target.value === '') $wire.unpickUser({{ $pickedUsers->last()->id }})"
+                        @endif
+                        placeholder="{{ $pickedUsers->isEmpty() ? 'Search by name or email…' : '' }}"
+                        class="h-6 min-w-[140px] flex-1 border-0 bg-transparent text-sm text-zinc-900 dark:text-zinc-100 placeholder-zinc-400 focus:outline-none focus:ring-0"
+                    />
+                </div>
+            </div>
+
+            {{-- Results --}}
+            <div class="max-h-[280px] overflow-y-auto p-1.5">
+                @if ($availableUsers->isEmpty())
+                    <div class="px-3 py-6 text-center text-[13px] text-zinc-500 dark:text-zinc-400">
+                        @if (strlen($memberSearch) < 2)
+                            {{ $pickedUsers->isNotEmpty() ? 'All set — anyone else?' : 'Search by name or email to find people.' }}
+                        @else
+                            No people match.
+                        @endif
+                    </div>
+                @else
+                    @foreach ($availableUsers as $user)
+                        <button
+                            type="button"
+                            wire:key="avail-{{ $user->id }}"
+                            wire:click="pickUser({{ $user->id }})"
+                            class="flex w-full items-center gap-3 rounded-lg px-2.5 py-2 text-left transition hover:bg-zinc-100 dark:hover:bg-zinc-800">
+                            <img src="{{ $user->gravatar }}" alt="{{ $user->name }}" class="size-8 rounded-full object-cover" />
+                            <div class="min-w-0 flex-1">
+                                <div class="truncate text-[13px] font-semibold text-zinc-900 dark:text-zinc-100">{{ $user->name }}</div>
+                                <div class="truncate text-xs text-zinc-500 dark:text-zinc-400">{{ $user->email }}</div>
+                            </div>
+                            <div class="flex size-[22px] items-center justify-center rounded-md border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-zinc-400">
+                                <flux:icon.plus class="size-3" />
+                            </div>
+                        </button>
+                    @endforeach
+                @endif
+            </div>
+
+            {{-- Footer --}}
+            <div class="flex items-center justify-between gap-2 border-t border-zinc-200 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-800/60 px-3 py-2.5">
+                <div class="text-xs text-zinc-500 dark:text-zinc-400">
+                    @if ($pickedUsers->isEmpty())
+                        No one selected
+                    @elseif ($pickedUsers->count() === 1)
+                        1 person selected
+                    @else
+                        {{ $pickedUsers->count() }} people selected
+                    @endif
+                </div>
+                <div class="flex gap-2">
+                    <flux:button type="button" variant="ghost" size="sm" wire:click="closeAddMember">Cancel</flux:button>
+                    <flux:button
+                        type="button"
+                        variant="primary"
+                        size="sm"
+                        icon="user-plus"
+                        :disabled="$pickedUsers->isEmpty()"
+                        wire:click="confirmAddMembers">
+                        @if ($pickedUsers->count() > 1)
+                            Add {{ $pickedUsers->count() }} members
+                        @else
+                            Add member
+                        @endif
+                    </flux:button>
+                </div>
+            </div>
+        </div>
+    @endif
+</div>

--- a/resources/views/pages/groups/_partials/conversation-row.blade.php
+++ b/resources/views/pages/groups/_partials/conversation-row.blade.php
@@ -1,0 +1,91 @@
+@php
+    /** @var \App\Models\Conversation $conversation */
+    /** @var \App\Models\Group $group */
+    /** @var bool $isLeader */
+    /** @var string $preview */
+    /** @var string $previewAuthor */
+@endphp
+
+<div
+    wire:key="convo-{{ $conversation->id }}"
+    class="group relative grid items-center gap-3.5 rounded-lg border-t border-zinc-100 dark:border-zinc-800 px-3.5 py-3.5 transition hover:bg-zinc-50 dark:hover:bg-zinc-800/40"
+    style="grid-template-columns: auto 1fr auto auto;">
+
+    {{-- Avatar with pin indicator --}}
+    <div class="relative">
+        <flux:avatar
+            :name="$conversation->creator?->name ?? '?'"
+            :src="$conversation->creator?->gravatar"
+            size="md"
+        />
+        @if ($conversation->isPinned())
+            <span
+                title="Pinned"
+                class="absolute -top-1 -right-1 flex size-[18px] items-center justify-center rounded-full bg-purple-600 text-white ring-2 ring-white dark:ring-zinc-900">
+                <flux:icon.bookmark class="size-2.5" />
+            </span>
+        @endif
+    </div>
+
+    {{-- Title + preview --}}
+    <div class="min-w-0">
+        <div class="flex items-center gap-2 min-w-0">
+            <a
+                href="{{ route('groups.conversations.show', ['group' => $group, 'conversation' => $conversation]) }}"
+                wire:navigate
+                class="truncate text-sm font-semibold text-zinc-900 dark:text-zinc-100 hover:underline">
+                {{ $conversation->title }}
+            </a>
+            <flux:badge size="sm" color="zinc" inset="top bottom">
+                {{ $conversation->comments_count }} {{ str('reply')->plural($conversation->comments_count) }}
+            </flux:badge>
+        </div>
+
+        @if ($preview !== '')
+            <div class="mt-1 truncate text-[13px] text-zinc-500 dark:text-zinc-400">
+                <span class="text-zinc-700 dark:text-zinc-200">{{ $previewAuthor }}:</span>
+                {{ $preview }}
+            </div>
+        @endif
+    </div>
+
+    {{-- Timestamp --}}
+    <div class="whitespace-nowrap text-xs text-zinc-400 dark:text-zinc-500">
+        {{ ($conversation->last_comment_at ?? $conversation->created_at)->diffForHumans() }}
+    </div>
+
+    {{-- Actions --}}
+    <div class="flex items-center justify-end gap-0.5" style="min-width: 64px;">
+        @if ($isLeader)
+            <flux:tooltip :content="$conversation->isPinned() ? 'Unpin' : 'Pin to top'">
+                <flux:button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    square
+                    icon="bookmark"
+                    wire:click="{{ $conversation->isPinned() ? 'unpinConversation' : 'pinConversation' }}({{ $conversation->id }})"
+                    class="{{ $conversation->isPinned() ? 'text-purple-600 dark:text-purple-300' : 'opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity' }}"
+                />
+            </flux:tooltip>
+
+            <flux:dropdown align="end" offset="-8" class="opacity-0 group-hover:opacity-100 focus-within:opacity-100 data-[flux-dropdown-open]:opacity-100 transition-opacity">
+                <flux:button type="button" variant="ghost" size="sm" square icon="ellipsis-horizontal" />
+
+                <flux:menu class="min-w-48">
+                    @if ($conversation->isPinned())
+                        <flux:menu.item icon="bookmark-slash" wire:click="unpinConversation({{ $conversation->id }})">Unpin from top</flux:menu.item>
+                    @else
+                        <flux:menu.item icon="bookmark" wire:click="pinConversation({{ $conversation->id }})">Pin to top</flux:menu.item>
+                    @endif
+                    <flux:menu.separator />
+                    <flux:menu.item icon="trash" variant="danger" wire:click="openDeleteConversation({{ $conversation->id }})">
+                        Delete conversation
+                    </flux:menu.item>
+                </flux:menu>
+            </flux:dropdown>
+        @else
+            <div class="w-16"></div>
+        @endif
+    </div>
+</div>

--- a/resources/views/pages/groups/_partials/member-row.blade.php
+++ b/resources/views/pages/groups/_partials/member-row.blade.php
@@ -1,0 +1,115 @@
+@php
+    use App\Enums\GroupRole;
+
+    /** @var \App\Models\User $user */
+    /** @var bool $isLeader */
+    /** @var bool $isOnlyLeader */
+
+    $userIsLeader = $user->pivot->role === GroupRole::LEADER;
+    $isSelf = $user->id === auth()->id();
+@endphp
+
+<div
+    wire:key="member-{{ $user->id }}"
+    class="group grid items-center gap-4 border-b border-zinc-100 dark:border-zinc-800 px-4 py-3 transition hover:bg-zinc-50 dark:hover:bg-zinc-800/40"
+    style="grid-template-columns: 1fr 180px 160px 44px;">
+
+    {{-- Member --}}
+    <div class="flex items-center gap-3 min-w-0">
+        <flux:avatar :name="$user->name" :src="$user->gravatar" size="md" />
+        <div class="min-w-0">
+            <div class="truncate text-sm font-semibold text-zinc-900 dark:text-zinc-100">{{ $user->name }}</div>
+            <div class="truncate text-xs text-zinc-500 dark:text-zinc-400">{{ $user->email }}</div>
+        </div>
+    </div>
+
+    {{-- Role --}}
+    <div>
+        @if ($isLeader && ! $isSelf)
+            <flux:dropdown align="start" offset="4">
+                <flux:button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    :icon="$userIsLeader ? 'star' : 'user'"
+                    icon:trailing="chevron-down"
+                    :disabled="$isOnlyLeader"
+                    :title="$isOnlyLeader ? 'A group must have at least one leader.' : null"
+                    class="!justify-start !font-semibold {{ $userIsLeader ? '!text-purple-600 dark:!text-purple-300' : '' }}">
+                    {{ $userIsLeader ? 'Leader' : 'Member' }}
+                </flux:button>
+
+                <flux:menu class="min-w-[15rem]">
+                    <flux:menu.item
+                        icon="star"
+                        wire:click="setMemberRole({{ $user->id }}, 'leader')"
+                        :disabled="$userIsLeader">
+                        <div class="flex flex-col items-start">
+                            <span class="text-sm font-semibold">Leader</span>
+                            <span class="text-xs text-zinc-500 dark:text-zinc-400">Can manage members, pin and delete conversations.</span>
+                        </div>
+                    </flux:menu.item>
+
+                    <flux:menu.item
+                        icon="user"
+                        wire:click="setMemberRole({{ $user->id }}, 'member')"
+                        :disabled="! $userIsLeader || $isOnlyLeader"
+                        :title="$isOnlyLeader ? 'A group must have at least one leader.' : null">
+                        <div class="flex flex-col items-start">
+                            <span class="text-sm font-semibold">Member</span>
+                            <span class="text-xs text-zinc-500 dark:text-zinc-400">Can read and post in conversations.</span>
+                        </div>
+                    </flux:menu.item>
+                </flux:menu>
+            </flux:dropdown>
+        @else
+            @if ($userIsLeader)
+                <flux:badge size="sm" color="purple" icon="star">Leader</flux:badge>
+            @else
+                <flux:badge size="sm" color="zinc">Member</flux:badge>
+            @endif
+        @endif
+    </div>
+
+    {{-- Joined --}}
+    <div class="whitespace-nowrap text-[13px] text-zinc-500 dark:text-zinc-400">
+        {{ $user->pivot->created_at->diffForHumans() }}
+    </div>
+
+    {{-- Actions --}}
+    <div class="flex justify-end">
+        @if ($isLeader && ! $isSelf)
+            <flux:dropdown align="end" offset="-8" class="opacity-0 group-hover:opacity-100 focus-within:opacity-100 data-[flux-dropdown-open]:opacity-100 transition-opacity">
+                <flux:button type="button" variant="ghost" size="sm" square icon="ellipsis-horizontal" />
+
+                <flux:menu class="min-w-48">
+                    @if ($userIsLeader)
+                        <flux:menu.item
+                            icon="user"
+                            wire:click="setMemberRole({{ $user->id }}, 'member')"
+                            :disabled="$isOnlyLeader"
+                            :title="$isOnlyLeader ? 'A group must have at least one leader.' : null">
+                            Change to member
+                        </flux:menu.item>
+                    @else
+                        <flux:menu.item icon="star" wire:click="setMemberRole({{ $user->id }}, 'leader')">
+                            Make leader
+                        </flux:menu.item>
+                    @endif
+
+                    <flux:menu.separator />
+
+                    <flux:menu.item
+                        icon="trash"
+                        variant="danger"
+                        wire:click="removeMember({{ $user->id }})"
+                        wire:confirm="Remove {{ $user->name }} from this group?"
+                        :disabled="$isOnlyLeader"
+                        :title="$isOnlyLeader ? 'A group must have at least one leader.' : null">
+                        Remove from group
+                    </flux:menu.item>
+                </flux:menu>
+            </flux:dropdown>
+        @endif
+    </div>
+</div>

--- a/resources/views/pages/groups/_partials/member-row.blade.php
+++ b/resources/views/pages/groups/_partials/member-row.blade.php
@@ -33,8 +33,8 @@
                     size="sm"
                     :icon="$userIsLeader ? 'star' : 'user'"
                     icon:trailing="chevron-down"
-                    :disabled="$isOnlyLeader"
-                    :title="$isOnlyLeader ? 'A group must have at least one leader.' : null"
+                    :disabled="$userIsLeader && $isOnlyLeader"
+                    :title="$userIsLeader && $isOnlyLeader ? 'A group must have at least one leader.' : null"
                     class="!justify-start !font-semibold {{ $userIsLeader ? '!text-purple-600 dark:!text-purple-300' : '' }}">
                     {{ $userIsLeader ? 'Leader' : 'Member' }}
                 </flux:button>
@@ -104,8 +104,8 @@
                         variant="danger"
                         wire:click="removeMember({{ $user->id }})"
                         wire:confirm="Remove {{ $user->name }} from this group?"
-                        :disabled="$isOnlyLeader"
-                        :title="$isOnlyLeader ? 'A group must have at least one leader.' : null">
+                        :disabled="$userIsLeader && $isOnlyLeader"
+                        :title="$userIsLeader && $isOnlyLeader ? 'A group must have at least one leader.' : null">
                         Remove from group
                     </flux:menu.item>
                 </flux:menu>

--- a/resources/views/pages/groups/show.blade.php
+++ b/resources/views/pages/groups/show.blade.php
@@ -18,6 +18,7 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Url;
 use Livewire\Component;
@@ -29,7 +30,19 @@ new class extends Component {
     public string $tab = 'conversations';
 
     public string $memberSearch = '';
-    public ?int $selectedUserId = null;
+
+    public string $searchConvos = '';
+
+    public string $searchMembers = '';
+
+    public string $memberFilter = 'all';
+
+    public ?int $confirmDeleteId = null;
+
+    public bool $addMemberOpen = false;
+
+    /** @var array<int, int> */
+    public array $pickedUserIds = [];
 
     public function mount(Group $group): void
     {
@@ -75,6 +88,39 @@ new class extends Component {
     }
 
     #[Computed]
+    public function leaderCount(): int
+    {
+        return $this->activeMembers->filter(
+            fn (User $u): bool => $this->pivotRole($u) === GroupRole::LEADER,
+        )->count();
+    }
+
+    /** @return Collection<int, User> */
+    #[Computed]
+    public function filteredMembers(): Collection
+    {
+        $needle = mb_strtolower(trim($this->searchMembers));
+
+        return $this->activeMembers
+            ->when($this->memberFilter !== 'all', fn ($c) => $c->filter(
+                fn (User $u): bool => $this->pivotRole($u)->value === $this->memberFilter,
+            ))
+            ->when($needle !== '', fn ($c) => $c->filter(
+                fn (User $u): bool => str_contains(mb_strtolower($u->name), $needle)
+                    || str_contains(mb_strtolower($u->email), $needle),
+            ))
+            ->values();
+    }
+
+    private function pivotRole(User $user): GroupRole
+    {
+        /** @var GroupUser $pivot */
+        $pivot = $user->getRelation('pivot');
+
+        return $pivot->role;
+    }
+
+    #[Computed]
     public function conversationsVisible(): bool
     {
         return $this->isMember && $this->group->messaging !== GroupMessaging::OFF;
@@ -85,10 +131,27 @@ new class extends Component {
     public function conversations(): Collection
     {
         return $this->group->conversations()
-            ->with('creator')
+            ->with(['creator', 'firstComment'])
             ->withCount('comments')
+            ->orderByRaw('CASE WHEN pinned_at IS NULL THEN 1 ELSE 0 END')
+            ->orderByDesc('pinned_at')
             ->orderByRaw('COALESCE(last_comment_at, created_at) desc')
             ->get();
+    }
+
+    /** @return Collection<int, Conversation> */
+    #[Computed]
+    public function filteredConversations(): Collection
+    {
+        $needle = mb_strtolower(trim($this->searchConvos));
+
+        if ($needle === '') {
+            return $this->conversations;
+        }
+
+        return $this->conversations
+            ->filter(fn (Conversation $c) => str_contains(mb_strtolower($c->title), $needle))
+            ->values();
     }
 
     /** @return Collection<int, User>|BaseCollection<int, User> */
@@ -104,10 +167,64 @@ new class extends Component {
             ->pluck('users.id');
 
         return User::query()
-            ->where('name', 'like', "%{$this->memberSearch}%")
+            ->where(function ($q): void {
+                $q->where('name', 'like', "%{$this->memberSearch}%")
+                    ->orWhere('email', 'like', "%{$this->memberSearch}%");
+            })
             ->whereNotIn('id', $existingUserIds)
-            ->limit(20)
+            ->whereNotIn('id', $this->pickedUserIds)
+            ->limit(8)
             ->get();
+    }
+
+    /** @return Collection<int, User> */
+    #[Computed]
+    public function pickedUsers(): Collection
+    {
+        if ($this->pickedUserIds === []) {
+            return new Collection;
+        }
+
+        return User::query()->whereIn('id', $this->pickedUserIds)->get();
+    }
+
+    public function openAddMember(): void
+    {
+        $this->addMemberOpen = true;
+    }
+
+    public function closeAddMember(): void
+    {
+        $this->addMemberOpen = false;
+        $this->pickedUserIds = [];
+        $this->memberSearch = '';
+        unset($this->pickedUsers, $this->availableUsers);
+    }
+
+    public function pickUser(int $userId): void
+    {
+        if (! in_array($userId, $this->pickedUserIds, true)) {
+            $this->pickedUserIds[] = $userId;
+        }
+        $this->memberSearch = '';
+        unset($this->pickedUsers, $this->availableUsers);
+    }
+
+    public function unpickUser(int $userId): void
+    {
+        $this->pickedUserIds = array_values(array_filter(
+            $this->pickedUserIds,
+            fn (int $id) => $id !== $userId,
+        ));
+        unset($this->pickedUsers, $this->availableUsers);
+    }
+
+    public function confirmAddMembers(): void
+    {
+        if ($this->pickedUserIds !== []) {
+            $this->addMembers($this->pickedUserIds);
+        }
+        $this->closeAddMember();
     }
 
     public function join(): void
@@ -238,42 +355,50 @@ new class extends Component {
         Flux::toast(text: "{$user->name} rejected.");
     }
 
-    public function addMember(): void
+    /** @param  array<int, int|string>  $userIds */
+    public function addMembers(array $userIds): void
     {
         $this->authorize('manageMembers', $this->group);
 
-        if (! $this->selectedUserId) {
+        $userIds = collect($userIds)->map(fn ($id) => (int) $id)->filter()->unique()->values()->all();
+
+        if ($userIds === []) {
             return;
         }
 
-        $user = User::findOrFail($this->selectedUserId);
+        $existingIds = $this->group->allUsers()
+            ->whereIn('users.id', $userIds)
+            ->pluck('users.id')
+            ->all();
 
-        if ($this->group->members()->where('user_id', $user->id)->exists()) {
-            Flux::toast(variant: 'warning', text: "{$user->name} is already a member.");
-            $this->reset('selectedUserId', 'memberSearch');
+        $users = User::query()->whereIn('id', $userIds)->get();
 
-            return;
+        DB::transaction(function () use ($users, $existingIds): void {
+            foreach ($users as $user) {
+                if (in_array($user->id, $existingIds, true)) {
+                    $this->group->allUsers()->updateExistingPivot($user->id, [
+                        'status' => MembershipStatus::ACTIVE,
+                    ]);
+                } else {
+                    $this->group->allUsers()->attach($user->id, [
+                        'role' => GroupRole::MEMBER,
+                        'status' => MembershipStatus::ACTIVE,
+                    ]);
+                }
+            }
+        });
+
+        foreach ($users as $user) {
+            $user->notify(new GroupMemberAddedNotification($this->group, Auth::user()));
         }
 
-        $existing = $this->group->allUsers()->where('user_id', $user->id)->exists();
-
-        if ($existing) {
-            $this->group->allUsers()->updateExistingPivot($user->id, [
-                'status' => MembershipStatus::ACTIVE,
-                'role' => GroupRole::MEMBER,
-            ]);
-        } else {
-            $this->group->allUsers()->attach($user->id, [
-                'role' => GroupRole::MEMBER,
-                'status' => MembershipStatus::ACTIVE,
-            ]);
-        }
-
-        $user->notify(new GroupMemberAddedNotification($this->group, Auth::user()));
-
-        $this->reset('selectedUserId', 'memberSearch');
+        $this->reset('memberSearch');
         unset($this->activeMembers, $this->pendingRequests, $this->availableUsers);
-        Flux::toast(text: "{$user->name} added to group.");
+
+        $count = $users->count();
+        Flux::toast(text: $count === 1
+            ? "{$users->first()->name} added to group."
+            : "{$count} members added to group.");
     }
 
     public function removeMember(int $userId): void
@@ -300,6 +425,114 @@ new class extends Component {
         });
     }
 
+    public function setMemberRole(int $userId, string $role): void
+    {
+        $this->authorize('manageMembers', $this->group);
+
+        $targetRole = GroupRole::from($role);
+
+        DB::transaction(function () use ($userId, $targetRole): void {
+            $user = $this->group->members()
+                ->whereKey($userId)
+                ->lockForUpdate()
+                ->firstOrFail();
+
+            if ($user->pivot->role === $targetRole) {
+                return;
+            }
+
+            if ($user->pivot->role === GroupRole::LEADER
+                && $targetRole === GroupRole::MEMBER
+                && $this->group->leaders()->lockForUpdate()->count() === 1) {
+                Flux::toast(variant: 'danger', text: 'A group must have at least one leader.');
+
+                return;
+            }
+
+            $this->group->allUsers()->updateExistingPivot($user->id, [
+                'role' => $targetRole,
+            ]);
+
+            unset($this->activeMembers);
+            Flux::toast(text: $targetRole === GroupRole::LEADER
+                ? "{$user->name} promoted to leader."
+                : "{$user->name} changed to member.");
+        });
+    }
+
+    public function pinConversation(int $conversationId): void
+    {
+        $conversation = $this->group->conversations()->whereKey($conversationId)->firstOrFail();
+        $this->authorize('pin', $conversation);
+
+        $conversation->pin(Auth::user());
+
+        unset($this->conversations);
+        Flux::toast(text: 'Conversation pinned.');
+    }
+
+    public function unpinConversation(int $conversationId): void
+    {
+        $conversation = $this->group->conversations()->whereKey($conversationId)->firstOrFail();
+        $this->authorize('pin', $conversation);
+
+        $conversation->unpin();
+
+        unset($this->conversations);
+        Flux::toast(text: 'Conversation unpinned.');
+    }
+
+    public function openDeleteConversation(int $conversationId): void
+    {
+        $this->confirmDeleteId = $conversationId;
+        $this->modal('delete-conversation')->show();
+    }
+
+    public function deleteConversation(): void
+    {
+        if (! $this->confirmDeleteId) {
+            return;
+        }
+
+        $conversation = $this->group->conversations()->whereKey($this->confirmDeleteId)->firstOrFail();
+        $this->authorize('delete', $conversation);
+
+        $conversation->delete();
+
+        $this->confirmDeleteId = null;
+        $this->modal('delete-conversation')->close();
+
+        unset($this->conversations);
+        Flux::toast(text: 'Conversation deleted.');
+    }
+
+    public function previewFor(Conversation $conversation): string
+    {
+        /** @var ?\App\Models\Comment $first */
+        $first = $conversation->firstComment->first();
+
+        if (! $first) {
+            return '';
+        }
+
+        $text = trim(html_entity_decode(strip_tags((string) $first->text), ENT_QUOTES | ENT_HTML5, 'UTF-8'));
+
+        return Str::limit($text, 100);
+    }
+
+    public function previewAuthorFor(Conversation $conversation): string
+    {
+        /** @var ?\App\Models\Comment $first */
+        $first = $conversation->firstComment->first();
+        $commentator = $first?->commentator;
+
+        if ($commentator instanceof User) {
+            return $commentator->name;
+        }
+
+        return $conversation->creator->name ?? 'Unknown';
+    }
+
     private function notifyLeaders(): void
     {
         Notification::send(
@@ -311,15 +544,22 @@ new class extends Component {
 ?>
 
 <section class="w-full">
-    <div class="flex items-start justify-between">
+    <div class="flex items-start justify-between gap-4">
         <div class="flex items-start gap-4">
             @if ($group->image)
                 <img src="{{ Storage::disk('digital-ocean')->url($group->image) }}" alt="{{ $group->name }}" class="size-24 rounded-lg object-cover" />
             @endif
 
             <div>
+                <div class="flex items-center gap-2 text-sm text-zinc-500 dark:text-zinc-400 mb-1">
+                    <a href="{{ route('groups.index') }}" wire:navigate class="hover:text-zinc-700 dark:hover:text-zinc-200">Groups</a>
+                    <flux:icon.chevron-right class="size-3" />
+                    <span>{{ $group->name }}</span>
+                </div>
+
                 <flux:heading size="xl" level="1">{{ $group->name }}</flux:heading>
-                <flux:subheading size="lg">
+
+                <flux:subheading size="lg" class="mt-2">
                     <flux:badge size="sm" :color="$group->visibility->color()">{{ $group->visibility->label() }}</flux:badge>
                     <flux:badge size="sm" :color="$group->messaging->color()">{{ $group->messaging->label() }}</flux:badge>
                     <span class="ml-2">{{ $this->activeMembers->count() }} {{ str('member')->plural($this->activeMembers->count()) }}</span>
@@ -329,7 +569,7 @@ new class extends Component {
 
         <div class="flex items-center gap-2">
             @can('update', $group)
-                <flux:button :href="route('groups.edit', $group)" variant="primary" icon="pencil-square">Edit</flux:button>
+                <flux:button :href="route('groups.edit', $group)" variant="ghost" icon="pencil-square" wire:navigate>Edit group</flux:button>
             @endcan
 
             @if ($this->membership === null && $group->visibility === GroupVisibility::PUBLIC)
@@ -355,13 +595,21 @@ new class extends Component {
     @endif
 
     <flux:tab.group class="mt-8">
-        <flux:tabs wire:model="tab">
+        <flux:tabs wire:model.live="tab">
             @if ($this->conversationsVisible)
-                <flux:tab name="conversations" icon="chat-bubble-left-right">Conversations</flux:tab>
+                <flux:tab name="conversations" icon="chat-bubble-left-right">
+                    Conversations
+                    <span class="ml-1 inline-flex items-center justify-center rounded-full px-1.5 py-px text-[11px] font-semibold {{ $tab === 'conversations' ? 'bg-zinc-200 text-zinc-700 dark:bg-zinc-700 dark:text-zinc-100' : 'bg-zinc-100 text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400' }}">
+                        {{ $this->conversations->count() }}
+                    </span>
+                </flux:tab>
             @endif
             @if ($this->isMember)
                 <flux:tab name="members" icon="user-group">
                     Members
+                    <span class="ml-1 inline-flex items-center justify-center rounded-full px-1.5 py-px text-[11px] font-semibold {{ $tab === 'members' ? 'bg-zinc-200 text-zinc-700 dark:bg-zinc-700 dark:text-zinc-100' : 'bg-zinc-100 text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400' }}">
+                        {{ $this->activeMembers->count() }}
+                    </span>
                     @if ($this->isLeader && $this->pendingRequests->isNotEmpty())
                         <flux:badge size="sm" color="amber" class="ml-1">{{ $this->pendingRequests->count() }}</flux:badge>
                     @endif
@@ -371,49 +619,119 @@ new class extends Component {
 
         @if ($this->conversationsVisible)
             <flux:tab.panel name="conversations">
-                <div class="flex items-center justify-between mb-4">
-                    <flux:heading size="lg">Conversations</flux:heading>
+                <div class="mb-4 flex items-center justify-between gap-3 flex-wrap">
+                    <flux:input
+                        wire:model.live.debounce.300ms="searchConvos"
+                        icon="magnifying-glass"
+                        placeholder="Search conversations…"
+                        class="!w-full sm:!w-[300px]"
+                    />
+
                     @can('create', [Conversation::class, $group])
-                        <flux:button :href="route('groups.conversations.create', $group)" variant="primary" size="sm" icon="plus" wire:navigate>
-                            New Conversation
+                        <flux:button :href="route('groups.conversations.create', $group)" variant="primary" icon="plus" wire:navigate>
+                            Start Conversation
                         </flux:button>
                     @endcan
                 </div>
 
-                @if ($this->conversations->isEmpty())
-                    <div class="text-center py-12">
-                        <flux:icon.chat-bubble-left-right class="mx-auto size-12 text-zinc-400" />
-                        <flux:heading size="lg" class="mt-4">No conversations yet</flux:heading>
-                        @can('create', [Conversation::class, $group])
-                            <flux:subheading>Start the first conversation in this group.</flux:subheading>
-                        @endcan
+                @php
+                    $pinned = $this->filteredConversations->filter(fn (Conversation $c) => $c->isPinned())->values();
+                    $rest = $this->filteredConversations->filter(fn (Conversation $c) => ! $c->isPinned())->values();
+                @endphp
+
+                @if ($this->filteredConversations->isEmpty())
+                    <div class="rounded-xl border border-dashed border-zinc-300 dark:border-zinc-700 py-12 px-6 text-center">
+                        <div class="mx-auto mb-3 flex size-11 items-center justify-center rounded-full bg-zinc-100 text-zinc-400 dark:bg-zinc-800 dark:text-zinc-500">
+                            <flux:icon.chat-bubble-left-right class="size-5" />
+                        </div>
+                        <div class="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+                            {{ $this->searchConvos !== '' ? 'No conversations match.' : 'No conversations yet' }}
+                        </div>
+                        @if ($this->searchConvos === '')
+                            <div class="mt-1 text-[13px] text-zinc-500 dark:text-zinc-400">
+                                Start a thread to get the discussion going.
+                            </div>
+                        @endif
                     </div>
                 @else
-                    <flux:table>
-                        <flux:table.columns>
-                            <flux:table.column>Title</flux:table.column>
-                            <flux:table.column>Started by</flux:table.column>
-                            <flux:table.column>Messages</flux:table.column>
-                            <flux:table.column>Last activity</flux:table.column>
-                        </flux:table.columns>
+                    @if ($pinned->isNotEmpty())
+                        <div class="mb-5">
+                            <div class="flex items-center gap-1.5 px-1 pb-2 text-[11px] font-semibold uppercase tracking-wider text-zinc-400 dark:text-zinc-500">
+                                <flux:icon.bookmark class="size-3" />
+                                Pinned
+                            </div>
 
-                        <flux:table.rows>
-                            @foreach ($this->conversations as $conversation)
-                                <flux:table.row :key="$conversation->id">
-                                    <flux:table.cell>
-                                        <flux:link :href="route('groups.conversations.show', ['group' => $group, 'conversation' => $conversation])" wire:navigate>
-                                            {{ $conversation->title }}
-                                        </flux:link>
-                                    </flux:table.cell>
-                                    <flux:table.cell>{{ $conversation->creator?->name ?? 'Unknown' }}</flux:table.cell>
-                                    <flux:table.cell>{{ $conversation->comments_count }}</flux:table.cell>
-                                    <flux:table.cell class="whitespace-nowrap">
-                                        {{ ($conversation->last_comment_at ?? $conversation->created_at)->diffForHumans() }}
-                                    </flux:table.cell>
-                                </flux:table.row>
-                            @endforeach
-                        </flux:table.rows>
-                    </flux:table>
+                            <div class="flex flex-col">
+                                @foreach ($pinned as $conversation)
+                                    @include('pages.groups._partials.conversation-row', [
+                                        'conversation' => $conversation,
+                                        'group' => $group,
+                                        'isLeader' => $this->isLeader,
+                                        'preview' => $this->previewFor($conversation),
+                                        'previewAuthor' => $this->previewAuthorFor($conversation),
+                                    ])
+                                @endforeach
+                            </div>
+                        </div>
+                    @endif
+
+                    @if ($rest->isNotEmpty())
+                        <div>
+                            @if ($pinned->isNotEmpty())
+                                <div class="px-1 pb-2 text-[11px] font-semibold uppercase tracking-wider text-zinc-400 dark:text-zinc-500">
+                                    All conversations
+                                </div>
+                            @endif
+
+                            <div class="flex flex-col">
+                                @foreach ($rest as $conversation)
+                                    @include('pages.groups._partials.conversation-row', [
+                                        'conversation' => $conversation,
+                                        'group' => $group,
+                                        'isLeader' => $this->isLeader,
+                                        'preview' => $this->previewFor($conversation),
+                                        'previewAuthor' => $this->previewAuthorFor($conversation),
+                                    ])
+                                @endforeach
+                            </div>
+                        </div>
+                    @endif
+                @endif
+
+                @if ($this->isLeader)
+                <flux:modal name="delete-conversation" class="min-w-[26rem]">
+                    @php
+                        $deleting = $this->confirmDeleteId
+                            ? $this->conversations->firstWhere('id', $this->confirmDeleteId)
+                            : null;
+                    @endphp
+
+                    <form wire:submit="deleteConversation" class="space-y-5">
+                        <div class="flex flex-col items-center text-center">
+                            <div class="mb-3 flex size-10 items-center justify-center rounded-full bg-red-100 text-red-600 dark:bg-red-900/40 dark:text-red-300">
+                                <flux:icon.trash class="size-5" />
+                            </div>
+                            <flux:heading size="lg">Delete this conversation?</flux:heading>
+                            <flux:subheading class="mt-2">
+                                @if ($deleting)
+                                    <span class="font-semibold text-zinc-700 dark:text-zinc-200">"{{ $deleting->title }}"</span>
+                                    and all
+                                    {{ $deleting->comments_count }}
+                                    {{ str('reply')->plural($deleting->comments_count) }}
+                                    will be permanently removed. This cannot be undone.
+                                @endif
+                            </flux:subheading>
+                        </div>
+
+                        <div class="flex justify-end gap-2 border-t border-zinc-200 dark:border-zinc-700 -mx-6 -mb-6 px-6 py-4 bg-zinc-50 dark:bg-zinc-900/40 rounded-b-lg">
+                            <flux:modal.close>
+                                <flux:button variant="ghost" type="button">Cancel</flux:button>
+                            </flux:modal.close>
+
+                            <flux:button type="submit" variant="danger" icon="trash">Delete conversation</flux:button>
+                        </div>
+                    </form>
+                </flux:modal>
                 @endif
             </flux:tab.panel>
         @endif
@@ -450,66 +768,67 @@ new class extends Component {
                     </div>
                 @endif
 
-                {{-- Active Members --}}
-                <div class="mb-8">
-                    <flux:heading size="lg" class="mb-3">Members</flux:heading>
+                {{-- Toolbar --}}
+                <div class="mb-4 flex items-center justify-between gap-3 flex-wrap">
+                    <div class="flex items-center gap-3 flex-wrap">
+                        <flux:input
+                            wire:model.live.debounce.300ms="searchMembers"
+                            icon="magnifying-glass"
+                            placeholder="Search members…"
+                            class="!w-full sm:!w-[260px]"
+                        />
 
-                    <flux:table>
-                        <flux:table.columns>
-                            <flux:table.column>Name</flux:table.column>
-                            <flux:table.column>Role</flux:table.column>
-                            <flux:table.column>Joined</flux:table.column>
-                            @if ($this->isLeader)
-                                <flux:table.column></flux:table.column>
-                            @endif
-                        </flux:table.columns>
-
-                        <flux:table.rows>
-                            @foreach ($this->activeMembers as $user)
-                                <flux:table.row :key="$user->id">
-                                    <flux:table.cell>{{ $user->name }}</flux:table.cell>
-                                    <flux:table.cell>
-                                        <flux:badge size="sm" inset="top bottom" :color="$user->pivot->role->color()">
-                                            {{ $user->pivot->role->label() }}
-                                        </flux:badge>
-                                    </flux:table.cell>
-                                    <flux:table.cell class="whitespace-nowrap">{{ $user->pivot->created_at->diffForHumans() }}</flux:table.cell>
-                                    @if ($this->isLeader)
-                                        <flux:table.cell align="end">
-                                            @if ($user->id !== Auth::id())
-                                                <flux:button wire:click="removeMember({{ $user->id }})" variant="ghost" size="sm" icon="trash"
-                                                    wire:confirm="Remove {{ $user->name }} from this group?" />
-                                            @endif
-                                        </flux:table.cell>
-                                    @endif
-                                </flux:table.row>
+                        <div role="tablist" class="inline-flex items-center gap-1 rounded-lg border border-zinc-200 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-800/60 p-1">
+                            @foreach ([
+                                'all' => "All · {$this->activeMembers->count()}",
+                                'leader' => "Leaders · {$this->leaderCount}",
+                                'member' => 'Members · ' . ($this->activeMembers->count() - $this->leaderCount),
+                            ] as $value => $label)
+                                <button
+                                    type="button"
+                                    wire:click="$set('memberFilter', '{{ $value }}')"
+                                    class="rounded-md px-3 py-1 text-xs font-semibold whitespace-nowrap transition {{ $memberFilter === $value ? 'bg-white shadow-sm text-zinc-800 dark:bg-zinc-700 dark:text-zinc-100' : 'text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-200' }}">
+                                    {{ $label }}
+                                </button>
                             @endforeach
-                        </flux:table.rows>
-                    </flux:table>
+                        </div>
+                    </div>
+
+                    @if ($this->isLeader)
+                        @include('pages.groups._partials.add-member-popover', [
+                            'group' => $group,
+                            'availableUsers' => $this->availableUsers,
+                            'pickedUsers' => $this->pickedUsers,
+                            'memberSearch' => $memberSearch,
+                            'addMemberOpen' => $addMemberOpen,
+                        ])
+                    @endif
                 </div>
 
-                {{-- Add Member (leaders only) --}}
-                @if ($this->isLeader)
-                    <div>
-                        <flux:heading size="lg" class="mb-3">Add Member</flux:heading>
-
-                        <form wire:submit="addMember" class="flex items-end gap-3 max-w-md">
-                            <div class="flex-1">
-                                <flux:select wire:model="selectedUserId" variant="combobox" :filter="false" placeholder="Search users..." clearable>
-                                    <x-slot name="input">
-                                        <flux:select.input wire:model.live.debounce.300ms="memberSearch" placeholder="Search by name..." />
-                                    </x-slot>
-
-                                    @foreach ($this->availableUsers as $user)
-                                        <flux:select.option :value="$user->id" wire:key="add-{{ $user->id }}">{{ $user->name }}</flux:select.option>
-                                    @endforeach
-                                </flux:select>
-                            </div>
-
-                            <flux:button type="submit" variant="primary" icon="user-plus">Add</flux:button>
-                        </form>
+                {{-- Members card --}}
+                <div class="overflow-hidden rounded-xl border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900">
+                    <div class="grid items-center gap-4 border-b border-zinc-200 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-800/60 px-4 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400"
+                        style="grid-template-columns: 1fr 180px 160px 44px;">
+                        <div>Member</div>
+                        <div>Role</div>
+                        <div>Joined</div>
+                        <div></div>
                     </div>
-                @endif
+
+                    @if ($this->filteredMembers->isEmpty())
+                        <div class="px-4 py-12 text-center text-[13px] text-zinc-500 dark:text-zinc-400">
+                            No members match your search.
+                        </div>
+                    @else
+                        @foreach ($this->filteredMembers as $user)
+                            @include('pages.groups._partials.member-row', [
+                                'user' => $user,
+                                'isLeader' => $this->isLeader,
+                                'isOnlyLeader' => $user->pivot->role === GroupRole::LEADER && $this->leaderCount === 1,
+                            ])
+                        @endforeach
+                    @endif
+                </div>
             </flux:tab.panel>
         @endif
     </flux:tab.group>

--- a/resources/views/pages/groups/show.blade.php
+++ b/resources/views/pages/groups/show.blade.php
@@ -429,7 +429,10 @@ new class extends Component {
     {
         $this->authorize('manageMembers', $this->group);
 
-        $targetRole = GroupRole::from($role);
+        $targetRole = GroupRole::tryFrom($role);
+        if (! $targetRole) {
+            return;
+        }
 
         DB::transaction(function () use ($userId, $targetRole): void {
             $user = $this->group->members()

--- a/tests/Feature/GroupConversationDeleteFromListTest.php
+++ b/tests/Feature/GroupConversationDeleteFromListTest.php
@@ -1,0 +1,106 @@
+<?php
+
+use App\Enums\GroupMessaging;
+use App\Enums\GroupRole;
+use App\Enums\GroupVisibility;
+use App\Enums\MembershipStatus;
+use App\Models\Conversation;
+use App\Models\Group;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+function deleteListGroup(): Group
+{
+    return Group::factory()->create([
+        'visibility' => GroupVisibility::PUBLIC,
+        'messaging' => GroupMessaging::ALL_MEMBERS,
+    ]);
+}
+
+function attachDel(Group $group, User $user, GroupRole $role = GroupRole::MEMBER): void
+{
+    $group->allUsers()->attach($user, [
+        'role' => $role,
+        'status' => MembershipStatus::ACTIVE,
+    ]);
+}
+
+test('a leader can delete a conversation from the list', function (): void {
+    $leader = User::factory()->create();
+    $group = deleteListGroup();
+    attachDel($group, $leader, GroupRole::LEADER);
+
+    $conversation = Conversation::factory()->create([
+        'group_id' => $group->id,
+        'user_id' => $leader->id,
+    ]);
+
+    Livewire::actingAs($leader)
+        ->test('pages::groups.show', ['group' => $group])
+        ->call('openDeleteConversation', $conversation->id)
+        ->assertSet('confirmDeleteId', $conversation->id)
+        ->call('deleteConversation');
+
+    expect(Conversation::find($conversation->id))->toBeNull();
+});
+
+test('a regular member cannot delete a conversation from the list', function (): void {
+    $member = User::factory()->create();
+    $leader = User::factory()->create();
+    $group = deleteListGroup();
+    attachDel($group, $leader, GroupRole::LEADER);
+    attachDel($group, $member);
+
+    $conversation = Conversation::factory()->create([
+        'group_id' => $group->id,
+        'user_id' => $leader->id,
+    ]);
+
+    Livewire::actingAs($member)
+        ->test('pages::groups.show', ['group' => $group])
+        ->set('confirmDeleteId', $conversation->id)
+        ->call('deleteConversation')
+        ->assertForbidden();
+
+    expect(Conversation::find($conversation->id))->not->toBeNull();
+});
+
+test('deleting clears the confirm id and closes the modal', function (): void {
+    $leader = User::factory()->create();
+    $group = deleteListGroup();
+    attachDel($group, $leader, GroupRole::LEADER);
+
+    $conversation = Conversation::factory()->create([
+        'group_id' => $group->id,
+        'user_id' => $leader->id,
+    ]);
+
+    Livewire::actingAs($leader)
+        ->test('pages::groups.show', ['group' => $group])
+        ->call('openDeleteConversation', $conversation->id)
+        ->call('deleteConversation')
+        ->assertSet('confirmDeleteId', null);
+});
+
+test('delete confirmation modal is not triggered for non-leaders viewing the page', function (): void {
+    $member = User::factory()->create();
+    $leader = User::factory()->create();
+    $group = deleteListGroup();
+    attachDel($group, $leader, GroupRole::LEADER);
+    attachDel($group, $member);
+
+    Conversation::factory()->create([
+        'group_id' => $group->id,
+        'user_id' => $leader->id,
+        'title' => 'A normal thread',
+    ]);
+
+    $this->actingAs($member)
+        ->get("/groups/{$group->id}")
+        ->assertSuccessful()
+        ->assertSee('A normal thread')
+        ->assertDontSee('Delete conversation');
+});

--- a/tests/Feature/GroupConversationPinTest.php
+++ b/tests/Feature/GroupConversationPinTest.php
@@ -1,0 +1,136 @@
+<?php
+
+use App\Enums\GroupMessaging;
+use App\Enums\GroupRole;
+use App\Enums\GroupVisibility;
+use App\Enums\MembershipStatus;
+use App\Models\Conversation;
+use App\Models\Group;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+function pinTestGroup(): Group
+{
+    return Group::factory()->create([
+        'visibility' => GroupVisibility::PUBLIC,
+        'messaging' => GroupMessaging::ALL_MEMBERS,
+    ]);
+}
+
+function attachPin(Group $group, User $user, GroupRole $role = GroupRole::MEMBER): void
+{
+    $group->allUsers()->attach($user, [
+        'role' => $role,
+        'status' => MembershipStatus::ACTIVE,
+    ]);
+}
+
+test('a leader can pin a conversation', function (): void {
+    $leader = User::factory()->create();
+    $group = pinTestGroup();
+    attachPin($group, $leader, GroupRole::LEADER);
+
+    $conversation = Conversation::factory()->create([
+        'group_id' => $group->id,
+        'user_id' => $leader->id,
+    ]);
+
+    Livewire::actingAs($leader)
+        ->test('pages::groups.show', ['group' => $group])
+        ->call('pinConversation', $conversation->id);
+
+    expect($conversation->refresh()->pinned_at)->not->toBeNull();
+    expect($conversation->pinned_by_user_id)->toBe($leader->id);
+});
+
+test('a leader can unpin a conversation', function (): void {
+    $leader = User::factory()->create();
+    $group = pinTestGroup();
+    attachPin($group, $leader, GroupRole::LEADER);
+
+    $conversation = Conversation::factory()->create([
+        'group_id' => $group->id,
+        'user_id' => $leader->id,
+    ]);
+    $conversation->pin($leader);
+
+    Livewire::actingAs($leader)
+        ->test('pages::groups.show', ['group' => $group])
+        ->call('unpinConversation', $conversation->id);
+
+    expect($conversation->refresh()->pinned_at)->toBeNull();
+    expect($conversation->pinned_by_user_id)->toBeNull();
+});
+
+test('a regular member cannot pin a conversation', function (): void {
+    $member = User::factory()->create();
+    $leader = User::factory()->create();
+    $group = pinTestGroup();
+    attachPin($group, $leader, GroupRole::LEADER);
+    attachPin($group, $member);
+
+    $conversation = Conversation::factory()->create([
+        'group_id' => $group->id,
+        'user_id' => $leader->id,
+    ]);
+
+    Livewire::actingAs($member)
+        ->test('pages::groups.show', ['group' => $group])
+        ->call('pinConversation', $conversation->id)
+        ->assertForbidden();
+
+    expect($conversation->refresh()->pinned_at)->toBeNull();
+});
+
+test('pinned conversations sort before unpinned ones', function (): void {
+    $leader = User::factory()->create();
+    $group = pinTestGroup();
+    attachPin($group, $leader, GroupRole::LEADER);
+
+    $oldUnpinned = Conversation::factory()->create([
+        'group_id' => $group->id,
+        'user_id' => $leader->id,
+        'last_comment_at' => now()->subDay(),
+    ]);
+    $newUnpinned = Conversation::factory()->create([
+        'group_id' => $group->id,
+        'user_id' => $leader->id,
+        'last_comment_at' => now()->subHour(),
+    ]);
+    $pinned = Conversation::factory()->create([
+        'group_id' => $group->id,
+        'user_id' => $leader->id,
+        'last_comment_at' => now()->subWeek(),
+    ]);
+    $pinned->pin($leader);
+
+    $component = Livewire::actingAs($leader)
+        ->test('pages::groups.show', ['group' => $group]);
+
+    $conversations = $component->invade()->conversations;
+
+    expect($conversations->first()->id)->toBe($pinned->id);
+    expect($conversations->skip(1)->first()->id)->toBe($newUnpinned->id);
+    expect($conversations->last()->id)->toBe($oldUnpinned->id);
+});
+
+test('the conversations list shows a Pinned section when conversations are pinned', function (): void {
+    $leader = User::factory()->create();
+    $group = pinTestGroup();
+    attachPin($group, $leader, GroupRole::LEADER);
+
+    $conversation = Conversation::factory()->create([
+        'group_id' => $group->id,
+        'user_id' => $leader->id,
+    ]);
+    $conversation->pin($leader);
+
+    $this->actingAs($leader)
+        ->get("/groups/{$group->id}")
+        ->assertSuccessful()
+        ->assertSee('Pinned')
+        ->assertSee($conversation->title);
+});

--- a/tests/Feature/GroupJoinTest.php
+++ b/tests/Feature/GroupJoinTest.php
@@ -233,8 +233,7 @@ test('leader can directly add a member', function (): void {
     $this->actingAs($leader);
 
     Livewire::test('pages::groups.show', ['group' => $group])
-        ->set('selectedUserId', $user->id)
-        ->call('addMember')
+        ->call('addMembers', [$user->id])
         ->assertHasNoErrors();
 
     $this->assertDatabaseHas('group_user', [
@@ -256,8 +255,7 @@ test('non-leader cannot add a member', function (): void {
     $this->actingAs($member);
 
     Livewire::test('pages::groups.show', ['group' => $group])
-        ->set('selectedUserId', $user->id)
-        ->call('addMember')
+        ->call('addMembers', [$user->id])
         ->assertForbidden();
 });
 
@@ -344,7 +342,7 @@ test('members tab is visible to leaders', function (): void {
 
     Livewire::test('pages::groups.show', ['group' => $group])
         ->set('tab', 'members')
-        ->assertSee('Add Member')
+        ->assertSee('Add member')
         ->assertSee($member->name);
 });
 
@@ -362,7 +360,7 @@ test('members tab is visible to regular members', function (): void {
     Livewire::test('pages::groups.show', ['group' => $group])
         ->set('tab', 'members')
         ->assertSee($leader->name)
-        ->assertDontSee('Add Member')
+        ->assertDontSee('Add member')
         ->assertDontSee($pending->name)
         ->assertDontSee('Pending Requests');
 });
@@ -378,7 +376,7 @@ test('members tab is not visible to non-members', function (): void {
     Livewire::test('pages::groups.show', ['group' => $group])
         ->set('tab', 'members')
         ->assertDontSee($leader->name)
-        ->assertDontSee('Add Member');
+        ->assertDontSee('Add member');
 });
 
 // --- Show Page Content ---

--- a/tests/Feature/GroupMemberRoleChangeTest.php
+++ b/tests/Feature/GroupMemberRoleChangeTest.php
@@ -1,0 +1,120 @@
+<?php
+
+use App\Enums\GroupMessaging;
+use App\Enums\GroupRole;
+use App\Enums\GroupVisibility;
+use App\Enums\MembershipStatus;
+use App\Models\Group;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+function roleGroup(): Group
+{
+    return Group::factory()->create([
+        'visibility' => GroupVisibility::PUBLIC,
+        'messaging' => GroupMessaging::ALL_MEMBERS,
+    ]);
+}
+
+function attachRole(Group $group, User $user, GroupRole $role = GroupRole::MEMBER): void
+{
+    $group->allUsers()->attach($user, [
+        'role' => $role,
+        'status' => MembershipStatus::ACTIVE,
+    ]);
+}
+
+test('a leader can promote a member to leader', function (): void {
+    $leader = User::factory()->create();
+    $member = User::factory()->create();
+    $group = roleGroup();
+    attachRole($group, $leader, GroupRole::LEADER);
+    attachRole($group, $member);
+
+    Livewire::actingAs($leader)
+        ->test('pages::groups.show', ['group' => $group])
+        ->call('setMemberRole', $member->id, 'leader');
+
+    $pivot = $group->allUsers()->whereKey($member->id)->first()->pivot;
+    expect($pivot->role)->toBe(GroupRole::LEADER);
+});
+
+test('a leader can demote another leader to member', function (): void {
+    $leaderA = User::factory()->create();
+    $leaderB = User::factory()->create();
+    $group = roleGroup();
+    attachRole($group, $leaderA, GroupRole::LEADER);
+    attachRole($group, $leaderB, GroupRole::LEADER);
+
+    Livewire::actingAs($leaderA)
+        ->test('pages::groups.show', ['group' => $group])
+        ->call('setMemberRole', $leaderB->id, 'member');
+
+    $pivot = $group->allUsers()->whereKey($leaderB->id)->first()->pivot;
+    expect($pivot->role)->toBe(GroupRole::MEMBER);
+});
+
+test('the last leader cannot be demoted', function (): void {
+    $onlyLeader = User::factory()->create();
+    $member = User::factory()->create();
+    $group = roleGroup();
+    attachRole($group, $onlyLeader, GroupRole::LEADER);
+    attachRole($group, $member);
+
+    Livewire::actingAs($onlyLeader)
+        ->test('pages::groups.show', ['group' => $group])
+        ->call('setMemberRole', $onlyLeader->id, 'member');
+
+    $pivot = $group->allUsers()->whereKey($onlyLeader->id)->first()->pivot;
+    expect($pivot->role)->toBe(GroupRole::LEADER);
+});
+
+test('the last leader cannot be removed from the group', function (): void {
+    $onlyLeader = User::factory()->create();
+    $member = User::factory()->create();
+    $group = roleGroup();
+    attachRole($group, $onlyLeader, GroupRole::LEADER);
+    attachRole($group, $member);
+
+    Livewire::actingAs($onlyLeader)
+        ->test('pages::groups.show', ['group' => $group])
+        ->call('removeMember', $onlyLeader->id);
+
+    expect($group->allUsers()->whereKey($onlyLeader->id)->exists())->toBeTrue();
+});
+
+test('a regular member cannot change roles', function (): void {
+    $leader = User::factory()->create();
+    $member = User::factory()->create();
+    $other = User::factory()->create();
+    $group = roleGroup();
+    attachRole($group, $leader, GroupRole::LEADER);
+    attachRole($group, $member);
+    attachRole($group, $other);
+
+    Livewire::actingAs($member)
+        ->test('pages::groups.show', ['group' => $group])
+        ->call('setMemberRole', $other->id, 'leader')
+        ->assertForbidden();
+
+    $pivot = $group->allUsers()->whereKey($other->id)->first()->pivot;
+    expect($pivot->role)->toBe(GroupRole::MEMBER);
+});
+
+test('setting a role to the same value is a no-op', function (): void {
+    $leader = User::factory()->create();
+    $member = User::factory()->create();
+    $group = roleGroup();
+    attachRole($group, $leader, GroupRole::LEADER);
+    attachRole($group, $member);
+
+    Livewire::actingAs($leader)
+        ->test('pages::groups.show', ['group' => $group])
+        ->call('setMemberRole', $member->id, 'member');
+
+    $pivot = $group->allUsers()->whereKey($member->id)->first()->pivot;
+    expect($pivot->role)->toBe(GroupRole::MEMBER);
+});

--- a/tests/Feature/GroupTest.php
+++ b/tests/Feature/GroupTest.php
@@ -387,3 +387,66 @@ test('leaders can delete a group from the edit page', function (): void {
 
     $this->assertDatabaseMissing('groups', ['id' => $group->id]);
 });
+
+test('leaders can add multiple members in one batch', function (): void {
+    $leader = User::factory()->create();
+    $alice = User::factory()->create(['name' => 'Alice']);
+    $bob = User::factory()->create(['name' => 'Bob']);
+    $group = Group::factory()->create([
+        'visibility' => GroupVisibility::PUBLIC,
+        'messaging' => GroupMessaging::ALL_MEMBERS,
+    ]);
+    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => MembershipStatus::ACTIVE]);
+
+    Livewire::actingAs($leader)
+        ->test('pages::groups.show', ['group' => $group])
+        ->call('addMembers', [$alice->id, $bob->id]);
+
+    expect($group->members()->whereKey($alice->id)->exists())->toBeTrue();
+    expect($group->members()->whereKey($bob->id)->exists())->toBeTrue();
+
+    $alicePivot = $group->allUsers()->whereKey($alice->id)->first()->pivot;
+    $bobPivot = $group->allUsers()->whereKey($bob->id)->first()->pivot;
+    expect($alicePivot->role)->toBe(GroupRole::MEMBER);
+    expect($bobPivot->role)->toBe(GroupRole::MEMBER);
+});
+
+test('regular members cannot add members via addMembers', function (): void {
+    $member = User::factory()->create();
+    $leader = User::factory()->create();
+    $newcomer = User::factory()->create();
+    $group = Group::factory()->create([
+        'visibility' => GroupVisibility::PUBLIC,
+        'messaging' => GroupMessaging::ALL_MEMBERS,
+    ]);
+    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($member, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+
+    Livewire::actingAs($member)
+        ->test('pages::groups.show', ['group' => $group])
+        ->call('addMembers', [$newcomer->id])
+        ->assertForbidden();
+
+    expect($group->members()->whereKey($newcomer->id)->exists())->toBeFalse();
+});
+
+test('addMembers picks up users via the popover pickUser flow', function (): void {
+    $leader = User::factory()->create();
+    $candidate = User::factory()->create();
+    $group = Group::factory()->create([
+        'visibility' => GroupVisibility::PUBLIC,
+        'messaging' => GroupMessaging::ALL_MEMBERS,
+    ]);
+    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => MembershipStatus::ACTIVE]);
+
+    Livewire::actingAs($leader)
+        ->test('pages::groups.show', ['group' => $group])
+        ->call('openAddMember')
+        ->call('pickUser', $candidate->id)
+        ->assertSet('pickedUserIds', [$candidate->id])
+        ->call('confirmAddMembers')
+        ->assertSet('addMemberOpen', false)
+        ->assertSet('pickedUserIds', []);
+
+    expect($group->members()->whereKey($candidate->id)->exists())->toBeTrue();
+});


### PR DESCRIPTION
## Summary

- Adds conversation pinning/unpinning for group leaders, with pinned conversations sorted to the top in a dedicated section
- Introduces inline role management (promote to leader / demote to member) with last-leader safeguard
- Replaces single-user add with a batch member-add popover featuring chip-input UX and multi-select
- Adds search/filter for both conversations and members, plus a delete-from-list confirmation modal
- Extracts conversation-row, member-row, and add-member-popover into blade partials for maintainability

## Test plan

- [ ] Verify pinning/unpinning conversations as a leader; confirm pinned section appears
- [ ] Verify regular members cannot pin, delete, or change roles
- [ ] Test batch-adding multiple members via the popover
- [ ] Test promoting/demoting members; confirm last leader cannot be demoted
- [ ] Test conversation search filtering and member role/name filtering
- [ ] Run `php artisan test` — all 75 group-related tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Group leaders can now pin and unpin conversations for easy reference
  * Bulk add multiple members to groups in a single action
  * Manage member roles—promote members to leader status or demote as needed
  * Delete conversations from group lists (leaders only)
  * Improved conversation organization with pinned conversations appearing at the top

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jpangborn/stave/pull/108?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->