### PR TITLE
Redesign groups index with card layout, discover filters, and join flow

### DIFF
--- a/app/Models/Conversation.php
+++ b/app/Models/Conversation.php
@@ -75,6 +75,15 @@ class Conversation extends Model
             ->limit(1);
     }
 
+    /** @return MorphMany<Comment, $this> */
+    public function lastComment(): MorphMany
+    {
+        return $this->morphMany(Comment::class, 'commentable')
+            ->with('commentator')
+            ->latest()
+            ->limit(1);
+    }
+
     public function isPinned(): bool
     {
         return $this->pinned_at !== null;

--- a/app/Models/Group.php
+++ b/app/Models/Group.php
@@ -111,6 +111,10 @@ class Group extends Model
 
     protected function firstLetter(): Attribute
     {
-        return Attribute::get(fn (): string => (string) Str::upper(Str::substr($this->name ?? '?', 0, 1)));
+        return Attribute::get(function (): string {
+            $first = Str::upper(Str::substr(trim((string) ($this->name ?? '')), 0, 1));
+
+            return $first !== '' ? $first : '?';
+        });
     }
 }

--- a/app/Models/Group.php
+++ b/app/Models/Group.php
@@ -8,11 +8,14 @@ use App\Enums\GroupVisibility;
 use App\Enums\MembershipStatus;
 use Database\Factories\GroupFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 use Mews\Purifier\Casts\CleanHtmlInput;
 
 /**
@@ -81,6 +84,14 @@ class Group extends Model
         return $this->hasMany(Conversation::class);
     }
 
+    /** @return HasOne<Conversation, $this> */
+    public function latestConversation(): HasOne
+    {
+        return $this->hasOne(Conversation::class)
+            ->whereNotNull('last_comment_at')
+            ->latestOfMany('last_comment_at');
+    }
+
     public function hasActiveMember(User $user): bool
     {
         return $this->members()->whereKey($user->id)->exists();
@@ -89,5 +100,17 @@ class Group extends Model
     public function hasLeader(User $user): bool
     {
         return $this->leaders()->whereKey($user->id)->exists();
+    }
+
+    protected function coverUrl(): Attribute
+    {
+        return Attribute::get(fn (): ?string => $this->image
+            ? Storage::disk('digital-ocean')->url($this->image)
+            : null);
+    }
+
+    protected function firstLetter(): Attribute
+    {
+        return Attribute::get(fn (): string => (string) Str::upper(Str::substr($this->name ?? '?', 0, 1)));
     }
 }

--- a/database/factories/GroupFactory.php
+++ b/database/factories/GroupFactory.php
@@ -3,8 +3,12 @@
 namespace Database\Factories;
 
 use App\Enums\GroupMessaging;
+use App\Enums\GroupRole;
 use App\Enums\GroupVisibility;
+use App\Enums\MembershipStatus;
+use App\Models\Conversation;
 use App\Models\Group;
+use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -13,8 +17,6 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 class GroupFactory extends Factory
 {
     /**
-     * Define the model's default state.
-     *
      * @return array<string, mixed>
      */
     public function definition(): array
@@ -25,5 +27,41 @@ class GroupFactory extends Factory
             'visibility' => $this->faker->randomElement(GroupVisibility::cases()),
             'messaging' => $this->faker->randomElement(GroupMessaging::cases()),
         ];
+    }
+
+    public function public(): self
+    {
+        return $this->state(['visibility' => GroupVisibility::PUBLIC]);
+    }
+
+    public function private(): self
+    {
+        return $this->state(['visibility' => GroupVisibility::PRIVATE]);
+    }
+
+    public function withMembers(int $count = 3, MembershipStatus $status = MembershipStatus::ACTIVE, GroupRole $role = GroupRole::MEMBER): self
+    {
+        return $this->afterCreating(function (Group $group) use ($count, $status, $role): void {
+            User::factory()->count($count)->create()->each(function (User $user) use ($group, $status, $role): void {
+                $group->allUsers()->attach($user, [
+                    'role' => $role,
+                    'status' => $status,
+                ]);
+            });
+        });
+    }
+
+    public function withConversation(?User $author = null, ?string $body = null): self
+    {
+        return $this->afterCreating(function (Group $group) use ($author, $body): void {
+            $author ??= $group->members()->first() ?? User::factory()->create();
+            /** @var Conversation $conversation */
+            $conversation = $group->conversations()->create([
+                'user_id' => $author->id,
+                'title' => 'Welcome thread',
+                'allow_replies' => true,
+            ]);
+            $conversation->postComment($body ?? '<p>'.$this->faker->sentence().'</p>', $author);
+        });
     }
 }

--- a/resources/views/components/groups/card.blade.php
+++ b/resources/views/components/groups/card.blade.php
@@ -1,0 +1,81 @@
+@props(['group'])
+
+@php
+    /** @var \App\Models\Group $group */
+    $latestConversation = $group->latestConversation;
+    $latestComment = $latestConversation?->lastComment->first();
+    $previewAuthor = $latestComment?->commentator?->name;
+    $previewBody = $latestComment
+        ? trim(html_entity_decode(strip_tags((string) $latestComment->text), ENT_QUOTES | ENT_HTML5, 'UTF-8'))
+        : null;
+    $membersCount = $group->members_count ?? $group->members()->count();
+    $previewMembers = $group->relationLoaded('members') ? $group->members : $group->members()->limit(4)->get();
+    $extraMembers = max(0, $membersCount - $previewMembers->count());
+@endphp
+
+<a
+    href="{{ route('groups.show', $group) }}"
+    wire:navigate
+    class="group block focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 rounded-lg"
+>
+    <div class="flex h-full flex-col overflow-hidden rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 transition group-hover:border-zinc-300 dark:group-hover:border-white/20 group-hover:shadow-sm">
+        <x-groups.cover :group="$group" height="88px" />
+
+        <div class="flex flex-col gap-1.5 px-4 pt-3 pb-2.5">
+            <h3 class="text-base font-bold tracking-tight text-zinc-900 dark:text-zinc-100">
+                {{ $group->name }}
+            </h3>
+            <div class="flex flex-wrap gap-1.5">
+                <flux:badge size="sm" :color="$group->visibility->color()">{{ $group->visibility->label() }}</flux:badge>
+                <flux:badge size="sm" :color="$group->messaging->color()">{{ $group->messaging->label() }}</flux:badge>
+            </div>
+        </div>
+
+        <div @class([
+            'px-4 py-2.5 border-t border-zinc-100 dark:border-zinc-800',
+            'bg-zinc-50 dark:bg-zinc-800/40' => ! $latestComment,
+            'bg-accent/5' => $latestComment,
+        ])>
+            @if ($latestComment && $previewAuthor)
+                <p class="text-xs text-zinc-900 dark:text-zinc-100 line-clamp-2">
+                    <span class="font-semibold">{{ $previewAuthor }}:</span>
+                    <span class="text-zinc-700 dark:text-zinc-300">{{ $previewBody }}</span>
+                </p>
+                <p class="mt-1 text-[11px] text-zinc-500">
+                    {{ $latestComment->created_at->diffForHumans() }}
+                </p>
+            @else
+                <p class="text-xs italic text-zinc-500">No messages yet.</p>
+            @endif
+        </div>
+
+        <div class="flex items-center justify-between gap-3 px-4 py-2.5 border-t border-zinc-100 dark:border-zinc-800 mt-auto">
+            <div class="flex items-center gap-2 min-w-0">
+                @if ($previewMembers->isNotEmpty())
+                    <div class="flex items-center">
+                        @foreach ($previewMembers->take(4) as $member)
+                            <span class="-ml-1.5 first:ml-0 ring-2 ring-white dark:ring-zinc-900 rounded-md">
+                                <flux:avatar
+                                    size="xs"
+                                    :name="$member->name"
+                                    :src="$member->gravatar"
+                                />
+                            </span>
+                        @endforeach
+                        @if ($extraMembers > 0)
+                            <span class="-ml-1.5 inline-flex h-5 min-w-5 items-center justify-center rounded-md bg-zinc-100 dark:bg-zinc-800 px-1 text-[10px] font-semibold text-zinc-600 dark:text-zinc-300 ring-2 ring-white dark:ring-zinc-900">
+                                +{{ $extraMembers }}
+                            </span>
+                        @endif
+                    </div>
+                @endif
+                <span class="text-xs text-zinc-500 whitespace-nowrap">
+                    {{ $membersCount }} {{ Str::plural('member', $membersCount) }}
+                </span>
+            </div>
+            <span class="text-xs font-semibold text-zinc-500 transition-all group-hover:text-accent group-hover:translate-x-0.5 whitespace-nowrap">
+                Open <span aria-hidden="true">→</span>
+            </span>
+        </div>
+    </div>
+</a>

--- a/resources/views/components/groups/cover.blade.php
+++ b/resources/views/components/groups/cover.blade.php
@@ -1,0 +1,47 @@
+@props([
+    'group',
+    'height' => '88px',
+    'rounded' => 'none',
+    'initialSize' => '36%',
+])
+
+@php
+    $roundedClass = match ($rounded) {
+        'none' => '',
+        'sm' => 'rounded-sm',
+        'md' => 'rounded-md',
+        'lg' => 'rounded-lg',
+        default => $rounded,
+    };
+@endphp
+
+<div
+    class="relative w-full overflow-hidden {{ $roundedClass }}"
+    style="height: {{ $height }};"
+>
+    @if ($group->cover_url)
+        <img
+            src="{{ $group->cover_url }}"
+            alt=""
+            class="h-full w-full object-cover"
+            loading="lazy"
+        />
+    @else
+        <div
+            class="flex h-full w-full items-center justify-center bg-zinc-100 dark:bg-zinc-800 text-zinc-400 dark:text-zinc-600 font-extrabold leading-none select-none"
+            style="
+                font-size: {{ $initialSize }};
+                background-image: repeating-linear-gradient(
+                    45deg,
+                    transparent 0,
+                    transparent 6px,
+                    rgb(0 0 0 / 0.04) 6px,
+                    rgb(0 0 0 / 0.04) 7px
+                );
+            "
+            aria-hidden="true"
+        >{{ $group->first_letter }}</div>
+    @endif
+
+    {{ $slot }}
+</div>

--- a/resources/views/livewire/groups/discover-card.blade.php
+++ b/resources/views/livewire/groups/discover-card.blade.php
@@ -1,0 +1,41 @@
+@php
+    /** @var \App\Models\Group $group */
+    $description = $group->description
+        ? trim(html_entity_decode(strip_tags((string) $group->description), ENT_QUOTES | ENT_HTML5, 'UTF-8'))
+        : null;
+@endphp
+
+<div class="flex h-full flex-col overflow-hidden rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 transition hover:border-zinc-300 dark:hover:border-white/20 hover:shadow-sm">
+    <a href="{{ route('groups.show', $group) }}" wire:navigate class="block">
+        <x-groups.cover :group="$group" height="72px"/>
+    </a>
+
+    <div class="flex flex-1 flex-col gap-2.5 px-4 pt-3 pb-3.5">
+        <div class="flex items-start justify-between gap-2">
+            <a href="{{ route('groups.show', $group) }}" wire:navigate class="font-bold text-zinc-900 dark:text-zinc-100 hover:underline">
+                {{ $group->name }}
+            </a>
+            <flux:badge size="sm" :color="$group->visibility->color()">{{ $group->visibility->label() }}</flux:badge>
+        </div>
+
+        <p class="text-xs text-zinc-500 leading-normal line-clamp-2 min-h-[34px]">
+            {{ $description ?? 'No description.' }}
+        </p>
+
+        <div class="flex items-center justify-between gap-3 pt-2 mt-auto border-t border-zinc-100 dark:border-zinc-800">
+            <span class="text-xs text-zinc-500">
+                <span class="font-semibold text-zinc-900 dark:text-zinc-100 tabular-nums">{{ $group->members_count ?? $group->members()->count() }}</span>
+                {{ Str::plural('member', $group->members_count ?? 0) }}
+            </span>
+
+            @can('join', $group)
+                <flux:button
+                    size="sm"
+                    variant="ghost"
+                    wire:click="join({{ $group->id }})"
+                    icon="user-plus"
+                >Join</flux:button>
+            @endcan
+        </div>
+    </div>
+</div>

--- a/resources/views/livewire/groups/discover-card.blade.php
+++ b/resources/views/livewire/groups/discover-card.blade.php
@@ -23,9 +23,10 @@
         </p>
 
         <div class="flex items-center justify-between gap-3 pt-2 mt-auto border-t border-zinc-100 dark:border-zinc-800">
+            @php $membersCount = $group->members_count ?? $group->members()->count(); @endphp
             <span class="text-xs text-zinc-500">
-                <span class="font-semibold text-zinc-900 dark:text-zinc-100 tabular-nums">{{ $group->members_count ?? $group->members()->count() }}</span>
-                {{ Str::plural('member', $group->members_count ?? 0) }}
+                <span class="font-semibold text-zinc-900 dark:text-zinc-100 tabular-nums">{{ $membersCount }}</span>
+                {{ Str::plural('member', $membersCount) }}
             </span>
 
             @can('join', $group)

--- a/resources/views/livewire/groups/row.blade.php
+++ b/resources/views/livewire/groups/row.blade.php
@@ -13,52 +13,87 @@ new class extends Component {
 };
 ?>
 
-<flux:table.row>
-    <flux:table.cell><a href="{{ route('groups.show', $group) }}" wire:navigate class="hover:underline">{{ $group->name }}</a></flux:table.cell>
+<flux:table.row class="group">
+    <flux:table.cell>
+        <div class="flex items-center gap-3">
+            <div class="shrink-0 w-11">
+                <x-groups.cover
+                    :group="$group"
+                    height="44px"
+                    rounded="md"
+                    initialSize="20px"
+                />
+            </div>
+            <div class="min-w-0">
+                <a
+                    href="{{ route('groups.show', $group) }}"
+                    wire:navigate
+                    class="font-semibold text-accent hover:underline"
+                >{{ $group->name }}</a>
+                @if ($group->description)
+                    <div class="text-xs text-zinc-500 line-clamp-1 max-w-md">
+                        {{ trim(html_entity_decode(strip_tags((string) $group->description), ENT_QUOTES | ENT_HTML5, 'UTF-8')) }}
+                    </div>
+                @endif
+            </div>
+        </div>
+    </flux:table.cell>
     <flux:table.cell>
         <flux:badge size="sm" inset="top bottom" :color="$group->visibility->color()">{{ $group->visibility->label() }}</flux:badge>
     </flux:table.cell>
     <flux:table.cell>
         <flux:badge size="sm" inset="top bottom" :color="$group->messaging->color()">{{ $group->messaging->label() }}</flux:badge>
     </flux:table.cell>
+    <flux:table.cell align="end" class="tabular-nums text-zinc-500">{{ $group->members_count ?? $group->members()->count() }}</flux:table.cell>
     <flux:table.cell class="whitespace-nowrap">{{ $group->created_at->toFormattedDayDateString() }}</flux:table.cell>
     <flux:table.cell align="end">
-        @can('update', $group)
-            <flux:dropdown align="end" offset="-15">
-                <flux:button variant="ghost" size="sm" icon="ellipsis-horizontal" inset="bottom"/>
-
-                <flux:menu class="min-w-32">
-                    <flux:menu.item :href="route('groups.edit', $group)" icon="pencil-square">Edit</flux:menu.item>
-                    @can('delete', $group)
-                        <flux:menu.item wire:click="delete" icon="trash" variant="danger">Delete</flux:menu.item>
-                    @endcan
-                </flux:menu>
-            </flux:dropdown>
-
-            @can('delete', $group)
-                <flux:modal name="delete-group" class="min-w-[22rem]">
-                    <form wire:submit="$parent.delete({{ $group->id }})" class="space-y-6">
-                        <div>
-                            <flux:heading size="lg">Delete group?</flux:heading>
-
-                            <flux:subheading>
-                                <p>This will permanently delete the group.</p>
-                                <p>It cannot be undone.</p>
-                            </flux:subheading>
-                        </div>
-
-                        <div class="flex gap-2">
-                            <flux:spacer/>
-
-                            <flux:modal.close>
-                                <flux:button variant="ghost">Cancel</flux:button>
-                            </flux:modal.close>
-
-                            <flux:button type="submit" variant="danger">Delete group</flux:button>
-                        </div>
-                    </form>
-                </flux:modal>
+        <div class="flex items-center justify-end gap-1 opacity-0 transition group-hover:opacity-100 focus-within:opacity-100">
+            @can('join', $group)
+                <flux:button
+                    size="sm"
+                    variant="ghost"
+                    wire:click="$parent.join({{ $group->id }})"
+                    icon="user-plus"
+                >Join</flux:button>
             @endcan
-        @endcan
+
+            @can('update', $group)
+                <flux:dropdown align="end" offset="-15">
+                    <flux:button variant="ghost" size="sm" icon="ellipsis-horizontal" inset="bottom"/>
+
+                    <flux:menu class="min-w-32">
+                        <flux:menu.item :href="route('groups.edit', $group)" icon="pencil-square">Edit</flux:menu.item>
+                        @can('delete', $group)
+                            <flux:menu.item wire:click="delete" icon="trash" variant="danger">Delete</flux:menu.item>
+                        @endcan
+                    </flux:menu>
+                </flux:dropdown>
+
+                @can('delete', $group)
+                    <flux:modal name="delete-group" class="min-w-[22rem]">
+                        <form wire:submit="$parent.delete({{ $group->id }})" class="space-y-6">
+                            <div>
+                                <flux:heading size="lg">Delete group?</flux:heading>
+
+                                <flux:subheading>
+                                    <p>This will permanently delete the group.</p>
+                                    <p>It cannot be undone.</p>
+                                </flux:subheading>
+                            </div>
+
+                            <div class="flex gap-2">
+                                <flux:spacer/>
+
+                                <flux:modal.close>
+                                    <flux:button variant="ghost">Cancel</flux:button>
+                                </flux:modal.close>
+
+                                <flux:button type="submit" variant="danger">Delete group</flux:button>
+                            </div>
+                        </form>
+                    </flux:modal>
+                @endcan
+            @endcan
+        </div>
     </flux:table.cell>
 </flux:table.row>

--- a/resources/views/pages/groups/index.blade.php
+++ b/resources/views/pages/groups/index.blade.php
@@ -1,6 +1,9 @@
 <?php
 
+use App\Enums\GroupMessaging;
+use App\Enums\GroupRole;
 use App\Enums\GroupVisibility;
+use App\Enums\MembershipStatus;
 use App\Models\Group;
 use Flux\Flux;
 use Illuminate\Database\Eloquent\Collection;
@@ -12,9 +15,10 @@ use Livewire\WithPagination;
 new class extends Component {
     use WithPagination;
 
-    public $sortBy = 'name';
-    public $sortDirection = 'asc';
-    public $search = '';
+    public string $sortBy = 'name';
+    public string $sortDirection = 'asc';
+    public string $search = '';
+    public string $messagingFilter = 'all';
 
     public function sort(string $column): void
     {
@@ -24,6 +28,18 @@ new class extends Component {
             $this->sortBy = $column;
             $this->sortDirection = 'asc';
         }
+    }
+
+    public function setMessagingFilter(string $filter): void
+    {
+        $allowed = ['all', 'all-members', 'only-leaders', 'off'];
+        $this->messagingFilter = in_array($filter, $allowed, true) ? $filter : 'all';
+        $this->resetPage();
+    }
+
+    public function updatedSearch(): void
+    {
+        $this->resetPage();
     }
 
     private function buildOrderByClause(): string
@@ -38,19 +54,82 @@ new class extends Component {
     #[Computed]
     public function myGroups(): Collection
     {
-        return Auth::user()->groups;
+        return Auth::user()->groups()
+            ->withCount('members')
+            ->with([
+                'members' => fn ($q) => $q->limit(4),
+                'latestConversation.lastComment.commentator',
+            ])
+            ->orderBy('name')
+            ->get();
     }
 
     #[Computed]
-    public function groups()
+    public function discover()
     {
         return Group::query()
             ->where('visibility', GroupVisibility::PUBLIC)
-            ->when($this->search, function ($query): void {
-                $query->where('name', 'like', "%{$this->search}%");
-            })
+            ->whereDoesntHave('allUsers', fn ($q) => $q
+                ->where('users.id', Auth::id())
+                ->whereIn('status', [MembershipStatus::ACTIVE->value, MembershipStatus::PENDING->value])
+            )
+            ->withCount('members')
+            ->when($this->search !== '', fn ($q) =>
+                $q->where(fn ($inner) => $inner
+                    ->where('name', 'like', "%{$this->search}%")
+                    ->orWhere('description', 'like', "%{$this->search}%")
+                )
+            )
+            ->when($this->messagingFilter !== 'all', fn ($q) =>
+                $q->where('messaging', $this->messagingFilter)
+            )
             ->orderByRaw($this->buildOrderByClause())
             ->paginate(12);
+    }
+
+    #[Computed]
+    public function filterCounts(): array
+    {
+        $base = Group::query()
+            ->where('visibility', GroupVisibility::PUBLIC)
+            ->whereDoesntHave('allUsers', fn ($q) => $q
+                ->where('users.id', Auth::id())
+                ->whereIn('status', [MembershipStatus::ACTIVE->value, MembershipStatus::PENDING->value])
+            );
+
+        $byMessaging = (clone $base)
+            ->selectRaw('messaging, COUNT(*) as aggregate')
+            ->groupBy('messaging')
+            ->pluck('aggregate', 'messaging');
+
+        return [
+            'all' => (int) $byMessaging->sum(),
+            'all-members' => (int) ($byMessaging[GroupMessaging::ALL_MEMBERS->value] ?? 0),
+            'only-leaders' => (int) ($byMessaging[GroupMessaging::ONLY_LEADERS->value] ?? 0),
+            'off' => (int) ($byMessaging[GroupMessaging::OFF->value] ?? 0),
+        ];
+    }
+
+    public function join(int $groupId): void
+    {
+        $group = Group::findOrFail($groupId);
+        $this->authorize('join', $group);
+
+        $existing = $group->allUsers()->where('user_id', Auth::id())->exists();
+
+        if ($existing) {
+            $group->allUsers()->updateExistingPivot(Auth::id(), [
+                'status' => MembershipStatus::PENDING,
+            ]);
+        } else {
+            $group->allUsers()->attach(Auth::id(), [
+                'role' => GroupRole::MEMBER,
+                'status' => MembershipStatus::PENDING,
+            ]);
+        }
+
+        unset($this->myGroups, $this->discover, $this->filterCounts);
+        Flux::toast(text: 'Join request sent.');
     }
 
     public function delete(int $id): void
@@ -75,46 +154,147 @@ new class extends Component {
                 <flux:callout.text>You're not a member of any groups yet.</flux:callout.text>
             </flux:callout>
         @else
-            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-3.5">
                 @foreach ($this->myGroups as $group)
-                    <a href="{{ route('groups.show', $group) }}" wire:navigate class="group block">
-                        <flux:card class="space-y-2 h-full transition group-hover:border-zinc-300 dark:group-hover:border-white/20">
-                            <flux:heading size="lg">{{ $group->name }}</flux:heading>
-                            <div class="flex gap-2">
-                                <flux:badge size="sm" :color="$group->visibility->color()">{{ $group->visibility->label() }}</flux:badge>
-                                <flux:badge size="sm" :color="$group->messaging->color()">{{ $group->messaging->label() }}</flux:badge>
-                            </div>
-                        </flux:card>
-                    </a>
+                    <x-groups.card :group="$group"/>
                 @endforeach
             </div>
         @endif
     </div>
 
-    <div>
+    <div x-data="{
+        layout: localStorage.getItem('groups-discover-layout') || 'table',
+        setLayout(value) {
+            this.layout = value;
+            localStorage.setItem('groups-discover-layout', value);
+        }
+    }">
         <flux:heading size="xl" level="2">Discover Groups</flux:heading>
         <flux:subheading size="lg" class="mb-6">Find and join public groups.</flux:subheading>
 
-        <div class="flex space-x-4 items-center">
-            <flux:input wire:model.live="search" size="sm" placeholder="Search groups..." icon="magnifying-glass" class="max-w-96" clearable/>
+        <div class="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center">
+            <flux:input
+                wire:model.live.debounce.250ms="search"
+                size="sm"
+                placeholder="Search groups..."
+                icon="magnifying-glass"
+                class="max-w-96"
+                clearable
+            />
+
+            <div class="flex flex-wrap items-center gap-1.5" role="group" aria-label="Filter by messaging">
+                @php
+                    $chips = [
+                        'all' => ['label' => 'All', 'count' => $this->filterCounts['all']],
+                        'all-members' => ['label' => 'All Members', 'count' => $this->filterCounts['all-members']],
+                        'only-leaders' => ['label' => 'Only Leaders', 'count' => $this->filterCounts['only-leaders']],
+                        'off' => ['label' => 'Off', 'count' => $this->filterCounts['off']],
+                    ];
+                @endphp
+                @foreach ($chips as $value => $chip)
+                    @php $active = $messagingFilter === $value; @endphp
+                    <button
+                        type="button"
+                        wire:click="setMessagingFilter('{{ $value }}')"
+                        @class([
+                            'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium transition cursor-pointer',
+                            'bg-accent/10 text-accent border-accent/30' => $active,
+                            'border-zinc-200 dark:border-zinc-700 text-zinc-600 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800' => ! $active,
+                        ])
+                        aria-pressed="{{ $active ? 'true' : 'false' }}"
+                    >
+                        <span>{{ $chip['label'] }}</span>
+                        <span @class([
+                            'text-[10px] font-semibold',
+                            'text-accent/70' => $active,
+                            'text-zinc-400' => ! $active,
+                        ])>{{ $chip['count'] }}</span>
+                    </button>
+                @endforeach
+            </div>
+
             <flux:spacer/>
-            <flux:button :href="route('groups.create')" size="sm" variant="primary" icon="plus">Add Group</flux:button>
+
+            <div class="flex items-center gap-2">
+                <div class="inline-flex items-center gap-0.5 rounded-lg border border-zinc-200 dark:border-zinc-700 p-0.5" role="group" aria-label="Discover layout">
+                    <button
+                        type="button"
+                        @click="setLayout('table')"
+                        :class="layout === 'table'
+                            ? 'bg-zinc-100 dark:bg-zinc-800 text-zinc-900 dark:text-zinc-100'
+                            : 'text-zinc-500 hover:text-zinc-900 dark:hover:text-zinc-100'"
+                        class="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-semibold transition cursor-pointer"
+                        :aria-pressed="layout === 'table'"
+                        aria-label="Table layout"
+                    >
+                        <flux:icon.list-bullet variant="micro" class="size-3.5"/>
+                        <span>Table</span>
+                    </button>
+                    <button
+                        type="button"
+                        @click="setLayout('cards')"
+                        :class="layout === 'cards'
+                            ? 'bg-zinc-100 dark:bg-zinc-800 text-zinc-900 dark:text-zinc-100'
+                            : 'text-zinc-500 hover:text-zinc-900 dark:hover:text-zinc-100'"
+                        class="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-semibold transition cursor-pointer"
+                        :aria-pressed="layout === 'cards'"
+                        aria-label="Cards layout"
+                    >
+                        <flux:icon.squares-2x2 variant="micro" class="size-3.5"/>
+                        <span>Cards</span>
+                    </button>
+                </div>
+
+                <flux:button :href="route('groups.create')" size="sm" variant="primary" icon="plus">Add Group</flux:button>
+            </div>
         </div>
 
-        <flux:table :paginate="$this->groups" class="mt-2">
-            <flux:table.columns>
-                <flux:table.column sortable :sorted="$sortBy === 'name'" :direction="$sortDirection" wire:click="sort('name')">Name</flux:table.column>
-                <flux:table.column>Visibility</flux:table.column>
-                <flux:table.column>Messaging</flux:table.column>
-                <flux:table.column sortable :sorted="$sortBy === 'created_at'" :direction="$sortDirection" wire:click="sort('created_at')">Created</flux:table.column>
-                <flux:table.column></flux:table.column>
-            </flux:table.columns>
+        <div class="mt-4">
+            @if ($this->discover->isEmpty())
+                <div class="rounded-lg border border-dashed border-zinc-200 dark:border-zinc-700 px-4 py-10 text-center">
+                    <p class="text-sm text-zinc-500">
+                        @if ($search !== '' || $messagingFilter !== 'all')
+                            No groups match that search.
+                        @else
+                            No public groups available right now.
+                        @endif
+                    </p>
+                </div>
+            @else
+                <div x-show="layout === 'table'" x-cloak>
+                    <flux:table :paginate="$this->discover">
+                        <flux:table.columns>
+                            <flux:table.column sortable :sorted="$sortBy === 'name'" :direction="$sortDirection" wire:click="sort('name')">Name</flux:table.column>
+                            <flux:table.column>Visibility</flux:table.column>
+                            <flux:table.column>Messaging</flux:table.column>
+                            <flux:table.column align="end">Members</flux:table.column>
+                            <flux:table.column sortable :sorted="$sortBy === 'created_at'" :direction="$sortDirection" wire:click="sort('created_at')">Created</flux:table.column>
+                            <flux:table.column></flux:table.column>
+                        </flux:table.columns>
 
-            <flux:table.rows>
-                @foreach ($this->groups as $group)
-                    <livewire:groups.row :$group :key="$group->id"/>
-                @endforeach
-            </flux:table.rows>
-        </flux:table>
+                        <flux:table.rows>
+                            @foreach ($this->discover as $group)
+                                <livewire:groups.row :$group :key="'row-'.$group->id"/>
+                            @endforeach
+                        </flux:table.rows>
+                    </flux:table>
+                </div>
+
+                <div x-show="layout === 'cards'" x-cloak>
+                    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3.5">
+                        @foreach ($this->discover as $group)
+                            @include('livewire.groups.discover-card', ['group' => $group])
+                        @endforeach
+                    </div>
+                    <div class="mt-4">
+                        {{ $this->discover->links() }}
+                    </div>
+                </div>
+
+                <p class="mt-3.5 text-xs text-zinc-500">
+                    Showing {{ $this->discover->firstItem() }} to {{ $this->discover->lastItem() }} of {{ $this->discover->total() }} results
+                </p>
+            @endif
+        </div>
     </div>
 </section>

--- a/resources/views/pages/groups/index.blade.php
+++ b/resources/views/pages/groups/index.blade.php
@@ -6,6 +6,7 @@ use App\Enums\GroupVisibility;
 use App\Enums\MembershipStatus;
 use App\Models\Group;
 use Flux\Flux;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Auth;
 use Livewire\Attributes\Computed;
@@ -65,7 +66,7 @@ new class extends Component {
     }
 
     #[Computed]
-    public function discover()
+    public function discover(): LengthAwarePaginator
     {
         return Group::query()
             ->where('visibility', GroupVisibility::PUBLIC)

--- a/tests/Feature/GroupTest.php
+++ b/tests/Feature/GroupTest.php
@@ -128,9 +128,9 @@ test('groups index search filters by name', function (): void {
     $component = Livewire::test('pages::groups.index')
         ->set('search', 'Youth');
 
-    $groups = $component->get('groups');
-    expect($groups)->toHaveCount(1);
-    expect($groups->first()->name)->toBe('Youth Group');
+    $discover = $component->get('discover');
+    expect($discover)->toHaveCount(1);
+    expect($discover->first()->name)->toBe('Youth Group');
 });
 
 test('leaders can delete a group from the index page', function (): void {
@@ -449,4 +449,136 @@ test('addMembers picks up users via the popover pickUser flow', function (): voi
         ->assertSet('pickedUserIds', []);
 
     expect($group->members()->whereKey($candidate->id)->exists())->toBeTrue();
+});
+
+/** @group groups-index-redesign */
+test('my groups card shows latest message preview when a comment exists', function (): void {
+    $user = User::factory()->create();
+    $author = User::factory()->create(['name' => 'Alice Author']);
+    $group = Group::factory()->create(['name' => 'Worship Team', 'visibility' => GroupVisibility::PUBLIC]);
+    $group->allUsers()->attach($user, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($author, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+
+    $conversation = $group->conversations()->create([
+        'user_id' => $author->id,
+        'title' => 'Practice Sunday',
+        'allow_replies' => true,
+    ]);
+    $conversation->postComment('<p>Rehearsal moved to 8am</p>', $author);
+
+    Livewire::actingAs($user)
+        ->test('pages::groups.index')
+        ->assertSee('Alice Author')
+        ->assertSee('Rehearsal moved to 8am');
+});
+
+test('my groups card shows "No messages yet" when group has no comments', function (): void {
+    $user = User::factory()->create();
+    $group = Group::factory()->create(['name' => 'Quiet Group', 'visibility' => GroupVisibility::PUBLIC]);
+    $group->allUsers()->attach($user, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+
+    Livewire::actingAs($user)
+        ->test('pages::groups.index')
+        ->assertSee('Quiet Group')
+        ->assertSee('No messages yet.');
+});
+
+test('discover search matches description as well as name', function (): void {
+    $user = User::factory()->create();
+    Group::factory()->create([
+        'name' => 'Sunday Choir',
+        'description' => '<p>Plain old singers.</p>',
+        'visibility' => GroupVisibility::PUBLIC,
+    ]);
+    Group::factory()->create([
+        'name' => 'Outreach',
+        'description' => '<p>Community evangelism crew.</p>',
+        'visibility' => GroupVisibility::PUBLIC,
+    ]);
+
+    $this->actingAs($user);
+
+    $discover = Livewire::test('pages::groups.index')
+        ->set('search', 'evangelism')
+        ->get('discover');
+
+    expect($discover)->toHaveCount(1);
+    expect($discover->first()->name)->toBe('Outreach');
+});
+
+test('discover filter chips restrict by messaging and combine with search', function (): void {
+    $user = User::factory()->create();
+    Group::factory()->create([
+        'name' => 'Singers Club',
+        'visibility' => GroupVisibility::PUBLIC,
+        'messaging' => GroupMessaging::ALL_MEMBERS,
+    ]);
+    Group::factory()->create([
+        'name' => 'Singers Council',
+        'visibility' => GroupVisibility::PUBLIC,
+        'messaging' => GroupMessaging::ONLY_LEADERS,
+    ]);
+    Group::factory()->create([
+        'name' => 'Choir Council',
+        'visibility' => GroupVisibility::PUBLIC,
+        'messaging' => GroupMessaging::ONLY_LEADERS,
+    ]);
+
+    $this->actingAs($user);
+
+    $component = Livewire::test('pages::groups.index')
+        ->call('setMessagingFilter', 'only-leaders');
+
+    $only = $component->get('discover');
+    expect($only)->toHaveCount(2);
+    expect($only->pluck('name'))->toContain('Singers Council', 'Choir Council');
+
+    $component->set('search', 'Singers');
+    $combined = $component->get('discover');
+    expect($combined)->toHaveCount(1);
+    expect($combined->first()->name)->toBe('Singers Council');
+});
+
+test('discover excludes groups the current user is already a member of', function (): void {
+    $user = User::factory()->create();
+    $joined = Group::factory()->create(['name' => 'My Group', 'visibility' => GroupVisibility::PUBLIC]);
+    $joined->allUsers()->attach($user, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+    Group::factory()->create(['name' => 'Other Group', 'visibility' => GroupVisibility::PUBLIC]);
+
+    $this->actingAs($user);
+
+    $discover = Livewire::test('pages::groups.index')->get('discover');
+
+    expect($discover->pluck('name')->all())->toBe(['Other Group']);
+});
+
+test('discover join action sends a join request and removes the group from discover', function (): void {
+    $user = User::factory()->create();
+    $group = Group::factory()->create(['name' => 'Joinable', 'visibility' => GroupVisibility::PUBLIC]);
+
+    $this->actingAs($user);
+
+    $component = Livewire::test('pages::groups.index');
+    expect($component->get('discover')->pluck('name')->all())->toBe(['Joinable']);
+
+    $component->call('join', $group->id);
+
+    $this->assertDatabaseHas('group_user', [
+        'group_id' => $group->id,
+        'user_id' => $user->id,
+        'status' => MembershipStatus::PENDING->value,
+    ]);
+
+    expect($component->get('discover')->pluck('name')->all())->toBe([]);
+});
+
+test('messaging filter rejects unknown values and defaults to all', function (): void {
+    $user = User::factory()->create();
+    Group::factory()->create(['visibility' => GroupVisibility::PUBLIC]);
+
+    $this->actingAs($user);
+
+    Livewire::test('pages::groups.index')
+        ->call('setMessagingFilter', 'bogus')
+        ->assertSet('messagingFilter', 'all');
 });


### PR DESCRIPTION
## Summary

- Replaces the simple card grid in "My Groups" with rich cards showing latest message preview, member avatars, and badges
- Adds a "Discover Groups" section with messaging filter chips, description search, and table/card layout toggle (persisted in localStorage)
- Introduces an inline join flow that sends a pending membership request and updates the UI reactively
- Extracts reusable `<x-groups.cover>` and `<x-groups.card>` Blade components
- Adds `latestConversation`, `lastComment`, `coverUrl`, and `firstLetter` model accessors/relations
- Expands GroupFactory with `public()`, `private()`, `withMembers()`, and `withConversation()` states
- Adds comprehensive test coverage for discover search, messaging filters, join action, and card previews

## Test plan

- [ ] Verify "My Groups" cards display latest message preview and member avatars
- [ ] Confirm "Discover Groups" filters by messaging type and combines with text search
- [ ] Test join button sends request and removes group from discover list
- [ ] Toggle between table/card layouts and verify persistence across page loads
- [ ] Check groups with no cover image show letter placeholder consistently
- [ ] Run `npm run pest` to confirm all new and existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced group cards now display latest messages with previews and timestamps
  * New group discovery interface with messaging type filters and search
  * Added table and card layout toggle for browsing groups
  * Groups now show cover images with fallback placeholders
  * Improved member preview display on group cards

* **Bug Fixes & Improvements**
  * Better group browsing experience with cleaner card layouts
  * More informative empty states when no messages or groups are available

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jpangborn/stave/pull/110?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->