### PR TITLE
Use solid badges on group card cover

### DIFF
--- a/resources/views/components/groups/card.blade.php
+++ b/resources/views/components/groups/card.blade.php
@@ -31,8 +31,8 @@
                     {{ $group->name }}
                 </h3>
                 <div class="flex flex-wrap gap-1.5">
-                    <flux:badge size="sm" :color="$group->visibility->color()">{{ $group->visibility->label() }}</flux:badge>
-                    <flux:badge size="sm" :color="$group->messaging->color()">{{ $group->messaging->label() }}</flux:badge>
+                    <flux:badge size="sm" variant="solid" :color="$group->visibility->color()">{{ $group->visibility->label() }}</flux:badge>
+                    <flux:badge size="sm" variant="solid" :color="$group->messaging->color()">{{ $group->messaging->label() }}</flux:badge>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- The visibility and messaging badges on the My Groups card sit on top of the cover image's dark gradient, where Flux's default translucent badge variant let the cover bleed through and washed out the colors.
- Switched both badges to \`variant=\"solid\"\` so they render with opaque backgrounds and read clearly against the cover in light and dark mode.

## Test plan
- [ ] Visit \`/groups\` and confirm the visibility and messaging badges on each card show solid, opaque colors over the cover image.
- [ ] Verify in both light and dark mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)