### PR TITLE
Add allow_replies toggle and pin-on-create for group conversations

### DIFF
--- a/app/Models/Conversation.php
+++ b/app/Models/Conversation.php
@@ -17,8 +17,9 @@ use Spatie\Comments\Models\Concerns\Interfaces\CanComment;
  * @property ?Carbon $last_comment_at
  * @property ?Carbon $pinned_at
  * @property ?int $pinned_by_user_id
+ * @property bool $allow_replies
  */
-#[Fillable(['group_id', 'user_id', 'title'])]
+#[Fillable(['group_id', 'user_id', 'title', 'allow_replies'])]
 class Conversation extends Model
 {
     /** @use HasFactory<ConversationFactory> */
@@ -30,7 +31,13 @@ class Conversation extends Model
         return [
             'last_comment_at' => 'datetime',
             'pinned_at' => 'datetime',
+            'allow_replies' => 'boolean',
         ];
+    }
+
+    public function allowsReplies(): bool
+    {
+        return (bool) $this->allow_replies;
     }
 
     /** @return BelongsTo<Group, $this> */

--- a/app/Policies/ConversationPolicy.php
+++ b/app/Policies/ConversationPolicy.php
@@ -26,7 +26,15 @@ class ConversationPolicy
 
     public function comment(User $user, Conversation $conversation): bool
     {
-        return $this->canPost($user, $conversation->group);
+        if (! $this->canPost($user, $conversation->group)) {
+            return false;
+        }
+
+        if (! $conversation->allowsReplies()) {
+            return $conversation->group->hasLeader($user);
+        }
+
+        return true;
     }
 
     public function update(User $user, Conversation $conversation): bool
@@ -40,6 +48,11 @@ class ConversationPolicy
     }
 
     public function pin(User $user, Conversation $conversation): bool
+    {
+        return $conversation->group->hasLeader($user);
+    }
+
+    public function updateReplies(User $user, Conversation $conversation): bool
     {
         return $conversation->group->hasLeader($user);
     }

--- a/database/factories/ConversationFactory.php
+++ b/database/factories/ConversationFactory.php
@@ -21,7 +21,13 @@ class ConversationFactory extends Factory
             'group_id' => Group::factory(),
             'user_id' => User::factory(),
             'title' => $this->faker->sentence(4),
+            'allow_replies' => true,
             'last_comment_at' => null,
         ];
+    }
+
+    public function repliesDisabled(): self
+    {
+        return $this->state(['allow_replies' => false]);
     }
 }

--- a/database/migrations/2026_05_17_214838_add_allow_replies_to_conversations_table.php
+++ b/database/migrations/2026_05_17_214838_add_allow_replies_to_conversations_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('conversations', function (Blueprint $table): void {
+            $table->boolean('allow_replies')->default(true)->after('title');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('conversations', function (Blueprint $table): void {
+            $table->dropColumn('allow_replies');
+        });
+    }
+};

--- a/resources/views/pages/groups/conversations/create.blade.php
+++ b/resources/views/pages/groups/conversations/create.blade.php
@@ -4,22 +4,41 @@ use App\Models\Conversation;
 use App\Models\Group;
 use App\Notifications\NewConversationNotification;
 use Flux\Flux;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Notification;
+use Livewire\Attributes\Computed;
 use Livewire\Component;
 
 new class extends Component {
     public Group $group;
 
     public string $title = '';
+
     public string $body = '';
+
+    public bool $allowReplies = true;
+
+    public bool $pinOnPost = false;
 
     public function mount(Group $group): void
     {
         $this->authorize('create', [Conversation::class, $group]);
 
         $this->group = $group;
+    }
+
+    #[Computed]
+    public function isLeader(): bool
+    {
+        return $this->group->hasLeader(Auth::user());
+    }
+
+    #[Computed]
+    public function leaders(): Collection
+    {
+        return $this->group->leaders()->get();
     }
 
     public function save(): void
@@ -29,6 +48,8 @@ new class extends Component {
         $validated = $this->validate([
             'title' => ['required', 'string', 'max:255'],
             'body' => ['required', 'string'],
+            'allowReplies' => ['boolean'],
+            'pinOnPost' => ['boolean'],
         ]);
 
         if (trim(strip_tags($validated['body'])) === '') {
@@ -37,13 +58,20 @@ new class extends Component {
             return;
         }
 
-        $conversation = DB::transaction(function () use ($validated): Conversation {
+        $shouldPin = $this->pinOnPost && $this->isLeader;
+
+        $conversation = DB::transaction(function () use ($validated, $shouldPin): Conversation {
             $conversation = $this->group->conversations()->create([
                 'user_id' => Auth::id(),
                 'title' => $validated['title'],
+                'allow_replies' => (bool) $validated['allowReplies'],
             ]);
 
             $conversation->postComment($validated['body'], Auth::user());
+
+            if ($shouldPin) {
+                $conversation->pin(Auth::user());
+            }
 
             return $conversation;
         });
@@ -58,6 +86,11 @@ new class extends Component {
         ]), navigate: true);
     }
 
+    public function cancel(): void
+    {
+        $this->redirect(route('groups.show', $this->group), navigate: true);
+    }
+
     private function notifyMembers(Conversation $conversation): void
     {
         $recipients = $this->group->members()
@@ -69,28 +102,178 @@ new class extends Component {
 };
 ?>
 
-<section class="w-full">
-    <flux:heading size="xl" level="1">Start a Conversation</flux:heading>
-    <flux:subheading size="lg" class="mb-6">Post a new conversation in {{ $group->name }}.</flux:subheading>
+<section
+    class="mx-auto w-full max-w-[980px] space-y-7 pb-16"
+    x-data
+    @keydown.escape.window="$wire.cancel()"
+    @keydown.meta.enter.window.prevent="$wire.save()"
+    @keydown.ctrl.enter.window.prevent="$wire.save()"
+>
+    {{-- Header --}}
+    <header class="space-y-2">
+        <div class="flex flex-wrap items-center gap-2.5">
+            <a
+                href="{{ route('groups.show', $group) }}"
+                wire:navigate
+                title="Back to {{ $group->name }}"
+                aria-label="Back to {{ $group->name }}"
+                class="inline-flex items-center gap-1.5 rounded-full bg-zinc-100 py-1 pl-2 pr-2.5 text-xs font-semibold leading-none text-zinc-900 transition-colors duration-100 hover:bg-zinc-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 dark:bg-zinc-700 dark:text-zinc-100 dark:hover:bg-zinc-600"
+                data-test="back-to-group"
+            >
+                <flux:icon.arrow-left variant="micro" class="size-3" />
+                {{ $group->name }}
+            </a>
+            <flux:heading size="xl" level="1">Start a Conversation</flux:heading>
+        </div>
+        <flux:subheading>
+            Post a new conversation in <span class="font-semibold text-zinc-900 dark:text-zinc-100">{{ $group->name }}</span>.
+        </flux:subheading>
+    </header>
 
-    <form wire:submit="save" class="max-w-2xl space-y-6">
+    <form wire:submit="save" class="space-y-6">
+        {{-- Title --}}
         <flux:field>
             <flux:label badge="Required">Title</flux:label>
-            <flux:input type="text" name="title" wire:model="title" />
+            <flux:input
+                type="text"
+                name="title"
+                wire:model="title"
+                placeholder="e.g. Sunday Service Planning"
+                autofocus
+            />
             <flux:error name="title" />
         </flux:field>
 
-        <flux:editor
-            label="Message"
-            wire:model="body"
-            toolbar="heading | bold italic underline strike | bullet ordered blockquote | link ~ undo redo"
-            class="**:data-[slot=content]:min-h-[200px]"
-        />
-        <flux:error name="body" />
+        {{-- Message --}}
+        <flux:field>
+            <flux:label badge="Required">Message</flux:label>
+            <flux:editor
+                wire:model="body"
+                toolbar="heading | bold italic underline strike | bullet ordered blockquote | link ~ undo redo"
+                class="**:data-[slot=content]:min-h-[200px]"
+            />
+            <flux:error name="body" />
+        </flux:field>
 
-        <div class="flex items-center gap-2">
-            <flux:button type="submit" variant="primary" icon="paper-airplane">Post</flux:button>
-            <flux:button :href="route('groups.show', $group)" variant="ghost" wire:navigate>Cancel</flux:button>
+        {{-- Settings --}}
+        <div class="space-y-2" data-test="settings-card">
+            <flux:label>Settings</flux:label>
+            <div
+                @class([
+                    'overflow-hidden rounded-xl border transition-colors duration-200',
+                    'border-zinc-200 bg-white dark:border-zinc-700 dark:bg-zinc-900' => $allowReplies,
+                    'border-yellow-300 bg-yellow-50 dark:border-yellow-700 dark:bg-yellow-900/20' => ! $allowReplies,
+                ])
+            >
+                {{-- Allow replies row --}}
+                <div class="flex items-start gap-3.5 p-4" data-test="allow-replies-row">
+                    <div
+                        @class([
+                            'grid size-7 shrink-0 place-items-center rounded-lg transition-colors duration-200',
+                            'bg-accent/10 text-accent' => $allowReplies,
+                            'bg-yellow-100 text-yellow-700 dark:bg-yellow-800/50 dark:text-yellow-200' => ! $allowReplies,
+                        ])
+                    >
+                        @if ($allowReplies)
+                            <flux:icon.chat-bubble-left-right variant="micro" />
+                        @else
+                            <flux:icon.lock-closed variant="micro" />
+                        @endif
+                    </div>
+                    <div class="min-w-0 flex-1">
+                        <div class="text-sm font-semibold text-zinc-900 dark:text-zinc-100">Allow replies</div>
+                        <div class="mt-0.5 text-xs leading-relaxed text-zinc-600 dark:text-zinc-400">
+                            @if ($allowReplies)
+                                Anyone in this group can post replies.
+                            @else
+                                Replies are turned off. Only group leaders will be able to post in this conversation.
+                            @endif
+                        </div>
+                    </div>
+                    <div class="shrink-0">
+                        <flux:switch wire:model.live="allowReplies" data-test="allow-replies-switch" />
+                    </div>
+                </div>
+
+                {{-- Leader preview --}}
+                @if (! $allowReplies)
+                    <div
+                        class="border-t border-yellow-300 bg-yellow-100/60 px-4 py-3 pl-[3.75rem] dark:border-yellow-700 dark:bg-yellow-900/30"
+                        data-test="leader-preview"
+                    >
+                        <div class="text-[11px] font-semibold uppercase tracking-wider text-yellow-800 dark:text-yellow-200">
+                            Leaders who can post · {{ $this->leaders->count() }}
+                        </div>
+                        <div class="mt-2 flex flex-wrap gap-1.5">
+                            @forelse ($this->leaders as $leader)
+                                <span class="inline-flex items-center gap-1.5 rounded-full border border-yellow-300 bg-white py-0.5 pl-0.5 pr-2.5 dark:border-yellow-700 dark:bg-zinc-900">
+                                    <flux:avatar
+                                        size="xs"
+                                        name="{{ $leader->name }}"
+                                        src="{{ $leader->gravatar }}"
+                                        color="auto"
+                                    />
+                                    <span class="text-xs font-semibold text-yellow-900 dark:text-yellow-100">{{ $leader->name }}</span>
+                                    <span class="text-[11px] text-yellow-700 dark:text-yellow-300">· Leader</span>
+                                </span>
+                            @empty
+                                <span class="text-xs text-yellow-800 dark:text-yellow-200">
+                                    No leaders are assigned to this group yet.
+                                </span>
+                            @endforelse
+                        </div>
+                    </div>
+                @endif
+
+                {{-- Pin to top — leaders only --}}
+                @if ($this->isLeader)
+                    <div
+                        @class([
+                            'flex items-start gap-3.5 border-t p-4',
+                            'border-zinc-200 dark:border-zinc-700' => $allowReplies,
+                            'border-yellow-300 dark:border-yellow-700' => ! $allowReplies,
+                        ])
+                        data-test="pin-row"
+                    >
+                        <div class="grid size-7 shrink-0 place-items-center rounded-lg bg-accent/10 text-accent">
+                            <flux:icon.bookmark variant="micro" />
+                        </div>
+                        <div class="min-w-0 flex-1">
+                            <div class="text-sm font-semibold text-zinc-900 dark:text-zinc-100">Pin to top</div>
+                            <div class="mt-0.5 text-xs leading-relaxed text-zinc-600 dark:text-zinc-400">
+                                Keep this conversation at the top of the group for everyone.
+                            </div>
+                        </div>
+                        <div class="shrink-0">
+                            <flux:switch wire:model="pinOnPost" data-test="pin-on-post-switch" />
+                        </div>
+                    </div>
+                @endif
+            </div>
+        </div>
+
+        {{-- Action row --}}
+        <div class="flex flex-wrap items-center gap-3 pt-1">
+            <flux:button
+                type="submit"
+                variant="primary"
+                icon="paper-airplane"
+                :disabled="trim($title) === ''"
+                data-test="post-button"
+            >
+                {{ $allowReplies ? 'Post conversation' : 'Post · replies off' }}
+            </flux:button>
+
+            <flux:button :href="route('groups.show', $group)" variant="ghost" wire:navigate>
+                Cancel
+            </flux:button>
+
+            <div class="flex-1"></div>
+
+            <span class="hidden text-xs text-zinc-500 sm:inline dark:text-zinc-400" data-test="posting-context">
+                Posting in <span class="font-semibold text-zinc-700 dark:text-zinc-300">{{ $group->name }}</span>
+                as <span class="font-semibold text-zinc-700 dark:text-zinc-300">{{ auth()->user()->name }}</span>
+            </span>
         </div>
     </form>
 </section>

--- a/resources/views/pages/groups/conversations/show.blade.php
+++ b/resources/views/pages/groups/conversations/show.blade.php
@@ -847,6 +847,22 @@ new class extends Component {
 
         $this->redirect(route('groups.show', $this->group), navigate: true);
     }
+
+    public function toggleReplies(): void
+    {
+        $this->authorize('updateReplies', $this->conversation);
+
+        $this->conversation->forceFill([
+            'allow_replies' => ! $this->conversation->allow_replies,
+        ])->save();
+
+        Flux::toast(
+            variant: 'success',
+            text: $this->conversation->allow_replies
+                ? 'Replies enabled.'
+                : 'Replies disabled. Only leaders can post.',
+        );
+    }
 };
 ?>
 
@@ -886,6 +902,16 @@ new class extends Component {
                         <flux:dropdown align="end">
                             <flux:button variant="ghost" size="sm" icon="ellipsis-horizontal" square />
                             <flux:menu>
+                                @can('updateReplies', $conversation)
+                                    <flux:menu.item
+                                        wire:click="toggleReplies"
+                                        icon="{{ $conversation->allow_replies ? 'lock-closed' : 'chat-bubble-left-right' }}"
+                                        data-test="toggle-replies"
+                                    >
+                                        {{ $conversation->allow_replies ? 'Disable replies' : 'Enable replies' }}
+                                    </flux:menu.item>
+                                    <flux:menu.separator />
+                                @endcan
                                 <flux:menu.item
                                     wire:click="deleteConversation"
                                     icon="trash"
@@ -971,6 +997,16 @@ new class extends Component {
                         <flux:dropdown align="end">
                             <flux:button variant="ghost" size="sm" icon="ellipsis-horizontal" square />
                             <flux:menu>
+                                @can('updateReplies', $conversation)
+                                    <flux:menu.item
+                                        wire:click="toggleReplies"
+                                        icon="{{ $conversation->allow_replies ? 'lock-closed' : 'chat-bubble-left-right' }}"
+                                        data-test="toggle-replies"
+                                    >
+                                        {{ $conversation->allow_replies ? 'Disable replies' : 'Enable replies' }}
+                                    </flux:menu.item>
+                                    <flux:menu.separator />
+                                @endcan
                                 <flux:menu.item
                                     wire:click="deleteConversation"
                                     icon="trash"
@@ -1350,6 +1386,23 @@ new class extends Component {
                 @endforeach
             </div>
         </div>
+
+        {{-- Replies-disabled banner (visible to anyone who can't post — including viewers of a locked thread) --}}
+        @cannot('comment', $conversation)
+            @if (! $conversation->allow_replies)
+                <div
+                    class="border-t border-yellow-300 bg-yellow-50 px-3.5 py-3 lg:px-6 dark:border-yellow-700 dark:bg-yellow-900/20"
+                    data-test="replies-disabled-banner"
+                >
+                    <div class="flex items-start gap-2.5">
+                        <flux:icon.lock-closed variant="micro" class="mt-0.5 size-4 shrink-0 text-yellow-700 dark:text-yellow-300" />
+                        <div class="text-sm text-yellow-800 dark:text-yellow-200">
+                            Replies are turned off for this conversation. Only group leaders can post.
+                        </div>
+                    </div>
+                </div>
+            @endif
+        @endcannot
 
         {{-- Composer --}}
         @can('comment', $conversation)

--- a/tests/Feature/GroupConversationsTest.php
+++ b/tests/Feature/GroupConversationsTest.php
@@ -159,11 +159,81 @@ test('a member can create a conversation and an opening comment', function (): v
 
     expect($conversation->title)->toBe('Welcome aboard');
     expect($conversation->user_id)->toBe($author->id);
+    expect($conversation->allow_replies)->toBeTrue();
+    expect($conversation->pinned_at)->toBeNull();
     expect($conversation->comments()->count())->toBe(1);
     expect($conversation->refresh()->last_comment_at)->not->toBeNull();
 
     Notification::assertSentTo($other, NewConversationNotification::class);
     Notification::assertNotSentTo($author, NewConversationNotification::class);
+});
+
+test('a member can create a conversation with replies disabled', function (): void {
+    Notification::fake();
+
+    $author = User::factory()->create();
+    $group = Group::factory()->create([
+        'messaging' => GroupMessaging::ALL_MEMBERS,
+    ]);
+    attachMember($group, $author);
+
+    $this->actingAs($author);
+
+    Livewire::test('pages::groups.conversations.create', ['group' => $group])
+        ->set('title', 'Announcement only')
+        ->set('body', '<p>Read-only.</p>')
+        ->set('allowReplies', false)
+        ->call('save')
+        ->assertHasNoErrors()
+        ->assertRedirect();
+
+    $conversation = Conversation::where('group_id', $group->id)->firstOrFail();
+    expect($conversation->allow_replies)->toBeFalse();
+});
+
+test('a leader can pin the conversation on create', function (): void {
+    Notification::fake();
+
+    $leader = User::factory()->create();
+    $group = Group::factory()->create([
+        'messaging' => GroupMessaging::ALL_MEMBERS,
+    ]);
+    attachMember($group, $leader, GroupRole::LEADER);
+
+    $this->actingAs($leader);
+
+    Livewire::test('pages::groups.conversations.create', ['group' => $group])
+        ->set('title', 'Read me first')
+        ->set('body', '<p>Body</p>')
+        ->set('pinOnPost', true)
+        ->call('save')
+        ->assertHasNoErrors();
+
+    $conversation = Conversation::where('group_id', $group->id)->firstOrFail();
+    expect($conversation->pinned_at)->not->toBeNull();
+    expect($conversation->pinned_by_user_id)->toBe($leader->id);
+});
+
+test('a non-leader pinOnPost flag is ignored', function (): void {
+    Notification::fake();
+
+    $member = User::factory()->create();
+    $group = Group::factory()->create([
+        'messaging' => GroupMessaging::ALL_MEMBERS,
+    ]);
+    attachMember($group, $member);
+
+    $this->actingAs($member);
+
+    Livewire::test('pages::groups.conversations.create', ['group' => $group])
+        ->set('title', 'Trying to pin')
+        ->set('body', '<p>Body</p>')
+        ->set('pinOnPost', true)
+        ->call('save')
+        ->assertHasNoErrors();
+
+    $conversation = Conversation::where('group_id', $group->id)->firstOrFail();
+    expect($conversation->pinned_at)->toBeNull();
 });
 
 test('an empty body fails validation', function (): void {
@@ -288,6 +358,98 @@ test('an empty reply fails validation', function (): void {
         ->assertHasErrors('reply');
 
     expect($conversation->comments()->count())->toBe(0);
+});
+
+test('a non-leader cannot reply when replies are disabled on the conversation', function (): void {
+    $leader = User::factory()->create();
+    $member = User::factory()->create();
+    $group = Group::factory()->create([
+        'messaging' => GroupMessaging::ALL_MEMBERS,
+    ]);
+    attachMember($group, $leader, GroupRole::LEADER);
+    attachMember($group, $member);
+
+    $conversation = Conversation::factory()->repliesDisabled()->create([
+        'group_id' => $group->id,
+        'user_id' => $leader->id,
+    ]);
+
+    $this->actingAs($member);
+
+    Livewire::test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->set('reply', '<p>Should fail</p>')
+        ->call('postReply')
+        ->assertForbidden();
+
+    expect($conversation->comments()->count())->toBe(0);
+});
+
+test('a leader can reply when replies are disabled', function (): void {
+    $leader = User::factory()->create();
+    $group = Group::factory()->create([
+        'messaging' => GroupMessaging::ALL_MEMBERS,
+    ]);
+    attachMember($group, $leader, GroupRole::LEADER);
+
+    $conversation = Conversation::factory()->repliesDisabled()->create([
+        'group_id' => $group->id,
+        'user_id' => $leader->id,
+    ]);
+
+    $this->actingAs($leader);
+
+    Livewire::test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->set('reply', '<p>Leader can post</p>')
+        ->call('postReply')
+        ->assertHasNoErrors();
+
+    expect($conversation->comments()->count())->toBe(1);
+});
+
+test('a leader can toggle replies on and off from the show page', function (): void {
+    $leader = User::factory()->create();
+    $group = Group::factory()->create([
+        'messaging' => GroupMessaging::ALL_MEMBERS,
+    ]);
+    attachMember($group, $leader, GroupRole::LEADER);
+
+    $conversation = Conversation::factory()->create([
+        'group_id' => $group->id,
+        'user_id' => $leader->id,
+    ]);
+
+    $this->actingAs($leader);
+
+    Livewire::test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->call('toggleReplies');
+
+    expect($conversation->refresh()->allow_replies)->toBeFalse();
+
+    Livewire::test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->call('toggleReplies');
+
+    expect($conversation->refresh()->allow_replies)->toBeTrue();
+});
+
+test('a non-leader cannot toggle replies', function (): void {
+    $author = User::factory()->create();
+    $group = Group::factory()->create([
+        'messaging' => GroupMessaging::ALL_MEMBERS,
+    ]);
+    attachMember($group, $author);
+
+    $conversation = Conversation::factory()->create([
+        'group_id' => $group->id,
+        'user_id' => $author->id,
+    ]);
+
+    $this->actingAs($author);
+
+    Livewire::test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])
+        ->call('toggleReplies')
+        ->assertForbidden();
+
+    expect($conversation->refresh()->allow_replies)->toBeTrue();
 });
 
 test('a non-leader cannot reply when messaging is leaders only', function (): void {


### PR DESCRIPTION
## Summary

- Adds a per-conversation `allow_replies` boolean flag (defaults to true) that authors can set at creation time and leaders can toggle afterward via the show page menu.
- When replies are disabled, only group leaders can comment; non-leaders see a locked banner.
- Leaders can optionally pin a conversation immediately on creation via a new "Pin to top" switch.
- Redesigns the create form with a settings panel, leader preview when replies are off, and keyboard shortcuts (Cmd+Enter to post, Escape to cancel).
- Includes migration, policy updates, factory state, and comprehensive Pest tests covering authorization for all roles.

## Test plan

- [ ] Verify a member can create a conversation with replies disabled
- [ ] Verify a leader can toggle replies on/off from the conversation show page
- [ ] Verify non-leaders cannot comment when replies are disabled
- [ ] Verify leaders can still comment when replies are disabled
- [ ] Verify non-leaders cannot toggle the replies setting
- [ ] Verify pin-on-create works for leaders and is ignored for members
- [ ] Run `php artisan test --filter=GroupConversations` to confirm all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)