### PR TITLE
Polish service show page: card sections, two-pane content preview, squircle avatars

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -240,3 +240,19 @@ a.mention:hover {
 .tippy-box[data-theme~='mentions'] .tippy-content {
     @apply p-0;
 }
+
+/* ----------------------------------------------------------
+   Service detail page — scoped accent override.
+   The app-wide accent is Flexoki purple, but the service
+   show page uses emerald for active tab + save status to
+   match the Stave service-planning design system.
+   ---------------------------------------------------------- */
+[data-service-show] [data-flux-tab][data-selected] {
+    color: var(--color-emerald-700);
+    border-color: var(--color-emerald-600);
+}
+
+.dark [data-service-show] [data-flux-tab][data-selected] {
+    color: var(--color-emerald-300);
+    border-color: var(--color-emerald-400);
+}

--- a/resources/views/components/service/add-element-slot.blade.php
+++ b/resources/views/components/service/add-element-slot.blade.php
@@ -9,31 +9,33 @@
 <div x-data="{ open: false, hov: false }"
      @mouseenter="hov = true"
      @mouseleave="if (!open) hov = false"
-     class="relative h-2 cursor-pointer"
-     :class="(hov || open) ? 'h-7' : 'h-2'"
-     style="transition: height 120ms ease;">
+     class="relative z-10 h-2.5 cursor-pointer">
 
-    <div x-show="hov || open" x-cloak
-         class="absolute inset-x-0 top-1/2 flex -translate-y-1/2 justify-center">
-        <button type="button"
-                @click.stop="open = true"
-                class="inline-flex items-center gap-1.5 rounded-full border border-dashed border-zinc-300 bg-white px-3 py-1 text-xs font-medium text-zinc-500 hover:border-zinc-400 hover:text-zinc-700 dark:border-zinc-600 dark:bg-zinc-900 dark:text-zinc-400 dark:hover:border-zinc-500 dark:hover:text-zinc-200">
-            <flux:icon name="plus" class="size-3" />
-            Add element
-        </button>
-    </div>
+    <button type="button"
+            x-show="hov || open"
+            x-cloak
+            @click.stop="open = true"
+            class="absolute left-1/2 top-1/2 z-10 inline-flex -translate-x-1/2 -translate-y-1/2 items-center gap-1.5 rounded-full border border-dashed border-zinc-300 bg-white px-3 py-1 text-[11.5px] font-medium text-zinc-500 shadow-[0_1px_2px_rgba(0,0,0,0.04)] hover:border-zinc-400 hover:text-zinc-700 dark:border-zinc-600 dark:bg-zinc-900 dark:text-zinc-400 dark:hover:border-zinc-500 dark:hover:text-zinc-200">
+        <flux:icon name="plus" class="size-3" />
+        Add element
+    </button>
 
     <template x-if="open">
         <div>
             <div @click.stop="open = false; hov = false" class="fixed inset-0 z-40 bg-black/5"></div>
-            <div class="absolute left-1/2 top-full z-50 mt-2 w-44 -translate-x-1/2 overflow-hidden rounded-lg border border-zinc-200 bg-white p-1 shadow-lg dark:border-zinc-700 dark:bg-zinc-900"
+            <div class="absolute left-1/2 top-full z-50 mt-2 w-48 -translate-x-1/2 overflow-hidden rounded-lg border border-zinc-200 bg-white p-1 shadow-lg dark:border-zinc-700 dark:bg-zinc-900"
                  @click.stop
                  @keydown.escape.window="open = false; hov = false">
+                <div class="px-2 pt-1.5 pb-1 text-[10px] font-semibold uppercase tracking-wider text-zinc-400">
+                    Add element
+                </div>
                 @foreach ($types as $case)
                     <button type="button"
                             @click="$wire.call('addElementAfter', {{ $afterId }}, '{{ $case->value }}'); open = false; hov = false"
-                            class="flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-[13px] text-zinc-700 hover:bg-zinc-100 dark:text-zinc-200 dark:hover:bg-zinc-800">
-                        <flux:icon name="{{ $case->icon() }}" class="size-3.5 text-zinc-500" />
+                            class="flex w-full items-center gap-2.5 rounded-md px-2 py-1.5 text-left text-[13px] text-zinc-700 hover:bg-zinc-100 dark:text-zinc-200 dark:hover:bg-zinc-800">
+                        <span class="flex size-6 shrink-0 items-center justify-center rounded-md bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400">
+                            <flux:icon name="{{ $case->icon() }}" class="size-3.5" />
+                        </span>
                         {{ $case->label() }}
                     </button>
                 @endforeach

--- a/resources/views/components/service/date-block.blade.php
+++ b/resources/views/components/service/date-block.blade.php
@@ -3,7 +3,7 @@
 ])
 
 <div class="flex w-16 shrink-0 flex-col items-center rounded-lg border border-zinc-200 bg-white py-1.5 dark:border-zinc-700 dark:bg-zinc-900">
-    <div class="text-[10px] font-bold uppercase tracking-[0.14em] text-accent">
+    <div class="text-[10px] font-bold uppercase tracking-[0.14em] text-emerald-700 dark:text-emerald-300">
         {{ $date->format('M') }}
     </div>
     <div class="mt-0.5 text-[26px] font-bold leading-none tracking-tight text-zinc-900 tabular-nums dark:text-zinc-100">

--- a/resources/views/components/service/element-row.blade.php
+++ b/resources/views/components/service/element-row.blade.php
@@ -1,0 +1,65 @@
+@props([
+    'element',
+    'tone',
+    'sectionColor' => null,
+    'isFirstInSection' => false,
+    'isLastInSection' => false,
+    'name',
+    'placeholder' => null,
+    'icon' => null,
+    'typeLabel' => null,
+    'wireKeyPrefix' => 'row',
+])
+
+@php
+    $showStripe = $sectionColor !== null;
+    $iconName = $icon ?? $element->type->icon();
+    $label = $typeLabel ?? $element->type->label();
+    $placeholderText = $placeholder ?? $label;
+
+    $stripePosClass = match (true) {
+        $isFirstInSection && $isLastInSection => 'top-0.5 bottom-0.5',
+        $isFirstInSection => 'top-0.5 bottom-0',
+        $isLastInSection => 'top-0 bottom-0.5',
+        default => 'inset-y-0',
+    };
+@endphp
+
+<div :x-sort:item="$element->id"
+     wire:key="{{ $wireKeyPrefix }}-{{ $element->id }}"
+     class="group relative grid grid-cols-[18px_36px_minmax(160px,1fr)_minmax(120px,200px)_minmax(160px,260px)_32px] items-center gap-3 px-2.5 py-2 transition-colors hover:bg-zinc-50 dark:hover:bg-zinc-900/50">
+
+    @if ($showStripe)
+        <div class="absolute left-1.5 w-0.5 rounded-sm opacity-70 transition-opacity group-hover:opacity-100 {{ $stripePosClass }} {{ $tone['stripe'] }}"></div>
+    @endif
+
+    <div x-sort-handle
+         class="flex h-6 cursor-grab items-center justify-center text-zinc-300 opacity-0 transition-opacity group-hover:opacity-100 dark:text-zinc-600"
+         title="Drag to reorder">
+        <flux:icon name="grip-vertical" class="size-3.5" />
+    </div>
+
+    <div class="flex size-9 items-center justify-center rounded-lg {{ $tone['swatch'] }}">
+        <flux:icon name="{{ $iconName }}" class="size-4" />
+    </div>
+
+    <div class="min-w-0">
+        <div class="text-[13.5px] font-semibold text-zinc-900 dark:text-zinc-100">
+            <x-service.inline-text
+                wire-model="name"
+                :value="$name"
+                :placeholder="$placeholderText"
+                class="text-[13.5px] font-semibold"
+            />
+        </div>
+        <div class="text-[10.5px] font-medium uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
+            {{ $label }}
+        </div>
+    </div>
+
+    {{ $assignee }}
+
+    {{ $content }}
+
+    {{ $actions }}
+</div>

--- a/resources/views/components/service/inline-text.blade.php
+++ b/resources/views/components/service/inline-text.blade.php
@@ -40,6 +40,6 @@
         @blur="editing = false"
         @keydown.enter.prevent="$refs.inlineInput.blur()"
         @keydown.escape.prevent="$refs.inlineInput.blur()"
-        class="{{ $base }} {{ $padClasses }} block w-full max-w-full bg-transparent border-b border-accent outline-none"
+        class="{{ $base }} {{ $padClasses }} block w-full max-w-full rounded-md border border-emerald-400 bg-white outline-none dark:border-emerald-500 dark:bg-zinc-900"
     />
 </div>

--- a/resources/views/components/service/squircle-avatar.blade.php
+++ b/resources/views/components/service/squircle-avatar.blade.php
@@ -1,0 +1,39 @@
+@props([
+    'name' => '',
+    'size' => 24,
+    'src' => null,
+])
+
+@php
+    use App\Support\SectionTone;
+
+    $initials = collect(preg_split('/\s+/', trim($name ?? '')))
+        ->filter()
+        ->take(2)
+        ->map(fn ($part) => mb_strtoupper(mb_substr($part, 0, 1)))
+        ->implode('');
+
+    if ($initials === '') {
+        $initials = '?';
+    }
+
+    $radius = max(5, (int) round($size * 0.26));
+    $fontSize = max(9, (int) round($size * 0.40));
+
+    $first = mb_ord($initials[0] ?? '?');
+    $second = mb_ord(mb_substr($initials, 1, 1) ?: '0');
+    $index = ($first * 7 + $second) % count(SectionTone::PALETTE);
+    $hue = SectionTone::PALETTE[$index];
+@endphp
+
+@if ($src)
+    <img src="{{ $src }}"
+         alt="{{ $name }}"
+         style="width: {{ $size }}px; height: {{ $size }}px; border-radius: {{ $radius }}px;"
+         class="inline-block shrink-0 object-cover" />
+@else
+    <span style="width: {{ $size }}px; height: {{ $size }}px; border-radius: {{ $radius }}px; font-size: {{ $fontSize }}px;"
+          class="inline-flex shrink-0 items-center justify-center font-bold leading-none bg-{{ $hue }}-100 text-{{ $hue }}-700 dark:bg-{{ $hue }}-900 dark:text-{{ $hue }}-300">
+        {{ $initials }}
+    </span>
+@endif

--- a/resources/views/livewire/elements/_partials/assignee-chip.blade.php
+++ b/resources/views/livewire/elements/_partials/assignee-chip.blade.php
@@ -21,10 +21,10 @@
             wire:click="$set('assigneeOpen', true)"
             class="flex h-8 w-full items-center gap-2 rounded-full px-2.5 text-left text-[12.5px] transition hover:bg-zinc-100 dark:hover:bg-zinc-800 {{ $open ? 'bg-zinc-100 dark:bg-zinc-800' : '' }}">
         @if ($assignee)
-            <flux:avatar :name="$assignee->name" size="xs" />
+            <x-service.squircle-avatar :name="$assignee->name" :size="24" />
             <span class="min-w-0 flex-1 truncate font-medium text-zinc-900 dark:text-zinc-100">{{ $assignee->name }}</span>
         @else
-            <span class="flex size-6 shrink-0 items-center justify-center rounded-full border border-dashed border-zinc-300 text-zinc-400 dark:border-zinc-600 dark:text-zinc-500">
+            <span class="flex size-6 shrink-0 items-center justify-center rounded-md border border-dashed border-zinc-300 text-zinc-400 dark:border-zinc-600 dark:text-zinc-500">
                 <flux:icon name="user" class="size-3" />
             </span>
             <span class="flex-1 italic text-zinc-500 dark:text-zinc-400">Unassigned</span>
@@ -55,11 +55,11 @@
                 @endif
 
                 @if ($recents->isNotEmpty())
-                    <div class="px-2 pt-1 pb-1 text-[10px] font-semibold uppercase tracking-wider text-zinc-400">Recent in this service</div>
+                    <div class="px-2 pt-1 pb-1 text-[10px] font-semibold uppercase tracking-wider text-zinc-400">In this service</div>
                     @foreach ($recents as $user)
                         <button type="button" wire:key="recent-{{ $user->id }}" wire:click="setAssignee({{ $user->id }})"
                                 class="flex w-full items-center gap-2.5 rounded-md px-2.5 py-1.5 text-left text-[12.5px] hover:bg-zinc-100 dark:hover:bg-zinc-800">
-                            <flux:avatar :name="$user->name" size="xs" />
+                            <x-service.squircle-avatar :name="$user->name" :size="24" />
                             <span class="truncate text-zinc-900 dark:text-zinc-100">{{ $user->name }}</span>
                         </button>
                     @endforeach
@@ -75,7 +75,7 @@
                     @foreach ($rest as $user)
                         <button type="button" wire:key="all-{{ $user->id }}" wire:click="setAssignee({{ $user->id }})"
                                 class="flex w-full items-center gap-2.5 rounded-md px-2.5 py-1.5 text-left text-[12.5px] hover:bg-zinc-100 dark:hover:bg-zinc-800">
-                            <flux:avatar :name="$user->name" size="xs" />
+                            <x-service.squircle-avatar :name="$user->name" :size="24" />
                             <span class="truncate text-zinc-900 dark:text-zinc-100">{{ $user->name }}</span>
                         </button>
                     @endforeach

--- a/resources/views/livewire/elements/_partials/content-chip.blade.php
+++ b/resources/views/livewire/elements/_partials/content-chip.blade.php
@@ -4,17 +4,33 @@
     /** @var string $variant */  // 'song' | 'reading'
     /** @var bool $open */
     /** @var string $search */
+    /** @var int|null $hoverId */
+    /** @var \App\Models\Song|\App\Models\Reading|null $previewItem */
     $selected = $element->content;
     $icon = $variant === 'song' ? 'musical-note' : 'book-open-text';
     $placeholder = $variant === 'song' ? 'Pick a song' : 'Pick a reading';
-    $searchPlaceholder = $variant === 'song' ? 'Search songs…' : 'Search readings…';
+    $searchPlaceholder = $variant === 'song' ? 'Search songs…' : 'Search scripture and readings…';
     $titleField = $variant === 'song' ? 'name' : 'title';
+    $addNewLabel = $variant === 'song' ? 'Add new song' : 'Add new reading';
+    $emptyHint = $variant === 'song' ? 'No songs match.' : 'No readings match.';
+
+    $previewTitle = $previewItem?->{$titleField};
+    $previewLines = [];
+    if ($previewItem) {
+        $body = $variant === 'song'
+            ? ($previewItem->lyrics ?? '')
+            : ($previewItem->text ?? '');
+        $previewLines = collect(preg_split('/\r?\n/', $body))
+            ->slice(0, 20)
+            ->values()
+            ->all();
+    }
 @endphp
 
 <div class="relative w-full" x-data
      @keydown.escape.window="$wire.set('contentOpen', false)">
     <button type="button"
-            wire:click="$set('contentOpen', true)"
+            wire:click="openContent"
             class="flex h-8 w-full items-center gap-2 rounded-full px-3 text-left text-[12.5px] transition
                    {{ $selected ? 'hover:bg-zinc-100 dark:hover:bg-zinc-800' : 'border border-dashed border-zinc-300 dark:border-zinc-600' }}
                    {{ $open ? 'bg-zinc-100 dark:bg-zinc-800' : '' }}">
@@ -28,7 +44,7 @@
 
     @if ($open)
         <div wire:click="$set('contentOpen', false)" class="fixed inset-0 z-40 bg-black/5"></div>
-        <div class="absolute left-0 top-[calc(100%+4px)] z-50 w-80 overflow-hidden rounded-xl border border-zinc-200 bg-white shadow-lg dark:border-zinc-700 dark:bg-zinc-900">
+        <div class="absolute left-0 top-[calc(100%+4px)] z-50 w-[600px] max-w-[calc(100vw-2rem)] overflow-hidden rounded-xl border border-zinc-200 bg-white shadow-lg dark:border-zinc-700 dark:bg-zinc-900">
             <div class="border-b border-zinc-200 px-3 py-2 dark:border-zinc-700">
                 <input type="text"
                        x-init="$el.focus()"
@@ -37,33 +53,109 @@
                        class="h-7 w-full border-0 bg-transparent text-[13px] text-zinc-900 placeholder-zinc-400 focus:outline-none focus:ring-0 dark:text-zinc-100" />
             </div>
 
-            <div class="max-h-72 overflow-y-auto p-1">
-                @if ($selected)
-                    <button type="button" wire:click="setContent(null)"
-                            class="flex w-full items-center gap-2.5 rounded-md px-2.5 py-1.5 text-left text-[12.5px] text-zinc-700 hover:bg-zinc-100 dark:text-zinc-200 dark:hover:bg-zinc-800">
-                        <flux:icon name="x-mark" class="size-3 text-zinc-500" />
-                        <span class="italic">Clear</span>
-                    </button>
-                    <div class="my-1 h-px bg-zinc-100 dark:bg-zinc-800"></div>
-                @endif
+            <div class="grid grid-cols-[260px_1fr]" style="height: 340px;">
+                <div class="overflow-y-auto border-r border-zinc-200 dark:border-zinc-700">
+                    @if ($items->isEmpty())
+                        <div class="px-3 py-6 text-center text-[12.5px] text-zinc-500">{{ $emptyHint }}</div>
+                    @else
+                        @foreach ($items as $item)
+                            @php $isActive = $selected?->id === $item->id; @endphp
+                            <button type="button"
+                                    wire:key="content-{{ $item->id }}"
+                                    wire:click="setContent({{ $item->id }})"
+                                    wire:mouseenter="$set('hoverContentId', {{ $item->id }})"
+                                    class="flex w-full items-start gap-2 border-l-2 px-3 py-2 text-left transition
+                                           {{ $isActive ? 'border-l-emerald-600 bg-emerald-50/40 dark:border-l-emerald-400 dark:bg-emerald-900/20' : 'border-l-transparent hover:bg-zinc-100 dark:hover:bg-zinc-800' }}
+                                           {{ $hoverId === $item->id && ! $isActive ? 'bg-zinc-100 dark:bg-zinc-800' : '' }}">
+                                <flux:icon name="{{ $icon }}" class="mt-0.5 size-3 shrink-0 text-zinc-500" />
+                                <div class="min-w-0 flex-1">
+                                    <div class="flex items-center gap-1.5">
+                                        <span class="truncate text-[12.5px] {{ $isActive ? 'font-semibold text-emerald-700 dark:text-emerald-300' : 'font-medium text-zinc-900 dark:text-zinc-100' }}">
+                                            {{ $item->{$titleField} }}
+                                        </span>
+                                        @if ($isActive)
+                                            <flux:icon name="check" class="ml-auto size-3 shrink-0 text-emerald-600 dark:text-emerald-400" />
+                                        @endif
+                                    </div>
+                                    <div class="mt-0.5 flex items-center gap-2 text-[10px] text-zinc-500 dark:text-zinc-400">
+                                        @if ($variant === 'song')
+                                            @if (! empty($item->ccli_number))
+                                                <span>CCLI {{ $item->ccli_number }}</span>
+                                            @endif
+                                        @else
+                                            <span class="capitalize">{{ $item->type?->value }}</span>
+                                        @endif
+                                    </div>
+                                </div>
+                            </button>
+                        @endforeach
+                    @endif
+                </div>
 
-                @if ($items->isEmpty())
-                    <div class="px-3 py-6 text-center text-[12.5px] text-zinc-500">
-                        @if ($search === '')
-                            Start typing to search.
-                        @else
-                            No {{ $variant === 'song' ? 'songs' : 'readings' }} match.
-                        @endif
-                    </div>
-                @else
-                    @foreach ($items as $item)
-                        <button type="button" wire:key="content-{{ $item->id }}" wire:click="setContent({{ $item->id }})"
-                                class="flex w-full items-center gap-2.5 rounded-md px-2.5 py-1.5 text-left text-[12.5px] hover:bg-zinc-100 dark:hover:bg-zinc-800">
-                            <flux:icon name="{{ $icon }}" class="size-3 shrink-0 text-zinc-500" />
-                            <span class="truncate text-zinc-900 dark:text-zinc-100">{{ $item->{$titleField} }}</span>
+                <div class="overflow-y-auto bg-zinc-50 px-5 py-4 dark:bg-zinc-950/30">
+                    @if ($previewItem)
+                        <div class="flex items-baseline justify-between gap-2">
+                            <div class="text-[14px] font-bold tracking-tight text-zinc-900 dark:text-zinc-100">
+                                {{ $previewTitle }}
+                            </div>
+                            <div class="text-[9.5px] font-bold uppercase tracking-[0.08em] text-zinc-400">Preview</div>
+                        </div>
+                        <div class="mt-1 flex flex-wrap items-center gap-x-2.5 gap-y-0.5 text-[10.5px] text-zinc-500 dark:text-zinc-400">
+                            @if ($variant === 'song')
+                                @if (! empty($previewItem->ccli_number))
+                                    <span>CCLI {{ $previewItem->ccli_number }}</span>
+                                @endif
+                                @if (! empty($previewItem->authors))
+                                    <span class="truncate">{{ $previewItem->authors }}</span>
+                                @endif
+                            @else
+                                <span class="capitalize">{{ $previewItem->type?->value }}</span>
+                            @endif
+                            @if ($previewItem->last_used_date)
+                                <span class="ml-auto">Last used {{ $previewItem->last_used_date->format('M j, Y') }}</span>
+                            @endif
+                        </div>
+                        <div class="mt-2.5 space-y-1 text-[12px] leading-relaxed {{ $variant === 'reading' ? 'italic' : '' }} text-zinc-700 dark:text-zinc-300">
+                            @foreach ($previewLines as $line)
+                                @if (trim($line) === '')
+                                    <div class="h-2"></div>
+                                @else
+                                    <div>{{ $line }}</div>
+                                @endif
+                            @endforeach
+                            @if (empty($previewLines))
+                                <div class="italic text-zinc-400">No preview available.</div>
+                            @endif
+                        </div>
+                    @else
+                        <div class="flex h-full items-center justify-center text-[12px] italic text-zinc-400">
+                            Hover an item to preview.
+                        </div>
+                    @endif
+                </div>
+            </div>
+
+            <div class="flex items-center justify-between gap-2 border-t border-zinc-200 px-3 py-2 dark:border-zinc-700">
+                <div class="flex items-center gap-3">
+                    @if ($selected)
+                        <button type="button" wire:click="setContent(null)"
+                                class="inline-flex items-center gap-1.5 text-[11.5px] text-zinc-500 hover:text-zinc-800 dark:text-zinc-400 dark:hover:text-zinc-100">
+                            <flux:icon name="x-mark" class="size-3" />
+                            Remove
                         </button>
-                    @endforeach
-                @endif
+                    @endif
+                    @if ($variant === 'reading')
+                        <a href="{{ route('readings.create') }}"
+                           class="inline-flex items-center gap-1.5 text-[11.5px] text-zinc-500 no-underline hover:text-zinc-800 dark:text-zinc-400 dark:hover:text-zinc-100">
+                            <flux:icon name="plus" class="size-3" />
+                            {{ $addNewLabel }}
+                        </a>
+                    @endif
+                </div>
+                <div class="inline-flex items-center gap-1 text-[10.5px] text-zinc-400">
+                    <kbd class="rounded border border-zinc-200 bg-white px-1 py-0.5 font-mono text-[9.5px] dark:border-zinc-700 dark:bg-zinc-900">↵</kbd>
+                    select
+                </div>
             </div>
         </div>
     @endif

--- a/resources/views/livewire/elements/other.blade.php
+++ b/resources/views/livewire/elements/other.blade.php
@@ -83,58 +83,44 @@ new class extends Component {
 
 @php
     $tone = SectionTone::classesFor($sectionColor);
-    $showStripe = $sectionColor !== null;
 @endphp
 
-<div :x-sort:item="$element->id" wire:key="other-{{ $element->id }}"
-     class="group relative grid items-center gap-3 border-b border-zinc-100 px-2 py-2 transition-colors hover:bg-zinc-50 dark:border-zinc-800 dark:hover:bg-zinc-900
-            {{ $showStripe ? 'grid-cols-[4px_18px_36px_minmax(140px,1fr)_minmax(140px,200px)_minmax(160px,240px)_32px]' : 'grid-cols-[18px_36px_minmax(140px,1fr)_minmax(140px,200px)_minmax(160px,240px)_32px]' }}">
+<div>
+    <x-service.element-row
+        :element="$element"
+        :tone="$tone"
+        :section-color="$sectionColor"
+        :is-first-in-section="$isFirstInSection"
+        :is-last-in-section="$isLastInSection"
+        :name="$name"
+        wire-key-prefix="other"
+    >
+        <x-slot:assignee>
+            @include('livewire.elements._partials.assignee-chip', [
+                'element' => $element,
+                'users' => $users,
+                'recentIds' => $recentAssigneeIds,
+                'open' => $assigneeOpen,
+                'search' => $assigneeSearch,
+            ])
+        </x-slot:assignee>
 
-    @if ($showStripe)
-        <div class="-my-2 self-stretch rounded-sm opacity-60 {{ $tone['stripe'] }}"></div>
-    @endif
+        <x-slot:content>
+            <div class="flex h-8 items-center px-3 text-[12px] italic text-zinc-400 dark:text-zinc-500">
+                — no content needed —
+            </div>
+        </x-slot:content>
 
-    <div x-sort-handle class="flex h-6 cursor-grab items-center justify-center text-zinc-300 opacity-0 transition-opacity group-hover:opacity-100 dark:text-zinc-600" title="Drag to reorder">
-        <flux:icon name="bars-2" class="size-3.5" />
-    </div>
-
-    <div class="flex size-9 items-center justify-center rounded-lg {{ $tone['swatch'] }}">
-        <flux:icon name="{{ $element->type->icon() }}" class="size-4" />
-    </div>
-
-    <div class="min-w-0">
-        <div class="text-[13.5px] font-semibold text-zinc-900 dark:text-zinc-100">
-            <x-service.inline-text
-                wire-model="name"
-                :value="$name"
-                :placeholder="$element->type->label()"
-                class="text-[13.5px] font-semibold"
-            />
-        </div>
-        <div class="text-[10.5px] font-medium uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
-            {{ $element->type->label() }}
-        </div>
-    </div>
-
-    @include('livewire.elements._partials.assignee-chip', [
-        'element' => $element,
-        'users' => $users,
-        'recentIds' => $recentAssigneeIds,
-        'open' => $assigneeOpen,
-        'search' => $assigneeSearch,
-    ])
-
-    <div class="flex h-8 items-center px-3 text-[12px] italic text-zinc-400 dark:text-zinc-500">
-        — no content needed —
-    </div>
-
-    <flux:dropdown align="end" offset="-15">
-        <flux:button variant="ghost" size="sm" icon="ellipsis-horizontal" inset="bottom" />
-        <flux:menu class="min-w-36">
-            <flux:menu.item wire:click="duplicate" icon="document-duplicate">Duplicate</flux:menu.item>
-            <flux:menu.item wire:click="delete" icon="trash" variant="danger">Delete</flux:menu.item>
-        </flux:menu>
-    </flux:dropdown>
+        <x-slot:actions>
+            <flux:dropdown align="end" offset="-15">
+                <flux:button variant="ghost" size="sm" icon="ellipsis-horizontal" inset="bottom" />
+                <flux:menu class="min-w-36">
+                    <flux:menu.item wire:click="duplicate" icon="document-duplicate">Duplicate</flux:menu.item>
+                    <flux:menu.item wire:click="delete" icon="trash" variant="danger">Delete</flux:menu.item>
+                </flux:menu>
+            </flux:dropdown>
+        </x-slot:actions>
+    </x-service.element-row>
 
     <flux:modal name="delete-element" class="min-w-[22rem]">
         <form wire:submit="$parent.delete({{ $element->id }})" class="space-y-6">

--- a/resources/views/livewire/elements/reading.blade.php
+++ b/resources/views/livewire/elements/reading.blade.php
@@ -39,10 +39,20 @@ new class extends Component {
 
     public string $contentSearch = '';
 
+    public ?int $hoverContentId = null;
+
     public function mount(?Collection $users = null): void
     {
         $this->users = $users ?? collect();
         $this->name = $this->element->name;
+    }
+
+    public function openContent(): void
+    {
+        $this->contentOpen = true;
+        $this->contentSearch = '';
+        $this->hoverContentId = $this->element->content_id
+            ?? $this->readings->first()?->id;
     }
 
     public function updatedName(string $value): void
@@ -102,82 +112,84 @@ new class extends Component {
     #[Computed]
     public function readings(): Collection
     {
-        if ($this->contentSearch === '') {
-            return collect();
-        }
+        $query = Reading::query()->withLastUsedDate();
 
-        $query = Reading::query()
-            ->where('title', 'like', '%'.$this->contentSearch.'%')
-            ->orderBy('title');
+        if ($this->contentSearch !== '') {
+            $query->where('title', 'like', '%'.$this->contentSearch.'%');
+        }
 
         if ($this->element->reading_type) {
             $query->where('type', $this->element->reading_type);
         }
 
-        return $query->limit(50)->get();
+        return $query
+            ->orderByDesc('last_used_date')
+            ->orderBy('title')
+            ->limit(50)
+            ->get();
+    }
+
+    #[Computed]
+    public function previewReading(): ?Reading
+    {
+        if ($this->hoverContentId === null) {
+            return null;
+        }
+
+        return Reading::query()
+            ->withLastUsedDate()
+            ->find($this->hoverContentId);
     }
 };
 ?>
 
 @php
     $tone = SectionTone::classesFor($sectionColor);
-    $showStripe = $sectionColor !== null;
 @endphp
 
-<div :x-sort:item="$element->id" wire:key="reading-{{ $element->id }}"
-     class="group relative grid items-center gap-3 border-b border-zinc-100 px-2 py-2 transition-colors hover:bg-zinc-50 dark:border-zinc-800 dark:hover:bg-zinc-900
-            {{ $showStripe ? 'grid-cols-[4px_18px_36px_minmax(140px,1fr)_minmax(140px,200px)_minmax(160px,240px)_32px]' : 'grid-cols-[18px_36px_minmax(140px,1fr)_minmax(140px,200px)_minmax(160px,240px)_32px]' }}">
+<div>
+    <x-service.element-row
+        :element="$element"
+        :tone="$tone"
+        :section-color="$sectionColor"
+        :is-first-in-section="$isFirstInSection"
+        :is-last-in-section="$isLastInSection"
+        :name="$name"
+        wire-key-prefix="reading"
+    >
+        <x-slot:assignee>
+            @include('livewire.elements._partials.assignee-chip', [
+                'element' => $element,
+                'users' => $users,
+                'recentIds' => $recentAssigneeIds,
+                'open' => $assigneeOpen,
+                'search' => $assigneeSearch,
+            ])
+        </x-slot:assignee>
 
-    @if ($showStripe)
-        <div class="-my-2 self-stretch rounded-sm opacity-60 {{ $tone['stripe'] }}"></div>
-    @endif
+        <x-slot:content>
+            @include('livewire.elements._partials.content-chip', [
+                'element' => $element,
+                'items' => $this->readings,
+                'variant' => 'reading',
+                'open' => $contentOpen,
+                'search' => $contentSearch,
+                'hoverId' => $hoverContentId,
+                'previewItem' => $this->previewReading,
+            ])
+        </x-slot:content>
 
-    <div x-sort-handle class="flex h-6 cursor-grab items-center justify-center text-zinc-300 opacity-0 transition-opacity group-hover:opacity-100 dark:text-zinc-600" title="Drag to reorder">
-        <flux:icon name="bars-2" class="size-3.5" />
-    </div>
-
-    <div class="flex size-9 items-center justify-center rounded-lg {{ $tone['swatch'] }}">
-        <flux:icon name="{{ $element->type->icon() }}" class="size-4" />
-    </div>
-
-    <div class="min-w-0">
-        <div class="text-[13.5px] font-semibold text-zinc-900 dark:text-zinc-100">
-            <x-service.inline-text
-                wire-model="name"
-                :value="$name"
-                :placeholder="$element->type->label()"
-                class="text-[13.5px] font-semibold"
-            />
-        </div>
-        <div class="text-[10.5px] font-medium uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
-            {{ $element->type->label() }}
-        </div>
-    </div>
-
-    @include('livewire.elements._partials.assignee-chip', [
-        'element' => $element,
-        'users' => $users,
-        'recentIds' => $recentAssigneeIds,
-        'open' => $assigneeOpen,
-        'search' => $assigneeSearch,
-    ])
-
-    @include('livewire.elements._partials.content-chip', [
-        'element' => $element,
-        'items' => $this->readings,
-        'variant' => 'reading',
-        'open' => $contentOpen,
-        'search' => $contentSearch,
-    ])
-
-    <flux:dropdown align="end" offset="-15">
-        <flux:button variant="ghost" size="sm" icon="ellipsis-horizontal" inset="bottom" />
-        <flux:menu class="min-w-36">
-            <flux:menu.item href="{{ route('readings.create') }}" icon="plus">New reading</flux:menu.item>
-            <flux:menu.item wire:click="duplicate" icon="document-duplicate">Duplicate</flux:menu.item>
-            <flux:menu.item wire:click="delete" icon="trash" variant="danger">Delete</flux:menu.item>
-        </flux:menu>
-    </flux:dropdown>
+        <x-slot:actions>
+            <flux:dropdown align="end" offset="-15">
+                <flux:button variant="ghost" size="sm" icon="ellipsis-horizontal" inset="bottom" />
+                <flux:menu class="min-w-36">
+                    <flux:menu.item href="{{ route('readings.create') }}" icon="plus">New reading</flux:menu.item>
+                    <flux:menu.item wire:click="duplicate" icon="document-duplicate">Duplicate</flux:menu.item>
+                    <flux:menu.item wire:click="delete" icon="trash" variant="danger">Delete</flux:menu.item>
+                </flux:menu>
+            </flux:dropdown>
+        </x-slot:actions>
+    </x-service.element-row>
 
     <flux:modal name="delete-element" class="min-w-[22rem]">
         <form wire:submit="$parent.delete({{ $element->id }})" class="space-y-6">

--- a/resources/views/livewire/elements/section.blade.php
+++ b/resources/views/livewire/elements/section.blade.php
@@ -78,90 +78,92 @@ new class extends Component {
 @php
     $tone = SectionTone::classesFor($sectionColor);
     $countLabel = $sectionElementCount === 1 ? '1 element' : ($sectionElementCount ?? 0).' elements';
+    $indexLabel = str_pad((string) ($sectionIndex ?? 0), 2, '0', STR_PAD_LEFT);
 @endphp
 
 <div :x-sort:item="$element->id" wire:key="section-{{ $element->id }}"
-     class="group mt-6 grid grid-cols-[4px_1fr_auto] items-stretch gap-4">
+     class="group relative mt-6 mb-2 overflow-hidden rounded-lg pl-[22px] pr-[18px] pt-4 pb-4 {{ $tone['soft'] }}">
 
-    <div class="rounded-sm {{ $tone['stripe'] }}"></div>
+    <div class="absolute inset-y-0 left-0 w-1 {{ $tone['stripe'] }}"></div>
 
-    <div class="min-w-0 py-0.5">
-        <div class="flex items-baseline gap-3">
-            <div class="text-[11px] font-bold uppercase tracking-[0.12em] tabular-nums {{ $tone['dot'] }}">
-                {{ str_pad((string) ($sectionIndex ?? 0), 2, '0', STR_PAD_LEFT) }}
-            </div>
+    <div class="flex items-start gap-4">
+        <div class="min-w-[28px] shrink-0 pt-1 text-[22px] font-bold leading-none tracking-tight tabular-nums {{ $tone['dot'] }}">
+            {{ $indexLabel }}
+        </div>
 
-            <h2 class="m-0 min-w-0 flex-1 text-2xl font-bold tracking-tight text-zinc-900 dark:text-zinc-100">
+        <div class="min-w-0 flex-1">
+            <h2 class="m-0 text-xl font-bold leading-tight tracking-tight text-zinc-900 dark:text-zinc-100">
                 <x-service.inline-text
                     wire-model="name"
                     :value="$name"
                     placeholder="Untitled section"
-                    class="text-2xl font-bold tracking-tight"
+                    class="text-xl font-bold tracking-tight"
                 />
             </h2>
 
-            <div class="rounded-full bg-zinc-100 px-2 py-0.5 text-[11px] font-medium text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400">
-                {{ $countLabel }}
+            <div class="mt-1 max-w-[720px] text-[12.5px] leading-relaxed text-zinc-600 dark:text-zinc-400">
+                <x-service.inline-text
+                    wire-model="description"
+                    :value="$description"
+                    placeholder="Add a section description…"
+                    class="text-[12.5px] leading-relaxed"
+                />
             </div>
         </div>
 
-        <div class="mt-1 max-w-[680px] text-[12.5px] leading-relaxed text-zinc-600 dark:text-zinc-400">
-            <x-service.inline-text
-                wire-model="description"
-                :value="$description"
-                placeholder="Add a section description…"
-                class="text-[12.5px] leading-relaxed"
-            />
+        <div class="flex shrink-0 items-center gap-1.5 pt-0.5">
+            <div class="rounded-full border border-black/5 bg-white/70 px-2.5 py-1 text-[10.5px] font-semibold uppercase tracking-wider text-zinc-500 dark:border-white/5 dark:bg-zinc-900/40 dark:text-zinc-400">
+                {{ $countLabel }}
+            </div>
+
+            <div class="relative" x-data>
+                <button type="button" wire:click="$set('addOpen', true)"
+                        class="flex size-7 items-center justify-center rounded-md text-zinc-500 hover:bg-zinc-100 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-100"
+                        title="Add element to this section">
+                    <flux:icon name="plus" class="size-3.5" />
+                </button>
+
+                @if ($addOpen)
+                    <div wire:click="$set('addOpen', false)" class="fixed inset-0 z-40 bg-black/5"></div>
+                    <div class="absolute right-0 top-[calc(100%+4px)] z-50 w-48 overflow-hidden rounded-lg border border-zinc-200 bg-white p-1 shadow-lg dark:border-zinc-700 dark:bg-zinc-900"
+                         x-data @keydown.escape.window="$wire.set('addOpen', false)">
+                        <div class="px-2 pt-1.5 pb-1 text-[10px] font-semibold uppercase tracking-wider text-zinc-400">
+                            Add element
+                        </div>
+                        @foreach (LiturgyElementType::cases() as $case)
+                            @continue($case === LiturgyElementType::SECTION)
+                            <button type="button" wire:click="addElement('{{ $case->value }}')"
+                                    class="flex w-full items-center gap-2.5 rounded-md px-2 py-1.5 text-left text-[13px] text-zinc-700 hover:bg-zinc-100 dark:text-zinc-200 dark:hover:bg-zinc-800">
+                                <span class="flex size-6 shrink-0 items-center justify-center rounded-md bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400">
+                                    <flux:icon name="{{ $case->icon() }}" class="size-3.5" />
+                                </span>
+                                {{ $case->label() }}
+                            </button>
+                        @endforeach
+                    </div>
+                @endif
+            </div>
+
+            <flux:dropdown align="end" offset="-15">
+                <flux:button variant="ghost" size="sm" icon="ellipsis-horizontal" inset="bottom" />
+                <flux:menu class="min-w-44">
+                    <flux:menu.submenu heading="Change color" icon="swatch">
+                        @foreach (SectionTone::PALETTE as $color)
+                            <flux:menu.item wire:click="recolor('{{ $color }}')">
+                                <span class="flex items-center gap-2">
+                                    <span class="size-3 rounded-full {{ SectionTone::classesFor($color)['stripe'] }}"></span>
+                                    <span class="capitalize">{{ $color }}</span>
+                                    @if ($color === $sectionColor)
+                                        <flux:icon name="check" class="ml-auto size-3 text-emerald-600" />
+                                    @endif
+                                </span>
+                            </flux:menu.item>
+                        @endforeach
+                    </flux:menu.submenu>
+                    <flux:menu.item wire:click="delete" icon="trash" variant="danger">Delete</flux:menu.item>
+                </flux:menu>
+            </flux:dropdown>
         </div>
-    </div>
-
-    <div class="flex items-start gap-1 pt-0.5">
-        <div x-sort-handle class="hidden cursor-grab items-center text-zinc-300 group-hover:flex dark:text-zinc-600" title="Drag to reorder">
-            <flux:icon name="bars-2" class="size-4" />
-        </div>
-
-        <div class="relative" x-data>
-            <button type="button" wire:click="$set('addOpen', true)"
-                    class="flex size-7 items-center justify-center rounded-md text-zinc-500 hover:bg-zinc-100 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-100"
-                    title="Add element to this section">
-                <flux:icon name="plus" class="size-3.5" />
-            </button>
-
-            @if ($addOpen)
-                <div wire:click="$set('addOpen', false)" class="fixed inset-0 z-40 bg-black/5"></div>
-                <div class="absolute right-0 top-[calc(100%+4px)] z-50 w-44 overflow-hidden rounded-lg border border-zinc-200 bg-white p-1 shadow-lg dark:border-zinc-700 dark:bg-zinc-900"
-                     x-data @keydown.escape.window="$wire.set('addOpen', false)">
-                    @foreach (LiturgyElementType::cases() as $case)
-                        @continue($case === LiturgyElementType::SECTION)
-                        <button type="button" wire:click="addElement('{{ $case->value }}')"
-                                class="flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-[13px] text-zinc-700 hover:bg-zinc-100 dark:text-zinc-200 dark:hover:bg-zinc-800">
-                            <flux:icon name="{{ $case->icon() }}" class="size-3.5 text-zinc-500" />
-                            {{ $case->label() }}
-                        </button>
-                    @endforeach
-                </div>
-            @endif
-        </div>
-
-        <flux:dropdown align="end" offset="-15">
-            <flux:button variant="ghost" size="sm" icon="ellipsis-horizontal" inset="bottom" />
-            <flux:menu class="min-w-44">
-                <flux:menu.submenu heading="Change color" icon="swatch">
-                    @foreach (SectionTone::PALETTE as $color)
-                        <flux:menu.item wire:click="recolor('{{ $color }}')">
-                            <span class="flex items-center gap-2">
-                                <span class="size-3 rounded-full {{ SectionTone::classesFor($color)['stripe'] }}"></span>
-                                <span class="capitalize">{{ $color }}</span>
-                                @if ($color === $sectionColor)
-                                    <flux:icon name="check" class="ml-auto size-3 text-emerald-600" />
-                                @endif
-                            </span>
-                        </flux:menu.item>
-                    @endforeach
-                </flux:menu.submenu>
-                <flux:menu.item wire:click="delete" icon="trash" variant="danger">Delete</flux:menu.item>
-            </flux:menu>
-        </flux:dropdown>
     </div>
 
     <flux:modal name="delete-element" class="min-w-[22rem]">

--- a/resources/views/livewire/elements/sermon.blade.php
+++ b/resources/views/livewire/elements/sermon.blade.php
@@ -92,62 +92,51 @@ new class extends Component {
 
 @php
     $tone = SectionTone::classesFor($sectionColor);
-    $showStripe = $sectionColor !== null;
 @endphp
 
-<div :x-sort:item="$element->id" wire:key="sermon-{{ $element->id }}"
-     class="group relative grid items-center gap-3 border-b border-zinc-100 px-2 py-2 transition-colors hover:bg-zinc-50 dark:border-zinc-800 dark:hover:bg-zinc-900
-            {{ $showStripe ? 'grid-cols-[4px_18px_36px_minmax(140px,1fr)_minmax(140px,200px)_minmax(160px,240px)_32px]' : 'grid-cols-[18px_36px_minmax(140px,1fr)_minmax(140px,200px)_minmax(160px,240px)_32px]' }}">
+<div>
+    <x-service.element-row
+        :element="$element"
+        :tone="$tone"
+        :section-color="$sectionColor"
+        :is-first-in-section="$isFirstInSection"
+        :is-last-in-section="$isLastInSection"
+        :name="$name"
+        placeholder="Sermon"
+        type-label="Sermon"
+        icon="lectern"
+        wire-key-prefix="sermon"
+    >
+        <x-slot:assignee>
+            @include('livewire.elements._partials.assignee-chip', [
+                'element' => $element,
+                'users' => $users,
+                'recentIds' => $recentAssigneeIds,
+                'open' => $assigneeOpen,
+                'search' => $assigneeSearch,
+            ])
+        </x-slot:assignee>
 
-    @if ($showStripe)
-        <div class="-my-2 self-stretch rounded-sm opacity-60 {{ $tone['stripe'] }}"></div>
-    @endif
+        <x-slot:content>
+            <div class="flex w-full items-center gap-2 rounded-full border border-zinc-200 px-3 py-1 dark:border-zinc-700">
+                <flux:icon name="lectern" class="size-3 shrink-0 text-zinc-500" />
+                <input type="text"
+                       wire:model.live.blur="description"
+                       placeholder="Add sermon title…"
+                       class="h-6 w-full border-0 bg-transparent text-[12.5px] text-zinc-900 placeholder-zinc-400 focus:outline-none focus:ring-0 dark:text-zinc-100 dark:placeholder-zinc-500" />
+            </div>
+        </x-slot:content>
 
-    <div x-sort-handle class="flex h-6 cursor-grab items-center justify-center text-zinc-300 opacity-0 transition-opacity group-hover:opacity-100 dark:text-zinc-600" title="Drag to reorder">
-        <flux:icon name="bars-2" class="size-3.5" />
-    </div>
-
-    <div class="flex size-9 items-center justify-center rounded-lg {{ $tone['swatch'] }}">
-        <flux:icon name="lectern" class="size-4" />
-    </div>
-
-    <div class="min-w-0">
-        <div class="text-[13.5px] font-semibold text-zinc-900 dark:text-zinc-100">
-            <x-service.inline-text
-                wire-model="name"
-                :value="$name"
-                placeholder="Sermon"
-                class="text-[13.5px] font-semibold"
-            />
-        </div>
-        <div class="text-[10.5px] font-medium uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
-            Sermon
-        </div>
-    </div>
-
-    @include('livewire.elements._partials.assignee-chip', [
-        'element' => $element,
-        'users' => $users,
-        'recentIds' => $recentAssigneeIds,
-        'open' => $assigneeOpen,
-        'search' => $assigneeSearch,
-    ])
-
-    <div class="flex w-full items-center gap-2 rounded-full border border-zinc-200 px-3 py-1 dark:border-zinc-700">
-        <flux:icon name="lectern" class="size-3 shrink-0 text-zinc-500" />
-        <input type="text"
-               wire:model.live.blur="description"
-               placeholder="Add sermon title…"
-               class="h-6 w-full border-0 bg-transparent text-[12.5px] text-zinc-900 placeholder-zinc-400 focus:outline-none focus:ring-0 dark:text-zinc-100 dark:placeholder-zinc-500" />
-    </div>
-
-    <flux:dropdown align="end" offset="-15">
-        <flux:button variant="ghost" size="sm" icon="ellipsis-horizontal" inset="bottom" />
-        <flux:menu class="min-w-36">
-            <flux:menu.item wire:click="duplicate" icon="document-duplicate">Duplicate</flux:menu.item>
-            <flux:menu.item wire:click="delete" icon="trash" variant="danger">Delete</flux:menu.item>
-        </flux:menu>
-    </flux:dropdown>
+        <x-slot:actions>
+            <flux:dropdown align="end" offset="-15">
+                <flux:button variant="ghost" size="sm" icon="ellipsis-horizontal" inset="bottom" />
+                <flux:menu class="min-w-36">
+                    <flux:menu.item wire:click="duplicate" icon="document-duplicate">Duplicate</flux:menu.item>
+                    <flux:menu.item wire:click="delete" icon="trash" variant="danger">Delete</flux:menu.item>
+                </flux:menu>
+            </flux:dropdown>
+        </x-slot:actions>
+    </x-service.element-row>
 
     <flux:modal name="delete-element" class="min-w-[22rem]">
         <form wire:submit="$parent.delete({{ $element->id }})" class="space-y-6">

--- a/resources/views/livewire/elements/song.blade.php
+++ b/resources/views/livewire/elements/song.blade.php
@@ -39,10 +39,20 @@ new class extends Component {
 
     public string $contentSearch = '';
 
+    public ?int $hoverContentId = null;
+
     public function mount(?Collection $users = null): void
     {
         $this->users = $users ?? collect();
         $this->name = $this->element->name;
+    }
+
+    public function openContent(): void
+    {
+        $this->contentOpen = true;
+        $this->contentSearch = '';
+        $this->hoverContentId = $this->element->content_id
+            ?? $this->songs->first()?->id;
     }
 
     public function updatedName(string $value): void
@@ -102,77 +112,82 @@ new class extends Component {
     #[Computed]
     public function songs(): Collection
     {
-        if ($this->contentSearch === '') {
-            return collect();
+        $query = Song::query()->withLastUsedDate();
+
+        if ($this->contentSearch !== '') {
+            $query->where('name', 'like', '%'.$this->contentSearch.'%');
         }
 
-        return Song::query()
-            ->where('name', 'like', '%'.$this->contentSearch.'%')
+        return $query
+            ->orderByDesc('last_used_date')
             ->orderBy('name')
             ->limit(50)
             ->get();
+    }
+
+    #[Computed]
+    public function previewSong(): ?Song
+    {
+        if ($this->hoverContentId === null) {
+            return null;
+        }
+
+        return Song::query()
+            ->withLastUsedDate()
+            ->find($this->hoverContentId);
     }
 };
 ?>
 
 @php
     $tone = SectionTone::classesFor($sectionColor);
-    $showStripe = $sectionColor !== null;
 @endphp
 
-<div :x-sort:item="$element->id" wire:key="song-{{ $element->id }}"
-     class="group relative grid items-center gap-3 border-b border-zinc-100 px-2 py-2 transition-colors hover:bg-zinc-50 dark:border-zinc-800 dark:hover:bg-zinc-900
-            {{ $showStripe ? 'grid-cols-[4px_18px_36px_minmax(140px,1fr)_minmax(140px,200px)_minmax(160px,240px)_32px]' : 'grid-cols-[18px_36px_minmax(140px,1fr)_minmax(140px,200px)_minmax(160px,240px)_32px]' }}">
+<div>
+    <x-service.element-row
+        :element="$element"
+        :tone="$tone"
+        :section-color="$sectionColor"
+        :is-first-in-section="$isFirstInSection"
+        :is-last-in-section="$isLastInSection"
+        :name="$name"
+        placeholder="Song"
+        type-label="Song"
+        icon="musical-note"
+        wire-key-prefix="song"
+    >
+        <x-slot:assignee>
+            @include('livewire.elements._partials.assignee-chip', [
+                'element' => $element,
+                'users' => $users,
+                'recentIds' => $recentAssigneeIds,
+                'open' => $assigneeOpen,
+                'search' => $assigneeSearch,
+            ])
+        </x-slot:assignee>
 
-    @if ($showStripe)
-        <div class="-my-2 self-stretch rounded-sm opacity-60 {{ $tone['stripe'] }}"></div>
-    @endif
+        <x-slot:content>
+            @include('livewire.elements._partials.content-chip', [
+                'element' => $element,
+                'items' => $this->songs,
+                'variant' => 'song',
+                'open' => $contentOpen,
+                'search' => $contentSearch,
+                'hoverId' => $hoverContentId,
+                'previewItem' => $this->previewSong,
+            ])
+        </x-slot:content>
 
-    <div x-sort-handle class="flex h-6 cursor-grab items-center justify-center text-zinc-300 opacity-0 transition-opacity group-hover:opacity-100 dark:text-zinc-600" title="Drag to reorder">
-        <flux:icon name="bars-2" class="size-3.5" />
-    </div>
-
-    <div class="flex size-9 items-center justify-center rounded-lg {{ $tone['swatch'] }}">
-        <flux:icon name="musical-note" class="size-4" />
-    </div>
-
-    <div class="min-w-0">
-        <div class="text-[13.5px] font-semibold text-zinc-900 dark:text-zinc-100">
-            <x-service.inline-text
-                wire-model="name"
-                :value="$name"
-                placeholder="Song"
-                class="text-[13.5px] font-semibold"
-            />
-        </div>
-        <div class="text-[10.5px] font-medium uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
-            Song
-        </div>
-    </div>
-
-    @include('livewire.elements._partials.assignee-chip', [
-        'element' => $element,
-        'users' => $users,
-        'recentIds' => $recentAssigneeIds,
-        'open' => $assigneeOpen,
-        'search' => $assigneeSearch,
-    ])
-
-    @include('livewire.elements._partials.content-chip', [
-        'element' => $element,
-        'items' => $this->songs,
-        'variant' => 'song',
-        'open' => $contentOpen,
-        'search' => $contentSearch,
-    ])
-
-    <flux:dropdown align="end" offset="-15">
-        <flux:button variant="ghost" size="sm" icon="ellipsis-horizontal" inset="bottom" />
-        <flux:menu class="min-w-36">
-            <flux:menu.item wire:click="duplicate" icon="document-duplicate">Duplicate</flux:menu.item>
-            <flux:menu.item wire:click="delete" icon="trash" variant="danger">Delete</flux:menu.item>
-        </flux:menu>
-    </flux:dropdown>
+        <x-slot:actions>
+            <flux:dropdown align="end" offset="-15">
+                <flux:button variant="ghost" size="sm" icon="ellipsis-horizontal" inset="bottom" />
+                <flux:menu class="min-w-36">
+                    <flux:menu.item wire:click="duplicate" icon="document-duplicate">Duplicate</flux:menu.item>
+                    <flux:menu.item wire:click="delete" icon="trash" variant="danger">Delete</flux:menu.item>
+                </flux:menu>
+            </flux:dropdown>
+        </x-slot:actions>
+    </x-service.element-row>
 
     <flux:modal name="delete-element" class="min-w-[22rem]">
         <form wire:submit="$parent.delete({{ $element->id }})" class="space-y-6">

--- a/resources/views/pages/services/show.blade.php
+++ b/resources/views/pages/services/show.blade.php
@@ -57,13 +57,28 @@ new class extends Component {
 };
 ?>
 
-<section class="w-full">
+@php
+    $titleLc = mb_strtolower((string) $form->title);
+    $timeOfDay = match (true) {
+        str_contains($titleLc, 'morning') => 'MORNING',
+        str_contains($titleLc, 'afternoon') => 'AFTERNOON',
+        str_contains($titleLc, 'evening') => 'EVENING',
+        str_contains($titleLc, 'night') => 'NIGHT',
+        default => null,
+    };
+    $dayLabel = mb_strtoupper($form->date->format('l'));
+    $eyebrow = $timeOfDay
+        ? $dayLabel.' '.$timeOfDay.' · '.mb_strtoupper($form->date->format('F j, Y'))
+        : $dayLabel.' · '.mb_strtoupper($form->date->format('F j, Y'));
+@endphp
+
+<section class="w-full" data-service-show>
     <header class="flex flex-col gap-4 sm:flex-row sm:items-start">
         <x-service.date-block :date="$form->date" />
 
         <div class="min-w-0 flex-1">
             <div class="text-[11.5px] font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
-                {{ $form->date->format('l') }} · {{ $form->date->format('F j, Y') }}
+                {{ $eyebrow }}
             </div>
 
             <h1 class="mt-1 text-3xl font-bold tracking-tight text-zinc-900 dark:text-zinc-100">

--- a/tests/Feature/ElementSearchTest.php
+++ b/tests/Feature/ElementSearchTest.php
@@ -51,7 +51,7 @@ it('limits song results to 50', function (): void {
     expect($songs)->toHaveCount(50);
 });
 
-it('does not preload songs when no search term is entered', function (): void {
+it('preloads recent songs when no search term is entered', function (): void {
     Song::factory()->count(10)->create();
 
     $service = Service::factory()->create();
@@ -63,7 +63,7 @@ it('does not preload songs when no search term is entered', function (): void {
 
     $songs = Livewire::test('elements.song', ['element' => $element])->get('songs');
 
-    expect($songs)->toBeEmpty();
+    expect($songs)->toHaveCount(10);
 });
 
 it('filters readings by search term', function (): void {
@@ -116,7 +116,7 @@ it('combines reading_type filter with search term', function (): void {
     expect($readings->first()->id)->toBe($match->id);
 });
 
-it('does not preload readings when no search term is entered', function (): void {
+it('preloads recent readings when no search term is entered', function (): void {
     Reading::factory()->count(10)->create();
 
     $service = Service::factory()->create();
@@ -128,5 +128,5 @@ it('does not preload readings when no search term is entered', function (): void
 
     $readings = Livewire::test('elements.reading', ['element' => $element])->get('readings');
 
-    expect($readings)->toBeEmpty();
+    expect($readings)->toHaveCount(10);
 });

--- a/tests/Feature/ServiceShowRedesignTest.php
+++ b/tests/Feature/ServiceShowRedesignTest.php
@@ -242,6 +242,73 @@ it('renames a section inline', function (): void {
     expect($section->fresh()->name)->toBe('God the Father');
 });
 
+it('renders an uppercase time-of-day descriptor in the header eyebrow', function (): void {
+    $morning = Service::factory()->create([
+        'title' => 'Morning Service',
+        'date' => '2026-05-17 09:00:00',
+    ]);
+
+    $this->get(route('services.show', $morning))
+        ->assertOk()
+        ->assertSee('SUNDAY MORNING · MAY 17, 2026');
+
+    $evening = Service::factory()->create([
+        'title' => 'Evening Service',
+        'date' => '2026-05-17 18:00:00',
+    ]);
+
+    $this->get(route('services.show', $evening))
+        ->assertOk()
+        ->assertSee('SUNDAY EVENING · MAY 17, 2026');
+});
+
+it('defaults the content preview to the current selection when opened', function (): void {
+    $service = Service::factory()->create();
+    $library = Song::factory()->create(['name' => 'Doxology']);
+    $song = $service->liturgyElements()->create([
+        'type' => LiturgyElementType::SONG,
+        'name' => 'Opening',
+        'content_type' => Song::class,
+        'content_id' => $library->id,
+        'order' => 0,
+    ]);
+
+    Livewire::test('elements.song', ['element' => $song])
+        ->call('openContent')
+        ->assertSet('contentOpen', true)
+        ->assertSet('hoverContentId', $library->id);
+});
+
+it('defaults the content preview to the first song when nothing is selected', function (): void {
+    $service = Service::factory()->create();
+    Song::factory()->count(3)->create();
+    $song = $service->liturgyElements()->create([
+        'type' => LiturgyElementType::SONG,
+        'name' => 'Opening',
+        'order' => 0,
+    ]);
+
+    $component = Livewire::test('elements.song', ['element' => $song])
+        ->call('openContent');
+
+    expect($component->get('hoverContentId'))->not->toBeNull();
+});
+
+it('resolves a preview song from hoverContentId', function (): void {
+    $service = Service::factory()->create();
+    $library = Song::factory()->create(['name' => 'His Mercy Is More']);
+    $song = $service->liturgyElements()->create([
+        'type' => LiturgyElementType::SONG,
+        'name' => 'Opening',
+        'order' => 0,
+    ]);
+
+    $component = Livewire::test('elements.song', ['element' => $song])
+        ->set('hoverContentId', $library->id);
+
+    expect($component->get('previewSong')->id)->toBe($library->id);
+});
+
 it('renders the full service page with every element row type', function (): void {
     $service = Service::factory()->create(['title' => 'All-Type Service']);
     $service->liturgyElements()->createMany([

--- a/tests/Feature/SquircleAvatarTest.php
+++ b/tests/Feature/SquircleAvatarTest.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Support\Facades\Blade;
+
+it('renders deterministic palette hue for given initials', function (): void {
+    $first = Blade::render('<x-service.squircle-avatar name="Joshua Pangborn" :size="24" />');
+    $second = Blade::render('<x-service.squircle-avatar name="Joshua Pangborn" :size="24" />');
+
+    expect($first)->toBe($second);
+});
+
+it('uses one of the safelisted Flexoki hues', function (): void {
+    $rendered = Blade::render('<x-service.squircle-avatar name="Derek Brown" :size="24" />');
+
+    $hues = ['red', 'orange', 'yellow', 'green', 'cyan', 'blue', 'purple', 'pink'];
+    $matched = collect($hues)->first(fn ($hue) => str_contains($rendered, "bg-{$hue}-100"));
+
+    expect($matched)->not->toBeNull();
+});
+
+it('renders the first two initials of the name', function (): void {
+    $rendered = Blade::render('<x-service.squircle-avatar name="Joseph Louthan" :size="24" />');
+
+    expect($rendered)->toContain('JL');
+});
+
+it('renders a question mark when the name is empty', function (): void {
+    $rendered = Blade::render('<x-service.squircle-avatar name="" :size="24" />');
+
+    expect($rendered)->toContain('?');
+});
+
+it('renders an image when a src is provided', function (): void {
+    $rendered = Blade::render('<x-service.squircle-avatar name="Test" :size="24" src="https://example.com/avatar.png" />');
+
+    expect($rendered)
+        ->toContain('https://example.com/avatar.png')
+        ->toContain('<img');
+});


### PR DESCRIPTION
## Summary
- Section headers become tonal **cards** with an absolute 4px tone bar and a large 22px tonal index numeral.
- Element rows share a new `<x-service.element-row>` shell with the section stripe absolutely positioned (stable grid sizing), and the add-element slot is now a fixed-height overlay so adjacent rows no longer shift on hover.
- **ContentPopover** is rewritten as a 600px two-pane preview with `wire:mouseenter` hover updates, lyrics/scripture body, and last-used metadata; **AssigneePopover** swaps round Flux avatars for a new `<x-service.squircle-avatar>` over the eight Flexoki hues; inline-edit chrome moves to a 1px emerald-400 box border.
- Service header eyebrow goes uppercase with a title-derived time-of-day descriptor; tab strip + date-block month adopt emerald scoped to `[data-service-show]` only — the global accent stays Flexoki purple.
- 474 Pest tests pass (11 new/updated for hover preview, eyebrow format, squircle palette determinism, preload behavior); `pint`, `vite build` clean.

## Test plan
- [ ] Visit `/services/{id}` — verify section card visual (tonal fill + 4px bar + 22px index), tab underline shows emerald only on this page (other pages still purple).
- [ ] Hover between two element rows — confirm no Y-shift on the row above the cursor, dashed "Add element" pill appears centered.
- [ ] Open ContentPopover on a song — confirm preview pane renders lyrics immediately for currently-selected item, updates as you hover other rows.
- [ ] Open AssigneePopover — squircle avatars show two-letter initials, "In this service" group renders before "People".
- [ ] Click section title / element name / sermon title — confirm 1px emerald box border in editing state, Enter commits, Escape cancels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)