### PR TITLE
Redesign service show page with section tones and inline editing

### DIFF
--- a/app/Livewire/Forms/ServiceForm.php
+++ b/app/Livewire/Forms/ServiceForm.php
@@ -4,6 +4,7 @@ namespace App\Livewire\Forms;
 
 use App\Models\Service;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
 use Livewire\Attributes\Validate;
 use Livewire\Form;
 
@@ -51,5 +52,42 @@ class ServiceForm extends Form
         $this->validate();
 
         $this->service?->update($this->only(['date', 'title']));
+    }
+
+    /**
+     * Persist a single attribute (used by inline edits on the show page).
+     */
+    public function saveTitle(): void
+    {
+        $this->validateOnly('title');
+
+        $this->service?->update(['title' => $this->title]);
+    }
+
+    /**
+     * Clone this service and all of its liturgy elements. The new service
+     * keeps the same template + the same date, with " (Copy)" appended to
+     * the title.
+     */
+    public function duplicate(): Service
+    {
+        abort_if($this->service === null, 404);
+
+        return DB::transaction(function () {
+            $clone = Service::create([
+                'title' => trim(($this->service->title ?? 'Untitled').' (Copy)'),
+                'date' => $this->service->date,
+                'template_id' => $this->service->template_id,
+                'notes' => $this->service->notes,
+            ]);
+
+            foreach ($this->service->liturgyElements as $element) {
+                $copy = $element->replicate(['liturgy_type', 'liturgy_id']);
+                $copy->liturgy()->associate($clone);
+                $copy->save();
+            }
+
+            return $clone;
+        });
     }
 }

--- a/app/Models/LiturgyElement.php
+++ b/app/Models/LiturgyElement.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use App\Enums\LiturgyElementType;
 use App\Enums\ReadingType;
 use App\Observers\LiturgyElementObserver;
+use App\Support\SectionTone;
 use Database\Factories\LiturgyElementFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
@@ -16,6 +17,7 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
 /**
  * @property LiturgyElementType $type
  * @property ReadingType|null $reading_type
+ * @property string|null $section_color
  */
 #[ObservedBy([LiturgyElementObserver::class])]
 #[Fillable([
@@ -25,6 +27,7 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
     'name',
     'assignee_id',
     'description',
+    'section_color',
     'content_type',
     'content_id',
 ])]
@@ -85,6 +88,30 @@ class LiturgyElement extends Model
     public function hasContent(): bool
     {
         return $this->content_type && $this->content_id;
+    }
+
+    /**
+     * Whether this element type would normally have library content
+     * (song / reading). Sermon uses an inline title, not library content,
+     * and prayer/supper/baptism/section have no content.
+     */
+    public function requiresContent(): bool
+    {
+        return in_array($this->type, [
+            LiturgyElementType::SONG,
+            LiturgyElementType::READING,
+        ], true);
+    }
+
+    /**
+     * Tailwind classes for the section's tonal color. Pass through for
+     * non-section rows by looking up the parent section's color upstream.
+     *
+     * @return array{stripe:string, dot:string, swatch:string, soft:string}
+     */
+    public function sectionToneClasses(): array
+    {
+        return SectionTone::classesFor($this->section_color);
     }
 
     /**

--- a/app/Models/Service.php
+++ b/app/Models/Service.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Enums\LiturgyElementType;
 use Database\Factories\ServiceFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -78,5 +79,39 @@ class Service extends Model
             ->get()
             ->pluck('assignee')
             ->unique('id');
+    }
+
+    public function sectionCount(): int
+    {
+        return $this->liturgyElements
+            ->where('type', LiturgyElementType::SECTION)
+            ->count();
+    }
+
+    public function elementCount(): int
+    {
+        return $this->liturgyElements
+            ->where('type', '!=', LiturgyElementType::SECTION)
+            ->count();
+    }
+
+    public function unassignedCount(): int
+    {
+        return $this->liturgyElements
+            ->where('type', '!=', LiturgyElementType::SECTION)
+            ->whereNull('assignee_id')
+            ->count();
+    }
+
+    /**
+     * Count of elements that should have library content but don't.
+     * Excludes section/sermon/prayer/baptism/supper — they either
+     * use inline fields or need no content.
+     */
+    public function missingContentCount(): int
+    {
+        return $this->liturgyElements
+            ->filter(fn (LiturgyElement $el) => $el->requiresContent() && ! $el->hasContent())
+            ->count();
     }
 }

--- a/app/Observers/LiturgyElementObserver.php
+++ b/app/Observers/LiturgyElementObserver.php
@@ -2,16 +2,31 @@
 
 namespace App\Observers;
 
+use App\Enums\LiturgyElementType;
 use App\Models\LiturgyElement;
 use App\Models\Service;
 use App\Models\User;
 use App\Services\ServiceCommentSubscriptionService;
+use App\Support\SectionTone;
 
 class LiturgyElementObserver
 {
     public function __construct(
         private ServiceCommentSubscriptionService $subscriptionService
     ) {}
+
+    /**
+     * Handle the LiturgyElement "creating" event.
+     *
+     * Seed a tonal color for sections so element rows can inherit it.
+     * The color persists across renames; only the initial value is auto-picked.
+     */
+    public function creating(LiturgyElement $element): void
+    {
+        if ($element->type === LiturgyElementType::SECTION && $element->section_color === null) {
+            $element->section_color = SectionTone::pick($element->name ?? '');
+        }
+    }
 
     /**
      * Handle the LiturgyElement "created" event.

--- a/app/Support/SectionTone.php
+++ b/app/Support/SectionTone.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Support;
+
+/**
+ * Tonal color palette for liturgy section headers.
+ *
+ * Mirrors Flux UI's avatar color selection algorithm (crc32 of a seed mapped
+ * to a color in an ordered palette) so the visual language stays consistent.
+ * The palette is restricted to the colors with Flexoki overrides in app.css —
+ * other hues fall back to default Tailwind and clash with the muted theme.
+ *
+ * @see vendor/livewire/flux/stubs/resources/views/flux/avatar/index.blade.php
+ */
+class SectionTone
+{
+    /**
+     * Ordered palette. Do not reorder — the index is used by the hash and
+     * reordering would shift every existing section's color.
+     *
+     * @var list<string>
+     */
+    public const PALETTE = [
+        'red', 'orange', 'yellow', 'green',
+        'cyan', 'blue', 'purple', 'pink',
+    ];
+
+    public static function pick(string $seed): string
+    {
+        return self::PALETTE[crc32($seed) % count(self::PALETTE)];
+    }
+
+    /**
+     * Tailwind class names for a given tone. Returns neutral zinc classes
+     * when the color is null or not in the palette.
+     *
+     * @return array{stripe:string, dot:string, swatch:string, soft:string}
+     */
+    public static function classesFor(?string $color): array
+    {
+        if ($color === null || ! in_array($color, self::PALETTE, true)) {
+            return [
+                'stripe' => 'bg-zinc-300 dark:bg-zinc-600',
+                'dot' => 'text-zinc-600 dark:text-zinc-300',
+                'swatch' => 'bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300',
+                'soft' => 'bg-zinc-50 dark:bg-zinc-900',
+            ];
+        }
+
+        return [
+            'stripe' => "bg-{$color}-500 dark:bg-{$color}-400",
+            'dot' => "text-{$color}-700 dark:text-{$color}-300",
+            'swatch' => "bg-{$color}-100 text-{$color}-700 dark:bg-{$color}-900 dark:text-{$color}-300",
+            'soft' => "bg-{$color}-50 dark:bg-{$color}-900",
+        ];
+    }
+}

--- a/database/factories/LiturgyElementFactory.php
+++ b/database/factories/LiturgyElementFactory.php
@@ -5,6 +5,7 @@ namespace Database\Factories;
 use App\Enums\LiturgyElementType;
 use App\Models\LiturgyElement;
 use App\Models\User;
+use App\Support\SectionTone;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -53,5 +54,21 @@ class LiturgyElementFactory extends Factory
         return $this->state(fn () => [
             'assignee_id' => $user->id,
         ]);
+    }
+
+    /**
+     * State: a section element with a tonal color derived from its name.
+     */
+    public function section(?string $name = null): static
+    {
+        return $this->state(function () use ($name) {
+            $resolvedName = $name ?? $this->faker->word();
+
+            return [
+                'type' => LiturgyElementType::SECTION,
+                'name' => $resolvedName,
+                'section_color' => SectionTone::pick($resolvedName),
+            ];
+        });
     }
 }

--- a/database/migrations/2026_05_17_225222_add_section_color_to_liturgy_elements_table.php
+++ b/database/migrations/2026_05_17_225222_add_section_color_to_liturgy_elements_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use App\Support\SectionTone;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('liturgy_elements', function (Blueprint $table) {
+            $table->string('section_color')->nullable()->after('description');
+        });
+
+        DB::table('liturgy_elements')
+            ->where('type', 'section')
+            ->whereNull('section_color')
+            ->orderBy('id')
+            ->each(function (object $row) {
+                DB::table('liturgy_elements')
+                    ->where('id', $row->id)
+                    ->update(['section_color' => SectionTone::pick((string) $row->name)]);
+            });
+    }
+
+    public function down(): void
+    {
+        Schema::table('liturgy_elements', function (Blueprint $table) {
+            $table->dropColumn('section_color');
+        });
+    }
+};

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -7,6 +7,11 @@
 @source '../../vendor/livewire/flux-pro/stubs/**/*.blade.php';
 @source '../../vendor/livewire/flux/stubs/**/*.blade.php';
 
+/* Section tone classes are composed dynamically in PHP (see App\Support\SectionTone).
+   Safelist the eight Flexoki-mapped hues at the stops we use. */
+@source inline("{bg,text}-{red,orange,yellow,green,cyan,blue,purple,pink}-{50,100,300,400,500,700,900}");
+@source inline("dark:{bg,text}-{red,orange,yellow,green,cyan,blue,purple,pink}-{50,100,300,400,500,700,900}");
+
 @custom-variant dark (&:where(.dark, .dark *));
 
 @theme {

--- a/resources/views/components/service/add-element-slot.blade.php
+++ b/resources/views/components/service/add-element-slot.blade.php
@@ -1,0 +1,43 @@
+@props([
+    'afterId',
+])
+
+@php
+    $types = \App\Enums\LiturgyElementType::cases();
+@endphp
+
+<div x-data="{ open: false, hov: false }"
+     @mouseenter="hov = true"
+     @mouseleave="if (!open) hov = false"
+     class="relative h-2 cursor-pointer"
+     :class="(hov || open) ? 'h-7' : 'h-2'"
+     style="transition: height 120ms ease;">
+
+    <div x-show="hov || open" x-cloak
+         class="absolute inset-x-0 top-1/2 flex -translate-y-1/2 justify-center">
+        <button type="button"
+                @click.stop="open = true"
+                class="inline-flex items-center gap-1.5 rounded-full border border-dashed border-zinc-300 bg-white px-3 py-1 text-xs font-medium text-zinc-500 hover:border-zinc-400 hover:text-zinc-700 dark:border-zinc-600 dark:bg-zinc-900 dark:text-zinc-400 dark:hover:border-zinc-500 dark:hover:text-zinc-200">
+            <flux:icon name="plus" class="size-3" />
+            Add element
+        </button>
+    </div>
+
+    <template x-if="open">
+        <div>
+            <div @click.stop="open = false; hov = false" class="fixed inset-0 z-40 bg-black/5"></div>
+            <div class="absolute left-1/2 top-full z-50 mt-2 w-44 -translate-x-1/2 overflow-hidden rounded-lg border border-zinc-200 bg-white p-1 shadow-lg dark:border-zinc-700 dark:bg-zinc-900"
+                 @click.stop
+                 @keydown.escape.window="open = false; hov = false">
+                @foreach ($types as $case)
+                    <button type="button"
+                            @click="$wire.call('addElementAfter', {{ $afterId }}, '{{ $case->value }}'); open = false; hov = false"
+                            class="flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-[13px] text-zinc-700 hover:bg-zinc-100 dark:text-zinc-200 dark:hover:bg-zinc-800">
+                        <flux:icon name="{{ $case->icon() }}" class="size-3.5 text-zinc-500" />
+                        {{ $case->label() }}
+                    </button>
+                @endforeach
+            </div>
+        </div>
+    </template>
+</div>

--- a/resources/views/components/service/date-block.blade.php
+++ b/resources/views/components/service/date-block.blade.php
@@ -1,0 +1,15 @@
+@props([
+    'date',
+])
+
+<div class="flex w-16 shrink-0 flex-col items-center rounded-lg border border-zinc-200 bg-white py-1.5 dark:border-zinc-700 dark:bg-zinc-900">
+    <div class="text-[10px] font-bold uppercase tracking-[0.14em] text-accent">
+        {{ $date->format('M') }}
+    </div>
+    <div class="mt-0.5 text-[26px] font-bold leading-none tracking-tight text-zinc-900 tabular-nums dark:text-zinc-100">
+        {{ $date->format('j') }}
+    </div>
+    <div class="mt-1 text-[10px] font-medium text-zinc-500 tabular-nums dark:text-zinc-400">
+        {{ $date->format('Y') }}
+    </div>
+</div>

--- a/resources/views/components/service/inline-text.blade.php
+++ b/resources/views/components/service/inline-text.blade.php
@@ -1,0 +1,45 @@
+@props([
+    'wireModel',
+    'value' => null,
+    'placeholder' => 'Untitled',
+    'tag' => 'span',
+    'inputType' => 'text',
+])
+
+@php
+    $display = $value ?? '';
+    $base = $attributes->get('class', '');
+    $hoverClasses = 'cursor-text rounded-md hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors';
+    $padClasses = 'px-1.5 -mx-1.5';
+@endphp
+
+<div x-data="{ editing: false }" class="inline-block w-full max-w-full" wire:key="inline-{{ $wireModel }}">
+    <{{ $tag }}
+        x-show="!editing"
+        x-cloak
+        @click="editing = true; $nextTick(() => { $refs.inlineInput.focus(); $refs.inlineInput.select(); })"
+        @keydown.enter.prevent="editing = true; $nextTick(() => { $refs.inlineInput.focus(); $refs.inlineInput.select(); })"
+        tabindex="0"
+        title="Click to rename"
+        class="{{ $base }} {{ $padClasses }} {{ $hoverClasses }} block max-w-full truncate"
+    >
+        @if ($display !== '')
+            {{ $display }}
+        @else
+            <span class="italic text-zinc-400 dark:text-zinc-500">{{ $placeholder }}</span>
+        @endif
+    </{{ $tag }}>
+
+    <input
+        type="{{ $inputType }}"
+        x-show="editing"
+        x-ref="inlineInput"
+        x-cloak
+        wire:model.live.blur="{{ $wireModel }}"
+        placeholder="{{ $placeholder }}"
+        @blur="editing = false"
+        @keydown.enter.prevent="$refs.inlineInput.blur()"
+        @keydown.escape.prevent="$refs.inlineInput.blur()"
+        class="{{ $base }} {{ $padClasses }} block w-full max-w-full bg-transparent border-b border-accent outline-none"
+    />
+</div>

--- a/resources/views/components/service/stat.blade.php
+++ b/resources/views/components/service/stat.blade.php
@@ -1,0 +1,25 @@
+@props([
+    'label',
+    'value',
+    'warn' => false,
+])
+
+@php
+    $toneClass = $warn
+        ? 'text-orange-700 dark:text-orange-300'
+        : 'text-zinc-900 dark:text-zinc-100';
+@endphp
+
+<div class="flex flex-col">
+    <div class="flex items-baseline gap-1.5">
+        <div class="text-lg font-bold leading-none tracking-tight tabular-nums {{ $toneClass }}">
+            {{ $value }}
+        </div>
+        @if ($warn && $value > 0)
+            <div class="size-1.5 rounded-full bg-orange-500 dark:bg-orange-400"></div>
+        @endif
+    </div>
+    <div class="mt-1 text-[10px] font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
+        {{ $label }}
+    </div>
+</div>

--- a/resources/views/components/service/stats-strip.blade.php
+++ b/resources/views/components/service/stats-strip.blade.php
@@ -1,0 +1,25 @@
+@props([
+    'service',
+])
+
+@php
+    $sections = $service->sectionCount();
+    $elements = $service->elementCount();
+    $unassigned = $service->unassignedCount();
+    $missing = $service->missingContentCount();
+@endphp
+
+<div class="mt-4 flex flex-wrap items-center gap-x-6 gap-y-3 rounded-lg border border-zinc-200 bg-zinc-50 px-4 py-2.5 dark:border-zinc-700 dark:bg-zinc-900">
+    <x-service.stat label="Sections" :value="$sections" />
+    <div class="hidden h-6 w-px bg-zinc-200 sm:block dark:bg-zinc-700"></div>
+    <x-service.stat label="Elements" :value="$elements" />
+    <div class="hidden h-6 w-px bg-zinc-200 sm:block dark:bg-zinc-700"></div>
+    <x-service.stat label="Unassigned" :value="$unassigned" :warn="$unassigned > 0" />
+    <div class="hidden h-6 w-px bg-zinc-200 sm:block dark:bg-zinc-700"></div>
+    <x-service.stat label="Missing content" :value="$missing" :warn="$missing > 0" />
+    <div class="grow"></div>
+    <div class="hidden items-center gap-2 text-[11.5px] text-zinc-500 sm:flex dark:text-zinc-400">
+        <kbd class="rounded border border-zinc-200 bg-white px-1.5 py-0.5 font-mono text-[10px] dark:border-zinc-700 dark:bg-zinc-900">⌘K</kbd>
+        to search &amp; add
+    </div>
+</div>

--- a/resources/views/livewire/elements/_partials/assignee-chip.blade.php
+++ b/resources/views/livewire/elements/_partials/assignee-chip.blade.php
@@ -1,0 +1,90 @@
+@php
+    /** @var \App\Models\LiturgyElement $element */
+    /** @var \Illuminate\Support\Collection $users */
+    /** @var array<int,int> $recentIds */
+    /** @var bool $open */
+    /** @var string $search */
+    $assignee = $users->firstWhere('id', $element->assignee_id);
+    $recents = $users->whereIn('id', $recentIds)->where('id', '!=', $element->assignee_id);
+    $rest = $users->whereNotIn('id', $recentIds)->where('id', '!=', $element->assignee_id);
+    if ($search !== '') {
+        $haystack = strtolower($search);
+        $filter = fn ($u) => str_contains(strtolower($u->name), $haystack);
+        $recents = $recents->filter($filter);
+        $rest = $rest->filter($filter);
+    }
+@endphp
+
+<div class="relative w-full" x-data
+     @keydown.escape.window="$wire.set('assigneeOpen', false)">
+    <button type="button"
+            wire:click="$set('assigneeOpen', true)"
+            class="flex h-8 w-full items-center gap-2 rounded-full px-2.5 text-left text-[12.5px] transition hover:bg-zinc-100 dark:hover:bg-zinc-800 {{ $open ? 'bg-zinc-100 dark:bg-zinc-800' : '' }}">
+        @if ($assignee)
+            <flux:avatar :name="$assignee->name" size="xs" />
+            <span class="min-w-0 flex-1 truncate font-medium text-zinc-900 dark:text-zinc-100">{{ $assignee->name }}</span>
+        @else
+            <span class="flex size-6 shrink-0 items-center justify-center rounded-full border border-dashed border-zinc-300 text-zinc-400 dark:border-zinc-600 dark:text-zinc-500">
+                <flux:icon name="user" class="size-3" />
+            </span>
+            <span class="flex-1 italic text-zinc-500 dark:text-zinc-400">Unassigned</span>
+        @endif
+    </button>
+
+    @if ($open)
+        <div wire:click="$set('assigneeOpen', false)" class="fixed inset-0 z-40 bg-black/5"></div>
+        <div class="absolute left-0 top-[calc(100%+4px)] z-50 w-72 overflow-hidden rounded-xl border border-zinc-200 bg-white shadow-lg dark:border-zinc-700 dark:bg-zinc-900">
+            <div class="border-b border-zinc-200 px-3 py-2 dark:border-zinc-700">
+                <input type="text"
+                       x-init="$el.focus()"
+                       wire:model.live.debounce.200ms="assigneeSearch"
+                       placeholder="Search people…"
+                       class="h-7 w-full border-0 bg-transparent text-[13px] text-zinc-900 placeholder-zinc-400 focus:outline-none focus:ring-0 dark:text-zinc-100" />
+            </div>
+
+            <div class="max-h-72 overflow-y-auto p-1">
+                @if ($assignee)
+                    <button type="button" wire:click="setAssignee(null)"
+                            class="flex w-full items-center gap-2.5 rounded-md px-2.5 py-1.5 text-left text-[12.5px] text-zinc-700 hover:bg-zinc-100 dark:text-zinc-200 dark:hover:bg-zinc-800">
+                        <span class="flex size-6 shrink-0 items-center justify-center rounded-full bg-zinc-100 text-zinc-500 dark:bg-zinc-800">
+                            <flux:icon name="x-mark" class="size-3" />
+                        </span>
+                        <span class="italic">Unassign</span>
+                    </button>
+                    <div class="my-1 h-px bg-zinc-100 dark:bg-zinc-800"></div>
+                @endif
+
+                @if ($recents->isNotEmpty())
+                    <div class="px-2 pt-1 pb-1 text-[10px] font-semibold uppercase tracking-wider text-zinc-400">Recent in this service</div>
+                    @foreach ($recents as $user)
+                        <button type="button" wire:key="recent-{{ $user->id }}" wire:click="setAssignee({{ $user->id }})"
+                                class="flex w-full items-center gap-2.5 rounded-md px-2.5 py-1.5 text-left text-[12.5px] hover:bg-zinc-100 dark:hover:bg-zinc-800">
+                            <flux:avatar :name="$user->name" size="xs" />
+                            <span class="truncate text-zinc-900 dark:text-zinc-100">{{ $user->name }}</span>
+                        </button>
+                    @endforeach
+                    @if ($rest->isNotEmpty())
+                        <div class="my-1 h-px bg-zinc-100 dark:bg-zinc-800"></div>
+                    @endif
+                @endif
+
+                @if ($rest->isNotEmpty())
+                    @if ($recents->isEmpty() && $search === '')
+                        <div class="px-2 pt-1 pb-1 text-[10px] font-semibold uppercase tracking-wider text-zinc-400">People</div>
+                    @endif
+                    @foreach ($rest as $user)
+                        <button type="button" wire:key="all-{{ $user->id }}" wire:click="setAssignee({{ $user->id }})"
+                                class="flex w-full items-center gap-2.5 rounded-md px-2.5 py-1.5 text-left text-[12.5px] hover:bg-zinc-100 dark:hover:bg-zinc-800">
+                            <flux:avatar :name="$user->name" size="xs" />
+                            <span class="truncate text-zinc-900 dark:text-zinc-100">{{ $user->name }}</span>
+                        </button>
+                    @endforeach
+                @endif
+
+                @if ($recents->isEmpty() && $rest->isEmpty())
+                    <div class="px-3 py-6 text-center text-[12.5px] text-zinc-500">No people match.</div>
+                @endif
+            </div>
+        </div>
+    @endif
+</div>

--- a/resources/views/livewire/elements/_partials/content-chip.blade.php
+++ b/resources/views/livewire/elements/_partials/content-chip.blade.php
@@ -1,0 +1,70 @@
+@php
+    /** @var \App\Models\LiturgyElement $element */
+    /** @var \Illuminate\Support\Collection $items */
+    /** @var string $variant */  // 'song' | 'reading'
+    /** @var bool $open */
+    /** @var string $search */
+    $selected = $element->content;
+    $icon = $variant === 'song' ? 'musical-note' : 'book-open-text';
+    $placeholder = $variant === 'song' ? 'Pick a song' : 'Pick a reading';
+    $searchPlaceholder = $variant === 'song' ? 'Search songs…' : 'Search readings…';
+    $titleField = $variant === 'song' ? 'name' : 'title';
+@endphp
+
+<div class="relative w-full" x-data
+     @keydown.escape.window="$wire.set('contentOpen', false)">
+    <button type="button"
+            wire:click="$set('contentOpen', true)"
+            class="flex h-8 w-full items-center gap-2 rounded-full px-3 text-left text-[12.5px] transition
+                   {{ $selected ? 'hover:bg-zinc-100 dark:hover:bg-zinc-800' : 'border border-dashed border-zinc-300 dark:border-zinc-600' }}
+                   {{ $open ? 'bg-zinc-100 dark:bg-zinc-800' : '' }}">
+        <flux:icon name="{{ $icon }}" class="size-3 shrink-0 text-zinc-500" />
+        @if ($selected)
+            <span class="min-w-0 flex-1 truncate font-medium text-zinc-900 dark:text-zinc-100">{{ $selected->{$titleField} }}</span>
+        @else
+            <span class="flex-1 italic text-zinc-500 dark:text-zinc-400">{{ $placeholder }}</span>
+        @endif
+    </button>
+
+    @if ($open)
+        <div wire:click="$set('contentOpen', false)" class="fixed inset-0 z-40 bg-black/5"></div>
+        <div class="absolute left-0 top-[calc(100%+4px)] z-50 w-80 overflow-hidden rounded-xl border border-zinc-200 bg-white shadow-lg dark:border-zinc-700 dark:bg-zinc-900">
+            <div class="border-b border-zinc-200 px-3 py-2 dark:border-zinc-700">
+                <input type="text"
+                       x-init="$el.focus()"
+                       wire:model.live.debounce.300ms="contentSearch"
+                       placeholder="{{ $searchPlaceholder }}"
+                       class="h-7 w-full border-0 bg-transparent text-[13px] text-zinc-900 placeholder-zinc-400 focus:outline-none focus:ring-0 dark:text-zinc-100" />
+            </div>
+
+            <div class="max-h-72 overflow-y-auto p-1">
+                @if ($selected)
+                    <button type="button" wire:click="setContent(null)"
+                            class="flex w-full items-center gap-2.5 rounded-md px-2.5 py-1.5 text-left text-[12.5px] text-zinc-700 hover:bg-zinc-100 dark:text-zinc-200 dark:hover:bg-zinc-800">
+                        <flux:icon name="x-mark" class="size-3 text-zinc-500" />
+                        <span class="italic">Clear</span>
+                    </button>
+                    <div class="my-1 h-px bg-zinc-100 dark:bg-zinc-800"></div>
+                @endif
+
+                @if ($items->isEmpty())
+                    <div class="px-3 py-6 text-center text-[12.5px] text-zinc-500">
+                        @if ($search === '')
+                            Start typing to search.
+                        @else
+                            No {{ $variant === 'song' ? 'songs' : 'readings' }} match.
+                        @endif
+                    </div>
+                @else
+                    @foreach ($items as $item)
+                        <button type="button" wire:key="content-{{ $item->id }}" wire:click="setContent({{ $item->id }})"
+                                class="flex w-full items-center gap-2.5 rounded-md px-2.5 py-1.5 text-left text-[12.5px] hover:bg-zinc-100 dark:hover:bg-zinc-800">
+                            <flux:icon name="{{ $icon }}" class="size-3 shrink-0 text-zinc-500" />
+                            <span class="truncate text-zinc-900 dark:text-zinc-100">{{ $item->{$titleField} }}</span>
+                        </button>
+                    @endforeach
+                @endif
+            </div>
+        </div>
+    @endif
+</div>

--- a/resources/views/livewire/elements/other.blade.php
+++ b/resources/views/livewire/elements/other.blade.php
@@ -1,67 +1,154 @@
 <?php
+
+use App\Enums\LiturgyElementType;
 use App\Models\LiturgyElement;
+use App\Support\SectionTone;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Livewire\Attributes\Locked;
 use Livewire\Component;
 
 new class extends Component {
     public LiturgyElement $element;
 
-    public function delete()
+    #[Locked]
+    public Collection $users;
+
+    /** @var array<int,int> */
+    #[Locked]
+    public array $recentAssigneeIds = [];
+
+    public ?string $sectionColor = null;
+
+    public ?int $sectionIndex = null;
+
+    public ?int $sectionElementCount = null;
+
+    public bool $isFirstInSection = false;
+
+    public bool $isLastInSection = false;
+
+    public string $name;
+
+    public bool $assigneeOpen = false;
+
+    public string $assigneeSearch = '';
+
+    public function mount(?Collection $users = null): void
     {
-        $this->modal("delete-element")->show();
+        $this->users = $users ?? collect();
+        $this->name = $this->element->name;
+    }
+
+    public function updatedName(string $value): void
+    {
+        $this->element->update(['name' => $value]);
+        $this->dispatch('service-element-changed');
+    }
+
+    public function setAssignee(?int $userId): void
+    {
+        $this->element->update(['assignee_id' => $userId]);
+        $this->assigneeOpen = false;
+        $this->assigneeSearch = '';
+        $this->dispatch('service-element-changed');
+        Flux::toast(variant: 'success', text: 'Assignee saved.');
+    }
+
+    public function delete(): void
+    {
+        $this->modal('delete-element')->show();
+    }
+
+    public function duplicate(): void
+    {
+        DB::transaction(function () {
+            $copy = $this->element->replicate();
+            $copy->order = $this->element->order + 1;
+            $copy->save();
+
+            LiturgyElement::query()
+                ->where('liturgy_type', $this->element->liturgy_type)
+                ->where('liturgy_id', $this->element->liturgy_id)
+                ->where('order', '>=', $copy->order)
+                ->where('id', '!=', $copy->id)
+                ->increment('order');
+        });
+
+        $this->dispatch('service-element-changed');
+        Flux::toast(variant: 'success', text: 'Element duplicated.');
     }
 };
 ?>
 
-<flux:table.row :x-sort:item="$element->id">
-    <flux:table.cell>
-        <div class="flex flex-col md:flex-row gap-2 md:gap-x-2 md:items-center pl-1 group">
-            <div x-sort-handle class="cursor-grab active:cursor-grabbing hidden group-hover:block" title="Drag to reorder">
-                <flux:icon class="text-zinc-300" name="grip" />
-            </div>
-            <div class="flex-1 flex items-center gap-1">
-                <div>
-                    <flux:icon icon="{{ $element->type->icon() }}" />
-                </div>
-                <div>
-                    <flux:heading>{{ $element->name }}</flux:heading>
-                    @if($element->description)
-                        <flux:subheading>{{ $element->description }}</flux:subheading>
-                    @endif
-                </div>
-            </div>
-            <div class="hidden md:block md:pr-2">
-                <flux:dropdown align="end" offset="-15">
-                    <flux:button variant="ghost" size="sm" icon="ellipsis-horizontal" inset="bottom" />
+@php
+    $tone = SectionTone::classesFor($sectionColor);
+    $showStripe = $sectionColor !== null;
+@endphp
 
-                    <flux:menu class="min-w-32">
-                        <flux:menu.item wire:click="$dispatch('edit-element', { id: {{ $element->id }} })" icon="pencil-square"  class="cursor-default">Edit</flux:menu.item>
-                        <flux:menu.item wire:click="delete" icon="trash" variant="danger">Delete</flux:menu.item>
-                    </flux:menu>
-                </flux:dropdown>
-            </div>
+<div :x-sort:item="$element->id" wire:key="other-{{ $element->id }}"
+     class="group relative grid items-center gap-3 border-b border-zinc-100 px-2 py-2 transition-colors hover:bg-zinc-50 dark:border-zinc-800 dark:hover:bg-zinc-900
+            {{ $showStripe ? 'grid-cols-[4px_18px_36px_minmax(140px,1fr)_minmax(140px,200px)_minmax(160px,240px)_32px]' : 'grid-cols-[18px_36px_minmax(140px,1fr)_minmax(140px,200px)_minmax(160px,240px)_32px]' }}">
+
+    @if ($showStripe)
+        <div class="-my-2 self-stretch rounded-sm opacity-60 {{ $tone['stripe'] }}"></div>
+    @endif
+
+    <div x-sort-handle class="flex h-6 cursor-grab items-center justify-center text-zinc-300 opacity-0 transition-opacity group-hover:opacity-100 dark:text-zinc-600" title="Drag to reorder">
+        <flux:icon name="bars-2" class="size-3.5" />
+    </div>
+
+    <div class="flex size-9 items-center justify-center rounded-lg {{ $tone['swatch'] }}">
+        <flux:icon name="{{ $element->type->icon() }}" class="size-4" />
+    </div>
+
+    <div class="min-w-0">
+        <div class="text-[13.5px] font-semibold text-zinc-900 dark:text-zinc-100">
+            <x-service.inline-text
+                wire-model="name"
+                :value="$name"
+                :placeholder="$element->type->label()"
+                class="text-[13.5px] font-semibold"
+            />
         </div>
+        <div class="text-[10.5px] font-medium uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
+            {{ $element->type->label() }}
+        </div>
+    </div>
 
-        <flux:modal name="delete-element" class="min-w-[22rem]">
-            <form wire:submit="$parent.delete({{ $element->id }})" class="space-y-6">
-                <div>
-                    <flux:heading size="lg">Delete liturgy element?</flux:heading>
+    @include('livewire.elements._partials.assignee-chip', [
+        'element' => $element,
+        'users' => $users,
+        'recentIds' => $recentAssigneeIds,
+        'open' => $assigneeOpen,
+        'search' => $assigneeSearch,
+    ])
 
-                    <flux:subheading>
-                        <p>This will permanently delete the liturgy element.</p>
-                        <p>It cannot be undone.</p>
-                    </flux:subheading>
-                </div>
+    <div class="flex h-8 items-center px-3 text-[12px] italic text-zinc-400 dark:text-zinc-500">
+        — no content needed —
+    </div>
 
-                <div class="flex gap-2">
-                    <flux:spacer />
+    <flux:dropdown align="end" offset="-15">
+        <flux:button variant="ghost" size="sm" icon="ellipsis-horizontal" inset="bottom" />
+        <flux:menu class="min-w-36">
+            <flux:menu.item wire:click="duplicate" icon="document-duplicate">Duplicate</flux:menu.item>
+            <flux:menu.item wire:click="delete" icon="trash" variant="danger">Delete</flux:menu.item>
+        </flux:menu>
+    </flux:dropdown>
 
-                    <flux:modal.close>
-                        <flux:button variant="ghost">Cancel</flux:button>
-                    </flux:modal.close>
-
-                    <flux:button type="submit" variant="danger">Delete Element</flux:button>
-                </div>
-            </form>
-        </flux:modal>
-    </flux:table.cell>
-</flux:table.row>
+    <flux:modal name="delete-element" class="min-w-[22rem]">
+        <form wire:submit="$parent.delete({{ $element->id }})" class="space-y-6">
+            <div>
+                <flux:heading size="lg">Delete element?</flux:heading>
+                <flux:subheading>This will permanently delete the liturgy element. It cannot be undone.</flux:subheading>
+            </div>
+            <div class="flex gap-2">
+                <flux:spacer />
+                <flux:modal.close>
+                    <flux:button variant="ghost">Cancel</flux:button>
+                </flux:modal.close>
+                <flux:button type="submit" variant="danger">Delete Element</flux:button>
+            </div>
+        </form>
+    </flux:modal>
+</div>

--- a/resources/views/livewire/elements/reading.blade.php
+++ b/resources/views/livewire/elements/reading.blade.php
@@ -2,7 +2,9 @@
 
 use App\Models\LiturgyElement;
 use App\Models\Reading;
+use App\Support\SectionTone;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Locked;
 use Livewire\Component;
@@ -13,154 +15,183 @@ new class extends Component {
     #[Locked]
     public Collection $users;
 
-    public $selectedContent;
-    public $assigneeId;
-    public string $search = '';
+    /** @var array<int,int> */
+    #[Locked]
+    public array $recentAssigneeIds = [];
+
+    public ?string $sectionColor = null;
+
+    public ?int $sectionIndex = null;
+
+    public ?int $sectionElementCount = null;
+
+    public bool $isFirstInSection = false;
+
+    public bool $isLastInSection = false;
+
+    public string $name;
+
+    public bool $assigneeOpen = false;
+
+    public bool $contentOpen = false;
+
+    public string $assigneeSearch = '';
+
+    public string $contentSearch = '';
 
     public function mount(?Collection $users = null): void
     {
         $this->users = $users ?? collect();
-        $this->selectedContent = $this->element->content_id;
-        $this->assigneeId = $this->element->assignee_id;
+        $this->name = $this->element->name;
     }
 
-    public function updated($name, $value): void
+    public function updatedName(string $value): void
     {
-        switch ($name) {
-            case "selectedContent":
-                $reading = Reading::findOrFail($value);
-                $this->element->content()->associate($reading);
-                $this->element->save();
-                $this->element->refresh();
-                $this->selectedContent = $this->element->content_id;
-                $this->dispatch('service-element-changed');
-                Flux::toast(
-                    variant: "success",
-                    text: "Reading selection saved.",
-                );
-                break;
-            case "assigneeId":
-                $this->element->assignee_id = $value;
-                $this->element->save();
-                $this->element->refresh();
-                $this->assigneeId = $this->element->assignee_id;
-                $this->dispatch('service-element-changed');
-                Flux::toast(variant: "success", text: "Assignee saved.");
-                break;
+        $this->element->update(['name' => $value]);
+        $this->dispatch('service-element-changed');
+    }
+
+    public function setAssignee(?int $userId): void
+    {
+        $this->element->update(['assignee_id' => $userId]);
+        $this->assigneeOpen = false;
+        $this->assigneeSearch = '';
+        $this->dispatch('service-element-changed');
+        Flux::toast(variant: 'success', text: 'Assignee saved.');
+    }
+
+    public function setContent(?int $readingId): void
+    {
+        if ($readingId === null) {
+            $this->element->content()->dissociate();
+        } else {
+            $reading = Reading::findOrFail($readingId);
+            $this->element->content()->associate($reading);
         }
+        $this->element->save();
+        $this->contentOpen = false;
+        $this->contentSearch = '';
+        $this->dispatch('service-element-changed');
+        Flux::toast(variant: 'success', text: 'Reading selection saved.');
     }
 
     public function delete(): void
     {
-        $this->modal("delete-element")->show();
+        $this->modal('delete-element')->show();
+    }
+
+    public function duplicate(): void
+    {
+        DB::transaction(function () {
+            $copy = $this->element->replicate();
+            $copy->order = $this->element->order + 1;
+            $copy->save();
+
+            LiturgyElement::query()
+                ->where('liturgy_type', $this->element->liturgy_type)
+                ->where('liturgy_id', $this->element->liturgy_id)
+                ->where('order', '>=', $copy->order)
+                ->where('id', '!=', $copy->id)
+                ->increment('order');
+        });
+
+        $this->dispatch('service-element-changed');
+        Flux::toast(variant: 'success', text: 'Reading duplicated.');
     }
 
     #[Computed]
     public function readings(): Collection
     {
-        $readings = collect();
-
-        if ($this->search !== '') {
-            $query = Reading::query()
-                ->where('title', 'like', '%' . $this->search . '%')
-                ->orderBy('title');
-
-            if ($this->element->reading_type) {
-                $query->where('type', $this->element->reading_type);
-            }
-
-            $readings = $query->limit(50)->get();
+        if ($this->contentSearch === '') {
+            return collect();
         }
 
-        if ($this->selectedContent && ! $readings->contains('id', $this->selectedContent)) {
-            $selected = Reading::find($this->selectedContent);
+        $query = Reading::query()
+            ->where('title', 'like', '%'.$this->contentSearch.'%')
+            ->orderBy('title');
 
-            if ($selected) {
-                $readings = $readings->prepend($selected);
-            }
+        if ($this->element->reading_type) {
+            $query->where('type', $this->element->reading_type);
         }
 
-        return $readings;
+        return $query->limit(50)->get();
     }
 };
 ?>
 
-<flux:table.row :x-sort:item="$element->id">
-    <flux:table.cell>
-        <div class="flex flex-col md:flex-row gap-2 md:gap-x-2 md:items-center pl-1 group">
-            <div x-sort-handle class="cursor-grab hidden group-hover:block" title="Drag to reorder">
-                <flux:icon class="text-zinc-300" name="grip" />
-            </div>
-            <div class="flex-1 flex items-center gap-1">
-                <div>
-                    <flux:icon icon="{{ $element->type->icon() }}" />
-                </div>
-                <div>
-                    <flux:heading>{{ $element->name }}</flux:heading>
-                    @if($element->description)
-                        <flux:subheading>{{ $element->description }}</flux:subheading>
-                    @endif
-                </div>
-            </div>
-            <div>
-                <flux:select variant="combobox" size="sm" wire:model.live="assigneeId" placeholder="Assign element...">
-                    @foreach($users as $user)
-                        <flux:select.option value="{{ $user->id }}">{{ $user->name }}</flux:select.option>
-                    @endforeach
-                </flux:select>
-            </div>
-            <div class="md:w-[226px]">
-                <flux:select
-                    variant="listbox"
-                    searchable
-                    :filter="false"
-                    size="sm"
-                    wire:model.live="selectedContent"
-                    placeholder="Select a reading..."
-                >
-                    <x-slot:search>
-                        <flux:select.search wire:model.live.debounce.300ms="search" placeholder="Search readings..." />
-                    </x-slot:search>
+@php
+    $tone = SectionTone::classesFor($sectionColor);
+    $showStripe = $sectionColor !== null;
+@endphp
 
-                    @foreach($this->readings as $reading)
-                        <flux:select.option :value="$reading->id" wire:key="reading-option-{{ $reading->id }}">{{ $reading->title }}</flux:select.option>
-                    @endforeach
-                </flux:select>
-            </div>
-            <div class="hidden md:block md:pr-2">
-                <flux:dropdown align="end" offset="-15">
-                    <flux:button variant="ghost" size="sm" icon="ellipsis-horizontal" inset="bottom" />
+<div :x-sort:item="$element->id" wire:key="reading-{{ $element->id }}"
+     class="group relative grid items-center gap-3 border-b border-zinc-100 px-2 py-2 transition-colors hover:bg-zinc-50 dark:border-zinc-800 dark:hover:bg-zinc-900
+            {{ $showStripe ? 'grid-cols-[4px_18px_36px_minmax(140px,1fr)_minmax(140px,200px)_minmax(160px,240px)_32px]' : 'grid-cols-[18px_36px_minmax(140px,1fr)_minmax(140px,200px)_minmax(160px,240px)_32px]' }}">
 
-                    <flux:menu class="min-w-32">
-                        <flux:menu.item href="{{ route('readings.create') }}" icon="plus-circle">New Reading</flux:menu.item>
-                        <flux:menu.item wire:click="$dispatch('edit-element', { id: {{ $element->id }} })" icon="pencil-square"  class="cursor-default">Edit</flux:menu.item>
-                        <flux:menu.item wire:click="delete" icon="trash" variant="danger">Delete</flux:menu.item>
-                    </flux:menu>
-                </flux:dropdown>
-            </div>
+    @if ($showStripe)
+        <div class="-my-2 self-stretch rounded-sm opacity-60 {{ $tone['stripe'] }}"></div>
+    @endif
+
+    <div x-sort-handle class="flex h-6 cursor-grab items-center justify-center text-zinc-300 opacity-0 transition-opacity group-hover:opacity-100 dark:text-zinc-600" title="Drag to reorder">
+        <flux:icon name="bars-2" class="size-3.5" />
+    </div>
+
+    <div class="flex size-9 items-center justify-center rounded-lg {{ $tone['swatch'] }}">
+        <flux:icon name="{{ $element->type->icon() }}" class="size-4" />
+    </div>
+
+    <div class="min-w-0">
+        <div class="text-[13.5px] font-semibold text-zinc-900 dark:text-zinc-100">
+            <x-service.inline-text
+                wire-model="name"
+                :value="$name"
+                :placeholder="$element->type->label()"
+                class="text-[13.5px] font-semibold"
+            />
         </div>
+        <div class="text-[10.5px] font-medium uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
+            {{ $element->type->label() }}
+        </div>
+    </div>
 
-        <flux:modal name="delete-element" class="min-w-[22rem]">
-            <form wire:submit="$parent.delete({{ $element->id }})" class="space-y-6">
-                <div>
-                    <flux:heading size="lg">Delete liturgy element?</flux:heading>
+    @include('livewire.elements._partials.assignee-chip', [
+        'element' => $element,
+        'users' => $users,
+        'recentIds' => $recentAssigneeIds,
+        'open' => $assigneeOpen,
+        'search' => $assigneeSearch,
+    ])
 
-                    <flux:subheading>
-                        <p>This will permanently delete the liturgy element.</p>
-                        <p>It cannot be undone.</p>
-                    </flux:subheading>
-                </div>
+    @include('livewire.elements._partials.content-chip', [
+        'element' => $element,
+        'items' => $this->readings,
+        'variant' => 'reading',
+        'open' => $contentOpen,
+        'search' => $contentSearch,
+    ])
 
-                <div class="flex gap-2">
-                    <flux:spacer />
+    <flux:dropdown align="end" offset="-15">
+        <flux:button variant="ghost" size="sm" icon="ellipsis-horizontal" inset="bottom" />
+        <flux:menu class="min-w-36">
+            <flux:menu.item href="{{ route('readings.create') }}" icon="plus">New reading</flux:menu.item>
+            <flux:menu.item wire:click="duplicate" icon="document-duplicate">Duplicate</flux:menu.item>
+            <flux:menu.item wire:click="delete" icon="trash" variant="danger">Delete</flux:menu.item>
+        </flux:menu>
+    </flux:dropdown>
 
-                    <flux:modal.close>
-                        <flux:button variant="ghost">Cancel</flux:button>
-                    </flux:modal.close>
-
-                    <flux:button type="submit" variant="danger">Delete Element</flux:button>
-                </div>
-            </form>
-        </flux:modal>
-    </flux:table.cell>
-</flux:table.row>
+    <flux:modal name="delete-element" class="min-w-[22rem]">
+        <form wire:submit="$parent.delete({{ $element->id }})" class="space-y-6">
+            <div>
+                <flux:heading size="lg">Delete reading?</flux:heading>
+                <flux:subheading>This will permanently delete the liturgy element. It cannot be undone.</flux:subheading>
+            </div>
+            <div class="flex gap-2">
+                <flux:spacer />
+                <flux:modal.close>
+                    <flux:button variant="ghost">Cancel</flux:button>
+                </flux:modal.close>
+                <flux:button type="submit" variant="danger">Delete Element</flux:button>
+            </div>
+        </form>
+    </flux:modal>
+</div>

--- a/resources/views/livewire/elements/section.blade.php
+++ b/resources/views/livewire/elements/section.blade.php
@@ -1,61 +1,184 @@
 <?php
 
-use Livewire\Component;
+use App\Enums\LiturgyElementType;
 use App\Models\LiturgyElement;
+use App\Support\SectionTone;
+use Illuminate\Support\Collection;
+use Livewire\Attributes\Locked;
+use Livewire\Component;
 
 new class extends Component {
     public LiturgyElement $element;
 
+    #[Locked]
+    public Collection $users;
+
+    /** @var array<int, int> */
+    #[Locked]
+    public array $recentAssigneeIds = [];
+
+    public ?string $sectionColor = null;
+
+    public ?int $sectionIndex = null;
+
+    public ?int $sectionElementCount = null;
+
+    public bool $isFirstInSection = false;
+
+    public bool $isLastInSection = false;
+
+    public string $name;
+
+    public ?string $description;
+
+    public bool $addOpen = false;
+
+    public function mount(?Collection $users = null): void
+    {
+        $this->users = $users ?? collect();
+        $this->name = $this->element->name;
+        $this->description = $this->element->description;
+    }
+
+    public function updatedName(string $value): void
+    {
+        $this->element->update(['name' => $value]);
+        $this->dispatch('service-element-changed');
+        Flux::toast(variant: 'success', text: 'Section renamed.');
+    }
+
+    public function updatedDescription(?string $value): void
+    {
+        $this->element->update(['description' => $value]);
+        $this->dispatch('service-element-changed');
+        Flux::toast(variant: 'success', text: 'Section description saved.');
+    }
+
+    public function recolor(string $color): void
+    {
+        $this->element->update(['section_color' => $color]);
+        $this->sectionColor = $color;
+        $this->dispatch('service-element-changed');
+        Flux::toast(variant: 'success', text: 'Section color updated.');
+    }
+
     public function delete(): void
     {
-        $this->modal("delete-element")->show();
+        $this->modal('delete-element')->show();
+    }
+
+    public function addElement(string $type): void
+    {
+        $this->addOpen = false;
+        $this->dispatch('add-element-after', afterId: $this->element->id, type: $type);
     }
 };
 ?>
 
-<flux:table.row :x-sort:item="$element->id">
-    <flux:table.cell class="bg-zinc-50 dark:bg-zinc-900">
-        <div class="flex flex-col md:flex-row gap-2 md:gap-x-2 md:items-center pl-1 group">
-            <div x-sort-handle class="cursor-grab hidden group-hover:block" title="Drag to reorder">
-                <flux:icon class="text-zinc-300" name="grip" />
-            </div>
-            <div class="flex-1">
-                <flux:heading size="lg">{{ $element->name }}</flux:heading>
-                <flux:subheading size="sm">{{ $element->description }}</flux:subheading>
-            </div>
-            <div class="hidden md:block md:pr-2">
-                <flux:dropdown align="end" offset="-15">
-                    <flux:button variant="ghost" size="sm" icon="ellipsis-horizontal" inset="bottom" />
+@php
+    $tone = SectionTone::classesFor($sectionColor);
+    $countLabel = $sectionElementCount === 1 ? '1 element' : ($sectionElementCount ?? 0).' elements';
+@endphp
 
-                    <flux:menu class="min-w-32">
-                        <flux:menu.item wire:click="$dispatch('edit-element', { id: {{ $element->id }} })" icon="pencil-square"  class="cursor-default">Edit</flux:menu.item>
-                        <flux:menu.item wire:click="delete" icon="trash" variant="danger">Delete</flux:menu.item>
-                    </flux:menu>
-                </flux:dropdown>
+<div :x-sort:item="$element->id" wire:key="section-{{ $element->id }}"
+     class="group mt-6 grid grid-cols-[4px_1fr_auto] items-stretch gap-4">
+
+    <div class="rounded-sm {{ $tone['stripe'] }}"></div>
+
+    <div class="min-w-0 py-0.5">
+        <div class="flex items-baseline gap-3">
+            <div class="text-[11px] font-bold uppercase tracking-[0.12em] tabular-nums {{ $tone['dot'] }}">
+                {{ str_pad((string) ($sectionIndex ?? 0), 2, '0', STR_PAD_LEFT) }}
+            </div>
+
+            <h2 class="m-0 min-w-0 flex-1 text-2xl font-bold tracking-tight text-zinc-900 dark:text-zinc-100">
+                <x-service.inline-text
+                    wire-model="name"
+                    :value="$name"
+                    placeholder="Untitled section"
+                    class="text-2xl font-bold tracking-tight"
+                />
+            </h2>
+
+            <div class="rounded-full bg-zinc-100 px-2 py-0.5 text-[11px] font-medium text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400">
+                {{ $countLabel }}
             </div>
         </div>
 
-        <flux:modal name="delete-element" class="min-w-[22rem]">
-            <form wire:submit="$parent.delete({{ $element->id }})" class="space-y-6">
-                <div>
-                    <flux:heading size="lg">Delete liturgy element?</flux:heading>
+        <div class="mt-1 max-w-[680px] text-[12.5px] leading-relaxed text-zinc-600 dark:text-zinc-400">
+            <x-service.inline-text
+                wire-model="description"
+                :value="$description"
+                placeholder="Add a section description…"
+                class="text-[12.5px] leading-relaxed"
+            />
+        </div>
+    </div>
 
-                    <flux:subheading>
-                        <p>This will permanently delete the liturgy element.</p>
-                        <p>It cannot be undone.</p>
-                    </flux:subheading>
+    <div class="flex items-start gap-1 pt-0.5">
+        <div x-sort-handle class="hidden cursor-grab items-center text-zinc-300 group-hover:flex dark:text-zinc-600" title="Drag to reorder">
+            <flux:icon name="bars-2" class="size-4" />
+        </div>
+
+        <div class="relative" x-data>
+            <button type="button" wire:click="$set('addOpen', true)"
+                    class="flex size-7 items-center justify-center rounded-md text-zinc-500 hover:bg-zinc-100 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-100"
+                    title="Add element to this section">
+                <flux:icon name="plus" class="size-3.5" />
+            </button>
+
+            @if ($addOpen)
+                <div wire:click="$set('addOpen', false)" class="fixed inset-0 z-40 bg-black/5"></div>
+                <div class="absolute right-0 top-[calc(100%+4px)] z-50 w-44 overflow-hidden rounded-lg border border-zinc-200 bg-white p-1 shadow-lg dark:border-zinc-700 dark:bg-zinc-900"
+                     x-data @keydown.escape.window="$wire.set('addOpen', false)">
+                    @foreach (LiturgyElementType::cases() as $case)
+                        @continue($case === LiturgyElementType::SECTION)
+                        <button type="button" wire:click="addElement('{{ $case->value }}')"
+                                class="flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-[13px] text-zinc-700 hover:bg-zinc-100 dark:text-zinc-200 dark:hover:bg-zinc-800">
+                            <flux:icon name="{{ $case->icon() }}" class="size-3.5 text-zinc-500" />
+                            {{ $case->label() }}
+                        </button>
+                    @endforeach
                 </div>
+            @endif
+        </div>
 
-                <div class="flex gap-2">
-                    <flux:spacer />
+        <flux:dropdown align="end" offset="-15">
+            <flux:button variant="ghost" size="sm" icon="ellipsis-horizontal" inset="bottom" />
+            <flux:menu class="min-w-44">
+                <flux:menu.submenu heading="Change color" icon="swatch">
+                    @foreach (SectionTone::PALETTE as $color)
+                        <flux:menu.item wire:click="recolor('{{ $color }}')">
+                            <span class="flex items-center gap-2">
+                                <span class="size-3 rounded-full {{ SectionTone::classesFor($color)['stripe'] }}"></span>
+                                <span class="capitalize">{{ $color }}</span>
+                                @if ($color === $sectionColor)
+                                    <flux:icon name="check" class="ml-auto size-3 text-emerald-600" />
+                                @endif
+                            </span>
+                        </flux:menu.item>
+                    @endforeach
+                </flux:menu.submenu>
+                <flux:menu.item wire:click="delete" icon="trash" variant="danger">Delete</flux:menu.item>
+            </flux:menu>
+        </flux:dropdown>
+    </div>
 
-                    <flux:modal.close>
-                        <flux:button variant="ghost">Cancel</flux:button>
-                    </flux:modal.close>
-
-                    <flux:button type="submit" variant="danger">Delete Element</flux:button>
-                </div>
-            </form>
-        </flux:modal>
-    </flux:table.cell>
-</flux:table.row>
+    <flux:modal name="delete-element" class="min-w-[22rem]">
+        <form wire:submit="$parent.delete({{ $element->id }})" class="space-y-6">
+            <div>
+                <flux:heading size="lg">Delete section?</flux:heading>
+                <flux:subheading>
+                    <p>This will permanently delete the section. Elements inside it will remain.</p>
+                </flux:subheading>
+            </div>
+            <div class="flex gap-2">
+                <flux:spacer />
+                <flux:modal.close>
+                    <flux:button variant="ghost">Cancel</flux:button>
+                </flux:modal.close>
+                <flux:button type="submit" variant="danger">Delete Section</flux:button>
+            </div>
+        </form>
+    </flux:modal>
+</div>

--- a/resources/views/livewire/elements/sermon.blade.php
+++ b/resources/views/livewire/elements/sermon.blade.php
@@ -1,7 +1,9 @@
 <?php
 
 use App\Models\LiturgyElement;
+use App\Support\SectionTone;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
 use Livewire\Attributes\Locked;
 use Livewire\Component;
 
@@ -11,101 +13,155 @@ new class extends Component {
     #[Locked]
     public Collection $users;
 
-    public $description;
-    public $assigneeId;
+    /** @var array<int,int> */
+    #[Locked]
+    public array $recentAssigneeIds = [];
+
+    public ?string $sectionColor = null;
+
+    public ?int $sectionIndex = null;
+
+    public ?int $sectionElementCount = null;
+
+    public bool $isFirstInSection = false;
+
+    public bool $isLastInSection = false;
+
+    public string $name;
+
+    public ?string $description = null;
+
+    public bool $assigneeOpen = false;
+
+    public string $assigneeSearch = '';
 
     public function mount(?Collection $users = null): void
     {
         $this->users = $users ?? collect();
+        $this->name = $this->element->name;
         $this->description = $this->element->description;
-        $this->assigneeId = $this->element->assignee_id;
     }
 
-    public function updated($name, $value): void
+    public function updatedName(string $value): void
     {
-        switch ($name) {
-            case "description":
-                $this->element->description = $value;
-                $this->element->save();
-                $this->dispatch('service-element-changed');
-                Flux::toast(
-                    variant: "success",
-                    text: "Sermon description saved.",
-                );
-                break;
-            case "assigneeId":
-                $this->element->assignee_id = $value;
-                $this->element->save();
-                $this->dispatch('service-element-changed');
-                Flux::toast(variant: "success", text: "Assignee saved.");
-                break;
-        }
+        $this->element->update(['name' => $value]);
+        $this->dispatch('service-element-changed');
+    }
+
+    public function updatedDescription(?string $value): void
+    {
+        $this->element->update(['description' => $value]);
+        $this->dispatch('service-element-changed');
+        Flux::toast(variant: 'success', text: 'Sermon title saved.');
+    }
+
+    public function setAssignee(?int $userId): void
+    {
+        $this->element->update(['assignee_id' => $userId]);
+        $this->assigneeOpen = false;
+        $this->assigneeSearch = '';
+        $this->dispatch('service-element-changed');
+        Flux::toast(variant: 'success', text: 'Assignee saved.');
     }
 
     public function delete(): void
     {
-        $this->modal("delete-element")->show();
+        $this->modal('delete-element')->show();
+    }
+
+    public function duplicate(): void
+    {
+        DB::transaction(function () {
+            $copy = $this->element->replicate();
+            $copy->order = $this->element->order + 1;
+            $copy->save();
+
+            LiturgyElement::query()
+                ->where('liturgy_type', $this->element->liturgy_type)
+                ->where('liturgy_id', $this->element->liturgy_id)
+                ->where('order', '>=', $copy->order)
+                ->where('id', '!=', $copy->id)
+                ->increment('order');
+        });
+
+        $this->dispatch('service-element-changed');
+        Flux::toast(variant: 'success', text: 'Sermon duplicated.');
     }
 };
 ?>
 
-<flux:table.row :x-sort:item="$element->id">
-    <flux:table.cell>
-        <div class="flex flex-col md:flex-row gap-2 md:gap-x-2 md:items-center pl-1 group">
-            <div x-sort-handle class="cursor-grab hidden group-hover:block" title="Drag to reorder">
-                <flux:icon class="text-zinc-300" name="grip" />
-            </div>
-            <div class="flex-1 flex items-center gap-1">
-                <div>
-                    <flux:icon.lectern />
-                </div>
-                <div>
-                    <flux:heading>{{ $element->name }}</flux:heading>
-                </div>
-            </div>
-            <div>
-                <flux:select variant="combobox" size="sm" wire:model.live="assigneeId" placeholder="Assign element...">
-                    @foreach($users as $user)
-                        <flux:select.option value="{{ $user->id }}">{{ $user->name }}</flux:select.option>
-                    @endforeach
-                </flux:select>
-            </div>
-            <div class="md:w-[226px]">
-                <flux:input size="sm" placeholder="Enter title or reference" wire:model.live.blur="description" />
-            </div>
-            <div class="hidden md:block md:pr-2">
-                <flux:dropdown align="end" offset="-15">
-                    <flux:button variant="ghost" size="sm" icon="ellipsis-horizontal" inset="bottom" />
+@php
+    $tone = SectionTone::classesFor($sectionColor);
+    $showStripe = $sectionColor !== null;
+@endphp
 
-                    <flux:menu class="min-w-32">
-                        <flux:menu.item wire:click="$dispatch('edit-element', { id: {{ $element->id }} })" icon="pencil-square"  class="cursor-default">Edit</flux:menu.item>
-                        <flux:menu.item wire:click="delete" icon="trash" variant="danger">Delete</flux:menu.item>
-                    </flux:menu>
-                </flux:dropdown>
-            </div>
+<div :x-sort:item="$element->id" wire:key="sermon-{{ $element->id }}"
+     class="group relative grid items-center gap-3 border-b border-zinc-100 px-2 py-2 transition-colors hover:bg-zinc-50 dark:border-zinc-800 dark:hover:bg-zinc-900
+            {{ $showStripe ? 'grid-cols-[4px_18px_36px_minmax(140px,1fr)_minmax(140px,200px)_minmax(160px,240px)_32px]' : 'grid-cols-[18px_36px_minmax(140px,1fr)_minmax(140px,200px)_minmax(160px,240px)_32px]' }}">
+
+    @if ($showStripe)
+        <div class="-my-2 self-stretch rounded-sm opacity-60 {{ $tone['stripe'] }}"></div>
+    @endif
+
+    <div x-sort-handle class="flex h-6 cursor-grab items-center justify-center text-zinc-300 opacity-0 transition-opacity group-hover:opacity-100 dark:text-zinc-600" title="Drag to reorder">
+        <flux:icon name="bars-2" class="size-3.5" />
+    </div>
+
+    <div class="flex size-9 items-center justify-center rounded-lg {{ $tone['swatch'] }}">
+        <flux:icon name="lectern" class="size-4" />
+    </div>
+
+    <div class="min-w-0">
+        <div class="text-[13.5px] font-semibold text-zinc-900 dark:text-zinc-100">
+            <x-service.inline-text
+                wire-model="name"
+                :value="$name"
+                placeholder="Sermon"
+                class="text-[13.5px] font-semibold"
+            />
         </div>
+        <div class="text-[10.5px] font-medium uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
+            Sermon
+        </div>
+    </div>
 
-        <flux:modal name="delete-element" class="min-w-[22rem]">
-            <form wire:submit="$parent.delete({{ $element->id }})" class="space-y-6">
-                <div>
-                    <flux:heading size="lg">Delete liturgy element?</flux:heading>
+    @include('livewire.elements._partials.assignee-chip', [
+        'element' => $element,
+        'users' => $users,
+        'recentIds' => $recentAssigneeIds,
+        'open' => $assigneeOpen,
+        'search' => $assigneeSearch,
+    ])
 
-                    <flux:subheading>
-                        <p>This will permanently delete the liturgy element.</p>
-                        <p>It cannot be undone.</p>
-                    </flux:subheading>
-                </div>
+    <div class="flex w-full items-center gap-2 rounded-full border border-zinc-200 px-3 py-1 dark:border-zinc-700">
+        <flux:icon name="lectern" class="size-3 shrink-0 text-zinc-500" />
+        <input type="text"
+               wire:model.live.blur="description"
+               placeholder="Add sermon title…"
+               class="h-6 w-full border-0 bg-transparent text-[12.5px] text-zinc-900 placeholder-zinc-400 focus:outline-none focus:ring-0 dark:text-zinc-100 dark:placeholder-zinc-500" />
+    </div>
 
-                <div class="flex gap-2">
-                    <flux:spacer />
+    <flux:dropdown align="end" offset="-15">
+        <flux:button variant="ghost" size="sm" icon="ellipsis-horizontal" inset="bottom" />
+        <flux:menu class="min-w-36">
+            <flux:menu.item wire:click="duplicate" icon="document-duplicate">Duplicate</flux:menu.item>
+            <flux:menu.item wire:click="delete" icon="trash" variant="danger">Delete</flux:menu.item>
+        </flux:menu>
+    </flux:dropdown>
 
-                    <flux:modal.close>
-                        <flux:button variant="ghost">Cancel</flux:button>
-                    </flux:modal.close>
-
-                    <flux:button type="submit" variant="danger">Delete Element</flux:button>
-                </div>
-            </form>
-        </flux:modal>
-    </flux:table.cell>
-</flux:table.row>
+    <flux:modal name="delete-element" class="min-w-[22rem]">
+        <form wire:submit="$parent.delete({{ $element->id }})" class="space-y-6">
+            <div>
+                <flux:heading size="lg">Delete sermon?</flux:heading>
+                <flux:subheading>This will permanently delete the liturgy element. It cannot be undone.</flux:subheading>
+            </div>
+            <div class="flex gap-2">
+                <flux:spacer />
+                <flux:modal.close>
+                    <flux:button variant="ghost">Cancel</flux:button>
+                </flux:modal.close>
+                <flux:button type="submit" variant="danger">Delete Element</flux:button>
+            </div>
+        </form>
+    </flux:modal>
+</div>

--- a/resources/views/livewire/elements/song.blade.php
+++ b/resources/views/livewire/elements/song.blade.php
@@ -2,7 +2,9 @@
 
 use App\Models\LiturgyElement;
 use App\Models\Song;
+use App\Support\SectionTone;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Locked;
 use Livewire\Component;
@@ -13,146 +15,178 @@ new class extends Component {
     #[Locked]
     public Collection $users;
 
-    public $selectedContent;
-    public $assigneeId;
-    public string $search = '';
+    /** @var array<int,int> */
+    #[Locked]
+    public array $recentAssigneeIds = [];
+
+    public ?string $sectionColor = null;
+
+    public ?int $sectionIndex = null;
+
+    public ?int $sectionElementCount = null;
+
+    public bool $isFirstInSection = false;
+
+    public bool $isLastInSection = false;
+
+    public string $name;
+
+    public bool $assigneeOpen = false;
+
+    public bool $contentOpen = false;
+
+    public string $assigneeSearch = '';
+
+    public string $contentSearch = '';
 
     public function mount(?Collection $users = null): void
     {
         $this->users = $users ?? collect();
-        $this->selectedContent = $this->element->content_id;
-        $this->assigneeId = $this->element->assignee_id;
+        $this->name = $this->element->name;
     }
 
-    public function updated($name, $value): void
+    public function updatedName(string $value): void
     {
-        switch ($name) {
-            case "selectedContent":
-                $song = Song::findOrFail($value);
-                $this->element->content()->associate($song);
-                $this->element->save();
-                $this->element->refresh();
-                $this->selectedContent = $this->element->content_id;
-                $this->dispatch('service-element-changed');
-                Flux::toast(variant: "success", text: "Song selection saved.");
-                break;
-            case "assigneeId":
-                $this->element->assignee_id = $value;
-                $this->element->save();
-                $this->element->refresh();
-                $this->assigneeId = $this->element->assignee_id;
-                $this->dispatch('service-element-changed');
-                Flux::toast(variant: "success", text: "Assignee saved.");
-                break;
+        $this->element->update(['name' => $value]);
+        $this->dispatch('service-element-changed');
+    }
+
+    public function setAssignee(?int $userId): void
+    {
+        $this->element->update(['assignee_id' => $userId]);
+        $this->assigneeOpen = false;
+        $this->assigneeSearch = '';
+        $this->dispatch('service-element-changed');
+        Flux::toast(variant: 'success', text: 'Assignee saved.');
+    }
+
+    public function setContent(?int $songId): void
+    {
+        if ($songId === null) {
+            $this->element->content()->dissociate();
+        } else {
+            $song = Song::findOrFail($songId);
+            $this->element->content()->associate($song);
         }
+        $this->element->save();
+        $this->contentOpen = false;
+        $this->contentSearch = '';
+        $this->dispatch('service-element-changed');
+        Flux::toast(variant: 'success', text: 'Song selection saved.');
     }
 
     public function delete(): void
     {
-        $this->modal("delete-element")->show();
+        $this->modal('delete-element')->show();
+    }
+
+    public function duplicate(): void
+    {
+        DB::transaction(function () {
+            $copy = $this->element->replicate();
+            $copy->order = $this->element->order + 1;
+            $copy->save();
+
+            LiturgyElement::query()
+                ->where('liturgy_type', $this->element->liturgy_type)
+                ->where('liturgy_id', $this->element->liturgy_id)
+                ->where('order', '>=', $copy->order)
+                ->where('id', '!=', $copy->id)
+                ->increment('order');
+        });
+
+        $this->dispatch('service-element-changed');
+        Flux::toast(variant: 'success', text: 'Song duplicated.');
     }
 
     #[Computed]
     public function songs(): Collection
     {
-        $songs = collect();
-
-        if ($this->search !== '') {
-            $songs = Song::query()
-                ->where('name', 'like', '%' . $this->search . '%')
-                ->orderBy('name')
-                ->limit(50)
-                ->get();
+        if ($this->contentSearch === '') {
+            return collect();
         }
 
-        if ($this->selectedContent && ! $songs->contains('id', $this->selectedContent)) {
-            $selected = Song::find($this->selectedContent);
-
-            if ($selected) {
-                $songs = $songs->prepend($selected);
-            }
-        }
-
-        return $songs;
+        return Song::query()
+            ->where('name', 'like', '%'.$this->contentSearch.'%')
+            ->orderBy('name')
+            ->limit(50)
+            ->get();
     }
 };
 ?>
 
-<flux:table.row :x-sort:item="$element->id">
-    <flux:table.cell>
-        <div class="flex flex-col md:flex-row gap-2 md:gap-x-2 md:items-center pl-1 group">
-            <div x-sort-handle class="cursor-grab hidden group-hover:block" title="Drag to reorder">
-                <flux:icon class="text-zinc-300" name="grip" />
-            </div>
-            <div class="flex-1 flex items-center gap-1">
-                <div>
-                    <flux:icon.musical-note />
-                </div>
-                <div>
-                    <flux:heading>{{ $element->name }}</flux:heading>
-                    @if($element->description)
-                        <flux:subheading>{{ $element->description }}</flux:subheading>
-                    @endif
-                </div>
-            </div>
-            <div>
-                <flux:select variant="combobox" size="sm" wire:model.live="assigneeId" placeholder="Assign element...">
-                    @foreach($users as $user)
-                        <flux:select.option value="{{ $user->id }}">{{ $user->name }}</flux:select.option>
-                    @endforeach
-                </flux:select>
-            </div>
-            <div class="md:w-[226px]">
-                <flux:select
-                    variant="listbox"
-                    searchable
-                    :filter="false"
-                    size="sm"
-                    wire:model.live="selectedContent"
-                    placeholder="Select a song..."
-                >
-                    <x-slot:search>
-                        <flux:select.search wire:model.live.debounce.300ms="search" placeholder="Search songs..." />
-                    </x-slot:search>
+@php
+    $tone = SectionTone::classesFor($sectionColor);
+    $showStripe = $sectionColor !== null;
+@endphp
 
-                    @foreach($this->songs as $song)
-                        <flux:select.option :value="$song->id" wire:key="song-option-{{ $song->id }}">{{ $song->name }}</flux:select.option>
-                    @endforeach
-                </flux:select>
-            </div>
-            <div class="hidden md:block md:pr-2">
-                <flux:dropdown align="end" offset="-15">
-                    <flux:button variant="ghost" size="sm" icon="ellipsis-horizontal" inset="bottom" />
+<div :x-sort:item="$element->id" wire:key="song-{{ $element->id }}"
+     class="group relative grid items-center gap-3 border-b border-zinc-100 px-2 py-2 transition-colors hover:bg-zinc-50 dark:border-zinc-800 dark:hover:bg-zinc-900
+            {{ $showStripe ? 'grid-cols-[4px_18px_36px_minmax(140px,1fr)_minmax(140px,200px)_minmax(160px,240px)_32px]' : 'grid-cols-[18px_36px_minmax(140px,1fr)_minmax(140px,200px)_minmax(160px,240px)_32px]' }}">
 
-                    <flux:menu class="min-w-32">
-                        <flux:menu.item wire:click="$dispatch('edit-element', { id: {{ $element->id }} })" icon="pencil-square"  class="cursor-default">Edit</flux:menu.item>
-                        <flux:menu.item wire:click="delete" icon="trash" variant="danger">Delete</flux:menu.item>
-                    </flux:menu>
-                </flux:dropdown>
-            </div>
+    @if ($showStripe)
+        <div class="-my-2 self-stretch rounded-sm opacity-60 {{ $tone['stripe'] }}"></div>
+    @endif
+
+    <div x-sort-handle class="flex h-6 cursor-grab items-center justify-center text-zinc-300 opacity-0 transition-opacity group-hover:opacity-100 dark:text-zinc-600" title="Drag to reorder">
+        <flux:icon name="bars-2" class="size-3.5" />
+    </div>
+
+    <div class="flex size-9 items-center justify-center rounded-lg {{ $tone['swatch'] }}">
+        <flux:icon name="musical-note" class="size-4" />
+    </div>
+
+    <div class="min-w-0">
+        <div class="text-[13.5px] font-semibold text-zinc-900 dark:text-zinc-100">
+            <x-service.inline-text
+                wire-model="name"
+                :value="$name"
+                placeholder="Song"
+                class="text-[13.5px] font-semibold"
+            />
         </div>
+        <div class="text-[10.5px] font-medium uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
+            Song
+        </div>
+    </div>
 
-        <flux:modal name="delete-element" class="min-w-[22rem]">
-            <form wire:submit="$parent.delete({{ $element->id }})" class="space-y-6">
-                <div>
-                    <flux:heading size="lg">Delete song?</flux:heading>
+    @include('livewire.elements._partials.assignee-chip', [
+        'element' => $element,
+        'users' => $users,
+        'recentIds' => $recentAssigneeIds,
+        'open' => $assigneeOpen,
+        'search' => $assigneeSearch,
+    ])
 
-                    <flux:subheading>
-                        <p>This will permanently delete the liturgy element.</p>
-                        <p>It cannot be undone.</p>
-                    </flux:subheading>
-                </div>
+    @include('livewire.elements._partials.content-chip', [
+        'element' => $element,
+        'items' => $this->songs,
+        'variant' => 'song',
+        'open' => $contentOpen,
+        'search' => $contentSearch,
+    ])
 
-                <div class="flex gap-2">
-                    <flux:spacer />
+    <flux:dropdown align="end" offset="-15">
+        <flux:button variant="ghost" size="sm" icon="ellipsis-horizontal" inset="bottom" />
+        <flux:menu class="min-w-36">
+            <flux:menu.item wire:click="duplicate" icon="document-duplicate">Duplicate</flux:menu.item>
+            <flux:menu.item wire:click="delete" icon="trash" variant="danger">Delete</flux:menu.item>
+        </flux:menu>
+    </flux:dropdown>
 
-                    <flux:modal.close>
-                        <flux:button variant="ghost">Cancel</flux:button>
-                    </flux:modal.close>
-
-                    <flux:button type="submit" variant="danger">Delete Element</flux:button>
-                </div>
-            </form>
-        </flux:modal>
-    </flux:table.cell>
-</flux:table.row>
+    <flux:modal name="delete-element" class="min-w-[22rem]">
+        <form wire:submit="$parent.delete({{ $element->id }})" class="space-y-6">
+            <div>
+                <flux:heading size="lg">Delete song?</flux:heading>
+                <flux:subheading>This will permanently delete the liturgy element. It cannot be undone.</flux:subheading>
+            </div>
+            <div class="flex gap-2">
+                <flux:spacer />
+                <flux:modal.close>
+                    <flux:button variant="ghost">Cancel</flux:button>
+                </flux:modal.close>
+                <flux:button type="submit" variant="danger">Delete Element</flux:button>
+            </div>
+        </form>
+    </flux:modal>
+</div>

--- a/resources/views/livewire/services/elements.blade.php
+++ b/resources/views/livewire/services/elements.blade.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\LiturgyElementType;
 use App\Models\LiturgyElement;
 use App\Models\Service;
 use App\Models\User;
@@ -15,25 +16,119 @@ new class extends Component {
 
     public Service $service;
 
-    public function mount()
+    public function mount(): void
     {
         $this->loadService();
     }
 
-    public function loadService()
+    public function loadService(): void
     {
-        $this->service = Service::with("liturgyElements")->find(
-            $this->serviceId,
-        );
+        $this->service = Service::with('liturgyElements')->findOrFail($this->serviceId);
     }
 
     #[Computed]
     public function users()
     {
-        return User::orderBy("name")->get();
+        return User::orderBy('name')->get();
     }
 
-    #[On("service-element-changed")]
+    #[Computed]
+    public function recentAssigneeIds(): array
+    {
+        return $this->service->liturgyElements
+            ->pluck('assignee_id')
+            ->filter()
+            ->unique()
+            ->values()
+            ->all();
+    }
+
+    /**
+     * Walk the ordered elements once and tag each with its enclosing
+     * section's color + first/last-in-section flags. Returns a list of
+     * ['element' => LiturgyElement, 'section_color' => ?string, 'section_index' => int|null,
+     *   'is_first_in_section' => bool, 'is_last_in_section' => bool, 'section_element_count' => int|null].
+     *
+     * @return list<array<string, mixed>>
+     */
+    public function layout(): array
+    {
+        $elements = $this->service->liturgyElements;
+        $out = [];
+        $currentSection = null;
+        $sectionIndex = 0;
+        $sectionElementCount = 0;
+        $sectionBufferStart = 0;
+
+        foreach ($elements as $i => $el) {
+            if ($el->type === LiturgyElementType::SECTION) {
+                // close out the prior section's element-count back-references
+                if ($currentSection !== null) {
+                    for ($j = $sectionBufferStart; $j < count($out); $j++) {
+                        $out[$j]['section_element_count'] = $sectionElementCount;
+                    }
+                    $out[$sectionBufferStart - 1]['section_element_count'] = $sectionElementCount;
+                }
+                $sectionIndex++;
+                $currentSection = $el;
+                $sectionElementCount = 0;
+                $sectionBufferStart = count($out) + 1; // index of the first child below this header
+
+                $out[] = [
+                    'element' => $el,
+                    'section_color' => $el->section_color,
+                    'section_index' => $sectionIndex,
+                    'is_first_in_section' => false,
+                    'is_last_in_section' => false,
+                    'section_element_count' => 0, // patched below
+                ];
+                continue;
+            }
+
+            $sectionElementCount++;
+            $isFirst = ! isset($out[count($out) - 1]) || $out[count($out) - 1]['element']->type === LiturgyElementType::SECTION;
+            $out[] = [
+                'element' => $el,
+                'section_color' => $currentSection?->section_color,
+                'section_index' => $currentSection !== null ? $sectionIndex : null,
+                'is_first_in_section' => $isFirst,
+                'is_last_in_section' => false, // patched after the loop
+                'section_element_count' => null,
+            ];
+        }
+
+        // Patch last-in-section flags and the final section's element-count back-references.
+        $prevSectionStart = null;
+        $lastByIndex = [];
+        foreach ($out as $idx => $row) {
+            if ($row['element']->type === LiturgyElementType::SECTION) {
+                $prevSectionStart = $idx;
+            } else {
+                $lastByIndex[$row['section_index']] = $idx;
+            }
+        }
+        foreach ($lastByIndex as $lastIdx) {
+            $out[$lastIdx]['is_last_in_section'] = true;
+        }
+
+        // Final section count patch
+        if ($currentSection !== null) {
+            for ($j = $sectionBufferStart; $j < count($out); $j++) {
+                if ($out[$j]['element']->type !== LiturgyElementType::SECTION) {
+                    $out[$j]['section_element_count'] = $sectionElementCount;
+                }
+            }
+            // Also patch the section header row itself with its count
+            $headerIdx = $sectionBufferStart - 1;
+            if ($headerIdx >= 0 && isset($out[$headerIdx])) {
+                $out[$headerIdx]['section_element_count'] = $sectionElementCount;
+            }
+        }
+
+        return $out;
+    }
+
+    #[On('service-element-changed')]
     public function refreshElements(): void
     {
         $this->loadService();
@@ -51,11 +146,11 @@ new class extends Component {
                 return;
             }
 
-            $liturgyElement->update(["order" => 65535]);
+            $liturgyElement->update(['order' => 65535]);
 
             $elementsToShift = $this->service
                 ->liturgyElements()
-                ->whereBetween("order", [
+                ->whereBetween('order', [
                     min($before, $after),
                     max($before, $after),
                 ]);
@@ -63,35 +158,79 @@ new class extends Component {
             $shiftUp = $before < $after;
 
             $shiftUp
-                ? $elementsToShift->decrement("order")
-                : $elementsToShift->increment("order");
+                ? $elementsToShift->decrement('order')
+                : $elementsToShift->increment('order');
 
-            $liturgyElement->update(["order" => $after]);
+            $liturgyElement->update(['order' => $after]);
         });
 
         $this->loadService();
-        Flux::toast(variant: "success", text: "Service reordered.");
+        Flux::toast(variant: 'success', text: 'Service reordered.');
+    }
+
+    /**
+     * Insert a new element directly after the given anchor element. The anchor
+     * may be a section header (in which case the new row appears as the first
+     * row beneath that section) or another element.
+     */
+    #[On('add-element-after')]
+    public function addElementAfter(int $afterId, string $type): void
+    {
+        $anchor = $this->service->liturgyElements()->findOrFail($afterId);
+        $newType = LiturgyElementType::from($type);
+
+        DB::transaction(function () use ($anchor, $newType) {
+            $this->service
+                ->liturgyElements()
+                ->where('order', '>', $anchor->order)
+                ->increment('order');
+
+            $this->service->liturgyElements()->create([
+                'type' => $newType,
+                'name' => $newType->label(),
+                'order' => $anchor->order + 1,
+            ]);
+        });
+
+        $this->loadService();
+        Flux::toast(variant: 'success', text: $newType->label().' added.');
     }
 
     public function delete($id): void
     {
         LiturgyElement::findOrFail($id)->delete();
-        Flux::modal("delete-element")->close();
-        Flux::toast(variant: "danger", text: "Liturgy element deleted.");
+        Flux::modal('delete-element')->close();
+        Flux::toast(variant: 'danger', text: 'Liturgy element deleted.');
+        $this->loadService();
     }
 };
 ?>
 
-<flux:table class="w-full">
-    <flux:table.rows x-sort="$wire.sort($item, $position)" x-sort:config="{ handle: '[x-sort-handle]' }">
-        @if($this->service->liturgyElements->isEmpty())
-            <flux:table.row>
-                <flux:table.cell align="center">No Service Elements</flux:table.cell>
-            </flux:table.row>
-        @else
-            @foreach($this->service->liturgyElements as $element)
-                @livewire($element->type->component(), ['element' => $element, 'users' => $this->users], key($element->id))
-            @endforeach
-        @endif
-    </flux:table.rows>
-</flux:table>
+<div x-sort="$wire.sort($item, $position)" x-sort:config="{ handle: '[x-sort-handle]' }" class="mt-2">
+    @php($rows = $this->layout())
+
+    @if (empty($rows))
+        <div class="rounded-lg border border-dashed border-zinc-300 px-6 py-12 text-center text-sm text-zinc-500 dark:border-zinc-700 dark:text-zinc-400">
+            No service elements yet.
+        </div>
+    @else
+        @foreach ($rows as $row)
+            @livewire(
+                $row['element']->type->component(),
+                [
+                    'element' => $row['element'],
+                    'users' => $this->users,
+                    'recentAssigneeIds' => $this->recentAssigneeIds,
+                    'sectionColor' => $row['section_color'],
+                    'sectionIndex' => $row['section_index'],
+                    'sectionElementCount' => $row['section_element_count'],
+                    'isFirstInSection' => $row['is_first_in_section'],
+                    'isLastInSection' => $row['is_last_in_section'],
+                ],
+                key('liturgy-element-'.$row['element']->id)
+            )
+
+            <x-service.add-element-slot :after-id="$row['element']->id" />
+        @endforeach
+    @endif
+</div>

--- a/resources/views/pages/services/show.blade.php
+++ b/resources/views/pages/services/show.blade.php
@@ -1,26 +1,52 @@
 <?php
 
+use App\Livewire\Forms\ServiceForm;
 use App\Models\Service;
-use App\Enums\Permission;
 use App\Models\Template;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Url;
 use Livewire\Component;
-use App\Livewire\Forms\ServiceForm;
 
 new class extends Component {
     public ServiceForm $form;
 
     #[Url]
-    public $tab = "service-order";
+    public $tab = 'service-order';
+
+    public bool $saved = true;
 
     protected $listeners = [
-        "refreshParent" => '$refresh',
+        'refreshParent' => '$refresh',
+        'service-element-changed' => '$refresh',
     ];
 
     public function mount(Service $service): void
     {
         $this->form->setService($service);
+    }
+
+    public function updatedFormTitle(): void
+    {
+        $this->form->saveTitle();
+        $this->saved = true;
+        Flux::toast(variant: 'success', text: 'Service renamed.');
+    }
+
+    public function updatingFormTitle(): void
+    {
+        $this->saved = false;
+    }
+
+    public function viewBulletin(): void
+    {
+        $this->tab = 'bulletin';
+    }
+
+    public function duplicate(): void
+    {
+        $clone = $this->form->duplicate();
+        Flux::toast(variant: 'success', text: 'Service duplicated.');
+        $this->redirectRoute('services.show', ['service' => $clone], navigate: true);
     }
 
     #[Computed]
@@ -32,17 +58,60 @@ new class extends Component {
 ?>
 
 <section class="w-full">
-    <div class="flex items-center">
-        <header>
-            <flux:heading size="xl" level="1">{{ $form->title }}</flux:heading>
-            <flux:subheading>{{ $form->date->toFormattedDayDateString() }} @if($form->template_id) - Template: {{ $form->service->template->name }}@endif</flux:subheading>
-        </header>
-        <flux:spacer />
-        <flux:button size="sm" variant="primary" href="{{ route('services.edit', ['service' => $form->service]) }}">Edit</flux:button>
-    </div>
+    <header class="flex flex-col gap-4 sm:flex-row sm:items-start">
+        <x-service.date-block :date="$form->date" />
 
-    <flux:tab.group class="mt-8">
-        <flux:tabs wire:model="tab" scrollable>
+        <div class="min-w-0 flex-1">
+            <div class="text-[11.5px] font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
+                {{ $form->date->format('l') }} · {{ $form->date->format('F j, Y') }}
+            </div>
+
+            <h1 class="mt-1 text-3xl font-bold tracking-tight text-zinc-900 dark:text-zinc-100">
+                <x-service.inline-text
+                    wire-model="form.title"
+                    :value="$form->title"
+                    placeholder="Untitled Service"
+                    class="text-3xl font-bold tracking-tight"
+                />
+            </h1>
+
+            <div class="mt-2 flex flex-wrap items-center gap-2.5 text-[12.5px] text-zinc-500 dark:text-zinc-400">
+                @if ($form->service?->template)
+                    <span>Template:</span>
+                    <a href="{{ route('templates.show', ['template' => $form->service->template]) }}"
+                       class="inline-flex items-center gap-1.5 rounded-full bg-zinc-100 px-2.5 py-0.5 text-[11.5px] font-medium text-zinc-900 no-underline hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-100 dark:hover:bg-zinc-700">
+                        <flux:icon name="document-text" class="size-3 text-zinc-500" />
+                        {{ $form->service->template->name }}
+                    </a>
+                    <span class="text-zinc-300 dark:text-zinc-600">·</span>
+                @endif
+
+                <span class="inline-flex items-center gap-1 text-[11.5px]">
+                    @if ($saved)
+                        <flux:icon name="check" class="size-3 text-emerald-600 dark:text-emerald-400" />
+                        All changes saved
+                    @else
+                        <span class="size-1.5 rounded-full bg-amber-500 dark:bg-amber-400"></span>
+                        Saving…
+                    @endif
+                </span>
+            </div>
+        </div>
+
+        <div class="flex shrink-0 gap-2">
+            <flux:button size="sm" variant="ghost" wire:click="duplicate" icon="document-duplicate">
+                Duplicate
+            </flux:button>
+            <flux:button size="sm" variant="ghost" wire:click="viewBulletin" icon="document-text">
+                View Bulletin
+            </flux:button>
+        </div>
+    </header>
+
+    <x-service.stats-strip :service="$form->service" />
+
+    <flux:tab.group class="mt-6">
+        <flux:tabs wire:model.live="tab" scrollable>
             <flux:tab name="service-order" icon="queue-list">Service Order</flux:tab>
             <flux:tab name="discussion" icon="chat-bubble-left-right">Discussion</flux:tab>
             <flux:tab name="bulletin" icon="document-text">Bulletin</flux:tab>

--- a/tests/Feature/ElementSearchTest.php
+++ b/tests/Feature/ElementSearchTest.php
@@ -24,7 +24,7 @@ it('filters songs by search term', function (): void {
     ]);
 
     $songs = Livewire::test('elements.song', ['element' => $element])
-        ->set('search', 'Grace')
+        ->set('contentSearch', 'Grace')
         ->get('songs');
 
     expect($songs)->toHaveCount(1);
@@ -45,7 +45,7 @@ it('limits song results to 50', function (): void {
     ]);
 
     $songs = Livewire::test('elements.song', ['element' => $element])
-        ->set('search', 'Hymn')
+        ->set('contentSearch', 'Hymn')
         ->get('songs');
 
     expect($songs)->toHaveCount(50);
@@ -66,45 +66,6 @@ it('does not preload songs when no search term is entered', function (): void {
     expect($songs)->toBeEmpty();
 });
 
-it('returns only the selected song when no search term is entered', function (): void {
-    $selected = Song::factory()->create(['name' => 'Selected Song']);
-    Song::factory()->count(10)->create();
-
-    $service = Service::factory()->create();
-    $element = LiturgyElement::factory()->create([
-        'liturgy_type' => Service::class,
-        'liturgy_id' => $service->id,
-        'type' => LiturgyElementType::SONG,
-        'content_type' => Song::class,
-        'content_id' => $selected->id,
-    ]);
-
-    $songs = Livewire::test('elements.song', ['element' => $element])->get('songs');
-
-    expect($songs)->toHaveCount(1);
-    expect($songs->first()->id)->toBe($selected->id);
-});
-
-it('keeps the selected song in the list when the search would exclude it', function (): void {
-    $selected = Song::factory()->create(['name' => 'Selected Song']);
-    Song::factory()->create(['name' => 'Other Song']);
-
-    $service = Service::factory()->create();
-    $element = LiturgyElement::factory()->create([
-        'liturgy_type' => Service::class,
-        'liturgy_id' => $service->id,
-        'type' => LiturgyElementType::SONG,
-        'content_type' => Song::class,
-        'content_id' => $selected->id,
-    ]);
-
-    $songs = Livewire::test('elements.song', ['element' => $element])
-        ->set('search', 'Other')
-        ->get('songs');
-
-    expect($songs->pluck('id'))->toContain($selected->id);
-});
-
 it('filters readings by search term', function (): void {
     Reading::factory()->create(['title' => 'Psalm 23', 'type' => ReadingType::PRAISE]);
     Reading::factory()->create(['title' => 'Psalm 100', 'type' => ReadingType::PRAISE]);
@@ -118,7 +79,7 @@ it('filters readings by search term', function (): void {
     ]);
 
     $readings = Livewire::test('elements.reading', ['element' => $element])
-        ->set('search', 'Psalm')
+        ->set('contentSearch', 'Psalm')
         ->get('readings');
 
     expect($readings)->toHaveCount(2);
@@ -148,7 +109,7 @@ it('combines reading_type filter with search term', function (): void {
     ]);
 
     $readings = Livewire::test('elements.reading', ['element' => $element])
-        ->set('search', 'Benediction')
+        ->set('contentSearch', 'Benediction')
         ->get('readings');
 
     expect($readings)->toHaveCount(1);
@@ -168,52 +129,4 @@ it('does not preload readings when no search term is entered', function (): void
     $readings = Livewire::test('elements.reading', ['element' => $element])->get('readings');
 
     expect($readings)->toBeEmpty();
-});
-
-it('returns only the selected reading when no search term is entered', function (): void {
-    $selected = Reading::factory()->create([
-        'title' => 'Selected Reading',
-        'type' => ReadingType::PRAYER,
-    ]);
-    Reading::factory()->count(10)->create();
-
-    $service = Service::factory()->create();
-    $element = LiturgyElement::factory()->create([
-        'liturgy_type' => Service::class,
-        'liturgy_id' => $service->id,
-        'type' => LiturgyElementType::READING,
-        'content_type' => Reading::class,
-        'content_id' => $selected->id,
-    ]);
-
-    $readings = Livewire::test('elements.reading', ['element' => $element])->get('readings');
-
-    expect($readings)->toHaveCount(1);
-    expect($readings->first()->id)->toBe($selected->id);
-});
-
-it('keeps the selected reading in the list when the search would exclude it', function (): void {
-    $selected = Reading::factory()->create([
-        'title' => 'Selected Reading',
-        'type' => ReadingType::PRAYER,
-    ]);
-    Reading::factory()->create([
-        'title' => 'Other Reading',
-        'type' => ReadingType::PRAYER,
-    ]);
-
-    $service = Service::factory()->create();
-    $element = LiturgyElement::factory()->create([
-        'liturgy_type' => Service::class,
-        'liturgy_id' => $service->id,
-        'type' => LiturgyElementType::READING,
-        'content_type' => Reading::class,
-        'content_id' => $selected->id,
-    ]);
-
-    $readings = Livewire::test('elements.reading', ['element' => $element])
-        ->set('search', 'Other')
-        ->get('readings');
-
-    expect($readings->pluck('id'))->toContain($selected->id);
 });

--- a/tests/Feature/ReadingTypeFilteringTest.php
+++ b/tests/Feature/ReadingTypeFilteringTest.php
@@ -35,7 +35,7 @@ it('filters readings by reading_type when element has reading_type specified', f
     ]);
 
     $readings = Livewire::test('elements.reading', ['element' => $readingElement])
-        ->set('search', 'Reading')
+        ->set('contentSearch', 'Reading')
         ->get('readings');
 
     expect($readings)->toHaveCount(1);
@@ -57,7 +57,7 @@ it('returns all readings matching search when element has no reading_type specif
     ]);
 
     $readings = Livewire::test('elements.reading', ['element' => $readingElement])
-        ->set('search', 'Reading')
+        ->set('contentSearch', 'Reading')
         ->get('readings');
 
     expect($readings)->toHaveCount(3);

--- a/tests/Feature/ServiceShowRedesignTest.php
+++ b/tests/Feature/ServiceShowRedesignTest.php
@@ -1,0 +1,267 @@
+<?php
+
+use App\Enums\LiturgyElementType;
+use App\Models\Service;
+use App\Models\Song;
+use App\Models\User;
+use App\Support\SectionTone;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->actingAs($this->user);
+});
+
+it('seeds a tonal color when a section is created', function (): void {
+    $service = Service::factory()->create();
+
+    $section = $service->liturgyElements()->create([
+        'type' => LiturgyElementType::SECTION,
+        'name' => 'Grace',
+        'order' => 0,
+    ]);
+
+    expect($section->section_color)->toBe(SectionTone::pick('Grace'));
+});
+
+it('does not change section color when renamed', function (): void {
+    $service = Service::factory()->create();
+    $section = $service->liturgyElements()->create([
+        'type' => LiturgyElementType::SECTION,
+        'name' => 'Grace',
+        'order' => 0,
+    ]);
+    $originalColor = $section->section_color;
+
+    $section->update(['name' => 'Mercy']);
+
+    expect($section->fresh()->section_color)->toBe($originalColor);
+});
+
+it('exposes service stats counters', function (): void {
+    $service = Service::factory()->create();
+    $user = User::factory()->create();
+    $song = Song::factory()->create();
+
+    $service->liturgyElements()->createMany([
+        ['type' => LiturgyElementType::SECTION, 'name' => 'God', 'order' => 0],
+        ['type' => LiturgyElementType::SONG, 'name' => 'Doxology', 'assignee_id' => $user->id, 'content_type' => Song::class, 'content_id' => $song->id, 'order' => 1],
+        ['type' => LiturgyElementType::SONG, 'name' => 'Holy Holy Holy', 'order' => 2],
+        ['type' => LiturgyElementType::SECTION, 'name' => 'Grace', 'order' => 3],
+        ['type' => LiturgyElementType::READING, 'name' => 'Scripture', 'order' => 4],
+        ['type' => LiturgyElementType::SERMON, 'name' => 'Sermon', 'order' => 5],
+        ['type' => LiturgyElementType::PRAYER, 'name' => 'Closing prayer', 'order' => 6],
+    ]);
+    $service->refresh()->load('liturgyElements');
+
+    expect($service->sectionCount())->toBe(2);
+    expect($service->elementCount())->toBe(5);
+    // Four non-section elements have no assignee: the second song, reading, sermon, prayer
+    expect($service->unassignedCount())->toBe(4);
+    // Missing-content excludes sermon/prayer; song without content + reading without content = 2
+    expect($service->missingContentCount())->toBe(2);
+});
+
+it('renders the new header with date block, title and template chip', function (): void {
+    $service = Service::factory()->create([
+        'title' => 'Sunday Morning Service',
+        'date' => '2026-05-17',
+    ]);
+
+    $this->get(route('services.show', $service))
+        ->assertOk()
+        ->assertSee('Sunday Morning Service')
+        ->assertSeeText('May')
+        ->assertSeeText('17')
+        ->assertSeeText('2026')
+        ->assertSee('Duplicate')
+        ->assertSee('View Bulletin');
+});
+
+it('updates the service title inline', function (): void {
+    $service = Service::factory()->create(['title' => 'Old Title']);
+
+    Livewire::test('pages::services.show', ['service' => $service])
+        ->set('form.title', 'New Title');
+
+    expect($service->fresh()->title)->toBe('New Title');
+});
+
+it('duplicates a service and its liturgy elements', function (): void {
+    $service = Service::factory()->create(['title' => 'Original']);
+    $service->liturgyElements()->createMany([
+        ['type' => LiturgyElementType::SECTION, 'name' => 'God', 'order' => 0],
+        ['type' => LiturgyElementType::SONG, 'name' => 'Doxology', 'order' => 1],
+    ]);
+
+    Livewire::test('pages::services.show', ['service' => $service])
+        ->call('duplicate')
+        ->assertRedirect();
+
+    $clone = Service::where('title', 'Original (Copy)')->first();
+
+    expect($clone)->not->toBeNull();
+    expect($clone->id)->not->toBe($service->id);
+    expect($clone->liturgyElements)->toHaveCount(2);
+    expect($clone->liturgyElements->first()->name)->toBe('God');
+});
+
+it('switches to the bulletin tab when View Bulletin is clicked', function (): void {
+    $service = Service::factory()->create();
+
+    Livewire::test('pages::services.show', ['service' => $service])
+        ->call('viewBulletin')
+        ->assertSet('tab', 'bulletin');
+});
+
+it('inserts a new element after the anchor', function (): void {
+    $service = Service::factory()->create();
+    $section = $service->liturgyElements()->create([
+        'type' => LiturgyElementType::SECTION,
+        'name' => 'God',
+        'order' => 0,
+    ]);
+    $song = $service->liturgyElements()->create([
+        'type' => LiturgyElementType::SONG,
+        'name' => 'Doxology',
+        'order' => 1,
+    ]);
+
+    Livewire::test('services.elements', ['serviceId' => $service->id])
+        ->call('addElementAfter', $section->id, LiturgyElementType::READING->value);
+
+    $service->refresh()->load('liturgyElements');
+    $elements = $service->liturgyElements;
+
+    expect($elements)->toHaveCount(3);
+    expect($elements[0]->id)->toBe($section->id);
+    expect($elements[1]->type)->toBe(LiturgyElementType::READING);
+    expect($elements[2]->id)->toBe($song->id);
+});
+
+it('saves a new assignee through the chip popover', function (): void {
+    $service = Service::factory()->create();
+    $service->liturgyElements()->create([
+        'type' => LiturgyElementType::SECTION,
+        'name' => 'God',
+        'order' => 0,
+    ]);
+    $song = $service->liturgyElements()->create([
+        'type' => LiturgyElementType::SONG,
+        'name' => 'Doxology',
+        'order' => 1,
+    ]);
+    $user = User::factory()->create();
+
+    Livewire::test('elements.song', ['element' => $song])
+        ->call('setAssignee', $user->id);
+
+    expect($song->fresh()->assignee_id)->toBe($user->id);
+});
+
+it('clears an assignee when null is passed', function (): void {
+    $service = Service::factory()->create();
+    $user = User::factory()->create();
+    $song = $service->liturgyElements()->create([
+        'type' => LiturgyElementType::SONG,
+        'name' => 'Doxology',
+        'assignee_id' => $user->id,
+        'order' => 0,
+    ]);
+
+    Livewire::test('elements.song', ['element' => $song])
+        ->call('setAssignee', null);
+
+    expect($song->fresh()->assignee_id)->toBeNull();
+});
+
+it('saves a new song selection through the content chip', function (): void {
+    $service = Service::factory()->create();
+    $song = $service->liturgyElements()->create([
+        'type' => LiturgyElementType::SONG,
+        'name' => 'Pick one',
+        'order' => 0,
+    ]);
+    $library = Song::factory()->create(['name' => 'Doxology']);
+
+    Livewire::test('elements.song', ['element' => $song])
+        ->call('setContent', $library->id);
+
+    $song->refresh();
+    expect($song->content_id)->toBe($library->id);
+    expect($song->content_type)->toBe(Song::class);
+});
+
+it('clears a song selection when null is passed', function (): void {
+    $service = Service::factory()->create();
+    $library = Song::factory()->create();
+    $song = $service->liturgyElements()->create([
+        'type' => LiturgyElementType::SONG,
+        'name' => 'Doxology',
+        'content_type' => Song::class,
+        'content_id' => $library->id,
+        'order' => 0,
+    ]);
+
+    Livewire::test('elements.song', ['element' => $song])
+        ->call('setContent', null);
+
+    $song->refresh();
+    expect($song->content_id)->toBeNull();
+    expect($song->content_type)->toBeNull();
+});
+
+it('recolors a section', function (): void {
+    $service = Service::factory()->create();
+    $section = $service->liturgyElements()->create([
+        'type' => LiturgyElementType::SECTION,
+        'name' => 'God',
+        'order' => 0,
+    ]);
+
+    Livewire::test('elements.section', ['element' => $section])
+        ->call('recolor', 'blue');
+
+    expect($section->fresh()->section_color)->toBe('blue');
+});
+
+it('renames a section inline', function (): void {
+    $service = Service::factory()->create();
+    $section = $service->liturgyElements()->create([
+        'type' => LiturgyElementType::SECTION,
+        'name' => 'God',
+        'order' => 0,
+    ]);
+
+    Livewire::test('elements.section', ['element' => $section])
+        ->set('name', 'God the Father');
+
+    expect($section->fresh()->name)->toBe('God the Father');
+});
+
+it('renders the full service page with every element row type', function (): void {
+    $service = Service::factory()->create(['title' => 'All-Type Service']);
+    $service->liturgyElements()->createMany([
+        ['type' => LiturgyElementType::SECTION, 'name' => 'Worship', 'order' => 0],
+        ['type' => LiturgyElementType::SONG, 'name' => 'Doxology', 'order' => 1],
+        ['type' => LiturgyElementType::READING, 'name' => 'Psalm 23', 'order' => 2],
+        ['type' => LiturgyElementType::SERMON, 'name' => 'Sermon', 'description' => 'Of Christ', 'order' => 3],
+        ['type' => LiturgyElementType::PRAYER, 'name' => 'Pastoral Prayer', 'order' => 4],
+        ['type' => LiturgyElementType::SUPPER, 'name' => 'Communion', 'order' => 5],
+        ['type' => LiturgyElementType::BAPTISM, 'name' => 'Baptism', 'order' => 6],
+        ['type' => LiturgyElementType::OTHER, 'name' => 'Announcement', 'order' => 7],
+    ]);
+
+    $this->get(route('services.show', $service))
+        ->assertOk()
+        ->assertSee('All-Type Service')
+        ->assertSee('Worship')
+        ->assertSee('Doxology')
+        ->assertSee('Psalm 23')
+        ->assertSee('Sermon')
+        ->assertSee('Pastoral Prayer')
+        ->assertSee('Communion');
+});

--- a/tests/Unit/SectionToneTest.php
+++ b/tests/Unit/SectionToneTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use App\Support\SectionTone;
+
+it('picks deterministically from the palette', function (): void {
+    $first = SectionTone::pick('Grace');
+    $second = SectionTone::pick('Grace');
+
+    expect($first)->toBe($second);
+    expect(SectionTone::PALETTE)->toContain($first);
+});
+
+it('returns different colors for distinct seeds', function (): void {
+    $seeds = ['God', 'Guilt', 'Grace', 'Word', 'Communion', 'Sending'];
+    $colors = array_map([SectionTone::class, 'pick'], $seeds);
+
+    // The Flexoki-mapped palette has 8 colors; collisions across 6 named seeds
+    // are possible but the demo set above produces at least 4 distinct colors.
+    expect(array_unique($colors))->toHaveCount(count(array_unique($colors)));
+    expect(count(array_unique($colors)))->toBeGreaterThanOrEqual(4);
+});
+
+it('returns neutral classes for null or unknown colors', function (): void {
+    $null = SectionTone::classesFor(null);
+    $unknown = SectionTone::classesFor('not-a-color');
+
+    expect($null)->toBe($unknown);
+    expect($null['stripe'])->toContain('zinc');
+});
+
+it('returns tailwind classes scoped to a known color', function (): void {
+    $classes = SectionTone::classesFor('blue');
+
+    expect($classes['stripe'])->toContain('bg-blue-500');
+    expect($classes['dot'])->toContain('text-blue-700');
+    expect($classes['swatch'])->toContain('bg-blue-100');
+    expect($classes['soft'])->toContain('bg-blue-50');
+});


### PR DESCRIPTION
## Summary

- Replaces the table-based service order layout with a sectioned grid design featuring tonal color stripes per section, inline text editing for element names and descriptions, and assignee/content chip popovers
- Adds `SectionTone` support class that auto-seeds deterministic colors for section headers via the LiturgyElement observer, with a migration to backfill existing sections
- Introduces element and service duplication, an "add element" slot between rows, a stats strip header (sections, elements, unassigned, missing content), and a redesigned service header with inline title editing
- Extracts reusable Blade components (`inline-text`, `date-block`, `stats-strip`, `assignee-chip`, `content-chip`, `add-element-slot`) for consistent UI patterns
- Includes 27 tests covering section tone logic, service stats, inline editing, duplication, element insertion, assignee/content management, and full-page rendering

## Test plan

- [ ] Verify section color stripes render correctly for multi-section services
- [ ] Test inline renaming of service title, section names, and element names
- [ ] Test assignee and content chip popovers for setting/clearing values
- [ ] Test element and service duplication
- [ ] Test "add element" slot inserts elements at the correct position
- [ ] Verify stats strip counts update after adding/removing elements
- [ ] Run `php artisan test` to confirm all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)