### PR TITLE
Refine groups card with cover overlay and avatar group

### DIFF
--- a/resources/views/components/groups/card.blade.php
+++ b/resources/views/components/groups/card.blade.php
@@ -9,7 +9,7 @@
         ? trim(html_entity_decode(strip_tags((string) $latestComment->text), ENT_QUOTES | ENT_HTML5, 'UTF-8'))
         : null;
     $membersCount = $group->members_count ?? $group->members()->count();
-    $previewMembers = $group->relationLoaded('members') ? $group->members : $group->members()->limit(4)->get();
+    $previewMembers = $group->relationLoaded('members') ? $group->members->take(4) : $group->members()->limit(4)->get();
     $extraMembers = max(0, $membersCount - $previewMembers->count());
 @endphp
 
@@ -59,7 +59,7 @@
             <div class="flex items-center gap-2 min-w-0">
                 @if ($previewMembers->isNotEmpty())
                     <flux:avatar.group class="dark:**:ring-zinc-800">
-                        @foreach ($previewMembers->take(4) as $member)
+                        @foreach ($previewMembers as $member)
                             <flux:avatar
                                 size="xs"
                                 :name="$member->name"

--- a/resources/views/components/groups/card.blade.php
+++ b/resources/views/components/groups/card.blade.php
@@ -19,20 +19,26 @@
     class="group block focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 rounded-lg"
 >
     <div class="flex h-full flex-col overflow-hidden rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 transition group-hover:border-zinc-300 dark:group-hover:border-white/20 group-hover:shadow-sm">
-        <x-groups.cover :group="$group" height="88px" />
-
-        <div class="flex flex-col gap-1.5 px-4 pt-3 pb-2.5">
-            <h3 class="text-base font-bold tracking-tight text-zinc-900 dark:text-zinc-100">
-                {{ $group->name }}
-            </h3>
-            <div class="flex flex-wrap gap-1.5">
-                <flux:badge size="sm" :color="$group->visibility->color()">{{ $group->visibility->label() }}</flux:badge>
-                <flux:badge size="sm" :color="$group->messaging->color()">{{ $group->messaging->label() }}</flux:badge>
+        <div class="relative h-[132px]">
+            <x-groups.cover :group="$group" height="132px" :show-initial="false" />
+            <div
+                class="absolute inset-0"
+                style="background: linear-gradient(to top, rgba(0,0,0,0.62) 0%, rgba(0,0,0,0.30) 45%, rgba(0,0,0,0) 100%);"
+                aria-hidden="true"
+            ></div>
+            <div class="absolute inset-x-0 bottom-0 flex flex-col gap-2 px-4 pt-3 pb-3">
+                <h3 class="text-[17px] font-bold tracking-tight text-white" style="text-shadow: 0 1px 2px rgba(0,0,0,0.35);">
+                    {{ $group->name }}
+                </h3>
+                <div class="flex flex-wrap gap-1.5">
+                    <flux:badge size="sm" :color="$group->visibility->color()">{{ $group->visibility->label() }}</flux:badge>
+                    <flux:badge size="sm" :color="$group->messaging->color()">{{ $group->messaging->label() }}</flux:badge>
+                </div>
             </div>
         </div>
 
         <div @class([
-            'px-4 py-2.5 border-t border-zinc-100 dark:border-zinc-800',
+            'flex-1 min-h-16 px-4 py-2.5 border-t border-zinc-100 dark:border-zinc-800',
             'bg-zinc-50 dark:bg-zinc-800/40' => ! $latestComment,
             'bg-accent/5' => $latestComment,
         ])>
@@ -45,29 +51,25 @@
                     {{ $latestComment->created_at->diffForHumans() }}
                 </p>
             @else
-                <p class="text-xs italic text-zinc-500">No messages yet.</p>
+                <p class="text-xs italic text-zinc-500 dark:text-zinc-400">No messages yet.</p>
             @endif
         </div>
 
-        <div class="flex items-center justify-between gap-3 px-4 py-2.5 border-t border-zinc-100 dark:border-zinc-800 mt-auto">
+        <div class="flex items-center justify-between gap-3 px-4 py-2.5 border-t border-zinc-100 dark:border-zinc-800 shrink-0">
             <div class="flex items-center gap-2 min-w-0">
                 @if ($previewMembers->isNotEmpty())
-                    <div class="flex items-center">
+                    <flux:avatar.group class="dark:**:ring-zinc-800">
                         @foreach ($previewMembers->take(4) as $member)
-                            <span class="-ml-1.5 first:ml-0 ring-2 ring-white dark:ring-zinc-900 rounded-md">
-                                <flux:avatar
-                                    size="xs"
-                                    :name="$member->name"
-                                    :src="$member->gravatar"
-                                />
-                            </span>
+                            <flux:avatar
+                                size="xs"
+                                :name="$member->name"
+                                :src="$member->gravatar"
+                            />
                         @endforeach
                         @if ($extraMembers > 0)
-                            <span class="-ml-1.5 inline-flex h-5 min-w-5 items-center justify-center rounded-md bg-zinc-100 dark:bg-zinc-800 px-1 text-[10px] font-semibold text-zinc-600 dark:text-zinc-300 ring-2 ring-white dark:ring-zinc-900">
-                                +{{ $extraMembers }}
-                            </span>
+                            <flux:avatar size="xs">+{{ $extraMembers }}</flux:avatar>
                         @endif
-                    </div>
+                    </flux:avatar.group>
                 @endif
                 <span class="text-xs text-zinc-500 whitespace-nowrap">
                     {{ $membersCount }} {{ Str::plural('member', $membersCount) }}

--- a/resources/views/components/groups/cover.blade.php
+++ b/resources/views/components/groups/cover.blade.php
@@ -3,6 +3,7 @@
     'height' => '88px',
     'rounded' => 'none',
     'initialSize' => '36%',
+    'showInitial' => true,
 ])
 
 @php
@@ -40,7 +41,7 @@
                 );
             "
             aria-hidden="true"
-        >{{ $group->first_letter }}</div>
+        >@if ($showInitial){{ $group->first_letter }}@endif</div>
     @endif
 
     {{ $slot }}

--- a/tests/Feature/GroupTest.php
+++ b/tests/Feature/GroupTest.php
@@ -483,6 +483,23 @@ test('my groups card shows "No messages yet" when group has no comments', functi
         ->assertSee('No messages yet.');
 });
 
+/** @group groups-index-redesign */
+test('my groups card renders a flux avatar group with a +N overflow for groups with more than four members', function (): void {
+    $user = User::factory()->create();
+    $group = Group::factory()->create(['name' => 'Big Crew', 'visibility' => GroupVisibility::PUBLIC]);
+    $group->allUsers()->attach($user, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+
+    foreach (User::factory()->count(6)->create() as $member) {
+        $group->allUsers()->attach($member, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+    }
+
+    $component = Livewire::actingAs($user)
+        ->test('pages::groups.index');
+
+    $component->assertSee($user->name);
+    expect($component->html())->toContain('+3');
+});
+
 test('discover search matches description as well as name', function (): void {
     $user = User::factory()->create();
     Group::factory()->create([


### PR DESCRIPTION
Redesigns the groups index card to overlay the title and badges on the cover image using a gradient, replaces the manual avatar stacking with `flux:avatar.group`, and adds a `showInitial` prop to the cover component. Also fixes dark mode contrast for the empty-messages placeholder and adds a test for the +N member overflow badge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated group card design with an enhanced cover area and improved visual styling.
  * Redesigned member preview display with improved avatar component rendering.
  * Refined overflow member indicator for groups with more than four members.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jpangborn/stave/pull/112?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->