### PR TITLE
Polish service show page: header, popover, tabs, inline-edit

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -241,18 +241,3 @@ a.mention:hover {
     @apply p-0;
 }
 
-/* ----------------------------------------------------------
-   Service detail page — scoped accent override.
-   The app-wide accent is Flexoki purple, but the service
-   show page uses emerald for active tab + save status to
-   match the Stave service-planning design system.
-   ---------------------------------------------------------- */
-[data-service-show] [data-flux-tab][data-selected] {
-    color: var(--color-emerald-700);
-    border-color: var(--color-emerald-600);
-}
-
-.dark [data-service-show] [data-flux-tab][data-selected] {
-    color: var(--color-emerald-300);
-    border-color: var(--color-emerald-400);
-}

--- a/resources/views/components/service/date-block.blade.php
+++ b/resources/views/components/service/date-block.blade.php
@@ -2,7 +2,7 @@
     'date',
 ])
 
-<div class="flex w-16 shrink-0 flex-col items-center rounded-lg border border-zinc-200 bg-white py-1.5 dark:border-zinc-700 dark:bg-zinc-900">
+<div class="flex w-16 shrink-0 flex-col items-center justify-center rounded-lg border border-zinc-200 bg-white px-2 py-2 dark:border-zinc-700 dark:bg-zinc-900">
     <div class="text-[10px] font-bold uppercase tracking-[0.14em] text-emerald-700 dark:text-emerald-300">
         {{ $date->format('M') }}
     </div>

--- a/resources/views/components/service/inline-text.blade.php
+++ b/resources/views/components/service/inline-text.blade.php
@@ -40,6 +40,6 @@
         @blur="editing = false"
         @keydown.enter.prevent="$refs.inlineInput.blur()"
         @keydown.escape.prevent="$refs.inlineInput.blur()"
-        class="{{ $base }} {{ $padClasses }} block w-full max-w-full rounded-md border border-emerald-400 bg-white outline-none dark:border-emerald-500 dark:bg-zinc-900"
+        class="{{ $base }} {{ $padClasses }} block w-full max-w-full rounded-md border border-accent bg-white outline-none focus:ring-2 focus:ring-accent/30 dark:bg-zinc-900"
     />
 </div>

--- a/resources/views/components/service/stats-strip.blade.php
+++ b/resources/views/components/service/stats-strip.blade.php
@@ -17,9 +17,4 @@
     <x-service.stat label="Unassigned" :value="$unassigned" :warn="$unassigned > 0" />
     <div class="hidden h-6 w-px bg-zinc-200 sm:block dark:bg-zinc-700"></div>
     <x-service.stat label="Missing content" :value="$missing" :warn="$missing > 0" />
-    <div class="grow"></div>
-    <div class="hidden items-center gap-2 text-[11.5px] text-zinc-500 sm:flex dark:text-zinc-400">
-        <kbd class="rounded border border-zinc-200 bg-white px-1.5 py-0.5 font-mono text-[10px] dark:border-zinc-700 dark:bg-zinc-900">⌘K</kbd>
-        to search &amp; add
-    </div>
 </div>

--- a/resources/views/livewire/elements/_partials/content-chip.blade.php
+++ b/resources/views/livewire/elements/_partials/content-chip.blade.php
@@ -15,16 +15,9 @@
     $emptyHint = $variant === 'song' ? 'No songs match.' : 'No readings match.';
 
     $previewTitle = $previewItem?->{$titleField};
-    $previewLines = [];
-    if ($previewItem) {
-        $body = $variant === 'song'
-            ? ($previewItem->lyrics ?? '')
-            : ($previewItem->text ?? '');
-        $previewLines = collect(preg_split('/\r?\n/', $body))
-            ->slice(0, 20)
-            ->values()
-            ->all();
-    }
+    $previewBody = $previewItem
+        ? ($variant === 'song' ? ($previewItem->lyrics ?? '') : ($previewItem->text ?? ''))
+        : '';
 @endphp
 
 <div class="relative w-full" x-data
@@ -44,7 +37,7 @@
 
     @if ($open)
         <div wire:click="$set('contentOpen', false)" class="fixed inset-0 z-40 bg-black/5"></div>
-        <div class="absolute left-0 top-[calc(100%+4px)] z-50 w-[600px] max-w-[calc(100vw-2rem)] overflow-hidden rounded-xl border border-zinc-200 bg-white shadow-lg dark:border-zinc-700 dark:bg-zinc-900">
+        <div class="absolute right-0 top-[calc(100%+4px)] z-50 w-[600px] max-w-[calc(100vw-2rem)] overflow-hidden rounded-xl border border-zinc-200 bg-white shadow-lg dark:border-zinc-700 dark:bg-zinc-900">
             <div class="border-b border-zinc-200 px-3 py-2 dark:border-zinc-700">
                 <input type="text"
                        x-init="$el.focus()"
@@ -115,16 +108,13 @@
                                 <span class="ml-auto">Last used {{ $previewItem->last_used_date->format('M j, Y') }}</span>
                             @endif
                         </div>
-                        <div class="mt-2.5 space-y-1 text-[12px] leading-relaxed {{ $variant === 'reading' ? 'italic' : '' }} text-zinc-700 dark:text-zinc-300">
-                            @foreach ($previewLines as $line)
-                                @if (trim($line) === '')
-                                    <div class="h-2"></div>
-                                @else
-                                    <div>{{ $line }}</div>
-                                @endif
-                            @endforeach
-                            @if (empty($previewLines))
+                        <div class="mt-2.5 text-[12px] leading-relaxed text-zinc-700 dark:text-zinc-300
+                                    {{ $variant === 'reading' ? 'italic' : '' }}
+                                    [&_p]:mb-2 [&_p:last-child]:mb-0 [&_strong]:font-semibold [&_em]:italic [&_h1]:mt-2 [&_h1]:mb-1 [&_h1]:text-[13px] [&_h1]:font-semibold [&_h2]:mt-2 [&_h2]:mb-1 [&_h2]:text-[12.5px] [&_h2]:font-semibold">
+                            @if (trim(strip_tags($previewBody)) === '')
                                 <div class="italic text-zinc-400">No preview available.</div>
+                            @else
+                                {!! $previewBody !!}
                             @endif
                         </div>
                     @else

--- a/resources/views/pages/services/show.blade.php
+++ b/resources/views/pages/services/show.blade.php
@@ -73,7 +73,7 @@ new class extends Component {
 @endphp
 
 <section class="w-full" data-service-show>
-    <header class="flex flex-col gap-4 sm:flex-row sm:items-start">
+    <header class="flex flex-col gap-4 sm:flex-row sm:items-stretch">
         <x-service.date-block :date="$form->date" />
 
         <div class="min-w-0 flex-1">
@@ -90,7 +90,7 @@ new class extends Component {
                 />
             </h1>
 
-            <div class="mt-2 flex flex-wrap items-center gap-2.5 text-[12.5px] text-zinc-500 dark:text-zinc-400">
+            <div class="mt-1 flex flex-wrap items-center gap-2.5 text-[12.5px] text-zinc-500 dark:text-zinc-400">
                 @if ($form->service?->template)
                     <span>Template:</span>
                     <a href="{{ route('templates.show', ['template' => $form->service->template]) }}"


### PR DESCRIPTION
## Summary
- Removes the unimplemented ⌘K hint, fixes the content-picker popover overflowing the right edge of the viewport, and renders song/reading previews as HTML instead of escaped tags
- Stretches the date block to match the header height and tightens the title↔template spacing
- Switches the active tab underline and inline-edit input border from emerald to the Flexoki purple accent

## Test plan
- [ ] Open a service show page and confirm the stats strip no longer shows the ⌘K hint
- [ ] Open a content picker on a song/reading row — popover stays inside the viewport and preview renders bold/italic/paragraphs
- [ ] Verify the date block stretches the header height and the title spacing reads balanced
- [ ] Click into a section/element/service title — inline edit border is purple, active tab is purple

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined accent color consistency across service detail pages
  * Updated input field styling with rounded corners and improved focus states
  * Adjusted spacing and layout alignment on service pages
  * Removed keyboard hint from service stats section
  * Enhanced content preview formatting for songs and readings with richer HTML display

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jpangborn/stave/pull/115?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->