### PR TITLE
Redesign service discussion with full messaging UI

### DIFF
--- a/app/Actions/Comments/ResolveGroupMentionsAutocompleteAction.php
+++ b/app/Actions/Comments/ResolveGroupMentionsAutocompleteAction.php
@@ -4,6 +4,7 @@ namespace App\Actions\Comments;
 
 use App\Models\Conversation;
 use App\Models\GroupUser;
+use App\Models\Service;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Support\Facades\Auth;
@@ -18,21 +19,33 @@ class ResolveGroupMentionsAutocompleteAction extends ResolveMentionsAutocomplete
      */
     public function execute(string $query, $commentable): array
     {
-        if (! $commentable instanceof Conversation) {
-            return parent::execute($query, $commentable);
+        if ($commentable instanceof Conversation) {
+            return $this->resolveForConversation($query, $commentable);
         }
 
+        if ($commentable instanceof Service) {
+            return $this->resolveForService($query, $commentable);
+        }
+
+        return parent::execute($query, $commentable);
+    }
+
+    /**
+     * @return array<int, CanComment>
+     */
+    private function resolveForConversation(string $query, Conversation $conversation): array
+    {
         $nameField = Config::commentatorModelNameField();
         $currentUserId = Auth::id();
 
-        $inThreadIds = $commentable->comments()
+        $inThreadIds = $conversation->comments()
             ->where('commentator_type', (new User())->getMorphClass())
             ->whereNot('commentator_id', $currentUserId)
             ->distinct()
             ->pluck('commentator_id');
 
         /** @var \Closure(): BelongsToMany<User, Conversation, GroupUser> $base */
-        $base = fn (): BelongsToMany => $commentable->group->members()
+        $base = fn (): BelongsToMany => $conversation->group->members()
             ->where("users.{$nameField}", 'like', "%{$query}%")
             ->whereNot('users.id', $currentUserId)
             ->orderBy("users.{$nameField}");
@@ -49,5 +62,26 @@ class ResolveGroupMentionsAutocompleteAction extends ResolveMentionsAutocomplete
 
         /** @var array<int, CanComment> */
         return $inThreadMatches->merge($otherMatches)->values()->all();
+    }
+
+    /**
+     * Service mentions are scoped to liturgy-element assignees.
+     * Future: expand to all users with service-planning access.
+     *
+     * @return array<int, CanComment>
+     */
+    private function resolveForService(string $query, Service $service): array
+    {
+        $currentUserId = Auth::id();
+        $needle = mb_strtolower($query);
+
+        /** @var array<int, CanComment> */
+        return $service->assignedUsers()
+            ->filter(fn (User $user): bool => $user->id !== $currentUserId)
+            ->filter(fn (User $user): bool => $needle === '' || str_contains(mb_strtolower((string) $user->name), $needle))
+            ->sortBy('name')
+            ->take(10)
+            ->values()
+            ->all();
     }
 }

--- a/app/Policies/CommentPolicy.php
+++ b/app/Policies/CommentPolicy.php
@@ -4,6 +4,7 @@ namespace App\Policies;
 
 use App\Models\Comment;
 use App\Models\Conversation;
+use App\Models\Service;
 use App\Models\User;
 
 class CommentPolicy
@@ -27,14 +28,18 @@ class CommentPolicy
 
     public function update(User $user, Comment $comment): bool
     {
-        $conversation = $this->conversationFor($comment);
+        $commentable = $comment->commentable;
 
-        if (! $conversation instanceof Conversation) {
-            return false;
+        if ($commentable instanceof Conversation) {
+            return $this->isAuthor($user, $comment)
+                || $commentable->group->hasLeader($user);
         }
 
-        return $this->isAuthor($user, $comment)
-            || $conversation->group->hasLeader($user);
+        if ($commentable instanceof Service) {
+            return $this->isAuthor($user, $comment);
+        }
+
+        return false;
     }
 
     public function markPrayer(User $user, Comment $comment): bool
@@ -50,14 +55,18 @@ class CommentPolicy
 
     public function delete(User $user, Comment $comment): bool
     {
-        $conversation = $this->conversationFor($comment);
+        $commentable = $comment->commentable;
 
-        if (! $conversation instanceof Conversation) {
-            return false;
+        if ($commentable instanceof Conversation) {
+            return $this->isAuthor($user, $comment)
+                || $commentable->group->hasLeader($user);
         }
 
-        return $this->isAuthor($user, $comment)
-            || $conversation->group->hasLeader($user);
+        if ($commentable instanceof Service) {
+            return $this->isAuthor($user, $comment);
+        }
+
+        return false;
     }
 
     private function conversationFor(Comment $comment): ?Conversation

--- a/resources/views/components/conversation-composer.blade.php
+++ b/resources/views/components/conversation-composer.blade.php
@@ -1,11 +1,13 @@
 @props([
     'editorModel',
-    'prayerModel',
+    'prayerModel' => null,
     'prayerActive' => false,
-    'newImageModel',
-    'newAttachmentModel',
-    'pendingImages',
-    'pendingAttachments',
+    'allowPrayer' => true,
+    'allowMentions' => true,
+    'newImageModel' => null,
+    'newAttachmentModel' => null,
+    'pendingImages' => null,
+    'pendingAttachments' => null,
     'removeImageAction' => 'removePendingImage',
     'removeAttachmentAction' => 'removePendingAttachment',
     'submitAction',
@@ -17,12 +19,25 @@
     'testPrefix' => 'composer',
 ])
 
+@php
+    $hasImageUploads = $newImageModel !== null;
+    $hasAttachmentUploads = $newAttachmentModel !== null;
+    $hasPendingImages = $pendingImages !== null && $pendingImages->isNotEmpty();
+    $hasPendingAttachments = $pendingAttachments !== null && $pendingAttachments->isNotEmpty();
+    $hasExistingAttachments = $existingAttachments !== null && $existingAttachments->isNotEmpty();
+    $showPrayer = $allowPrayer && $prayerModel !== null;
+@endphp
+
 <form
     wire:submit="{{ $submitAction }}"
     x-on:keydown.enter="if ($event.metaKey || $event.ctrlKey) { $event.preventDefault(); $el.requestSubmit() }"
 >
-    <input type="file" x-ref="imageInput" wire:model="{{ $newImageModel }}" accept="image/jpeg,image/png,image/gif,image/webp" class="hidden" data-test="{{ $testPrefix }}-image-input" />
-    <input type="file" x-ref="attachInput" wire:model="{{ $newAttachmentModel }}" accept=".pdf,.md,.txt,audio/*" class="hidden" data-test="{{ $testPrefix }}-attach-input" />
+    @if ($hasImageUploads)
+        <input type="file" x-ref="imageInput" wire:model="{{ $newImageModel }}" accept="image/jpeg,image/png,image/gif,image/webp" class="hidden" data-test="{{ $testPrefix }}-image-input" />
+    @endif
+    @if ($hasAttachmentUploads)
+        <input type="file" x-ref="attachInput" wire:model="{{ $newAttachmentModel }}" accept=".pdf,.md,.txt,audio/*" class="hidden" data-test="{{ $testPrefix }}-attach-input" />
+    @endif
 
     <flux:composer wire:model="{{ $editorModel }}" label="{{ $editing ? 'Edit message' : 'Reply' }}" label:sr-only placeholder="Write a reply…  (use @ to mention a member)">
         <x-slot name="input">
@@ -32,9 +47,9 @@
                 class="**:data-[slot=content]:min-h-[100px]!"
             />
 
-            @if ($pendingImages->isNotEmpty() || $pendingAttachments->isNotEmpty() || ($existingAttachments && $existingAttachments->isNotEmpty()))
+            @if ($hasPendingImages || $hasPendingAttachments || $hasExistingAttachments)
                 <div class="mt-2 space-y-2" data-test="{{ $testPrefix }}-pending">
-                    @if ($pendingImages->isNotEmpty())
+                    @if ($hasPendingImages)
                         <div class="flex flex-wrap gap-2">
                             @foreach ($pendingImages as $image)
                                 <div
@@ -57,9 +72,9 @@
                         </div>
                     @endif
 
-                    @if ($pendingAttachments->isNotEmpty() || ($existingAttachments && $existingAttachments->isNotEmpty()))
+                    @if ($hasPendingAttachments || $hasExistingAttachments)
                         <div class="flex flex-wrap gap-1.5">
-                            @if ($existingAttachments)
+                            @if ($hasExistingAttachments)
                                 @foreach ($existingAttachments as $attachment)
                                     <span
                                         class="inline-flex items-center gap-1.5 rounded-full border border-zinc-200 bg-zinc-50 py-1 pl-2.5 pr-1 text-xs dark:border-zinc-700 dark:bg-zinc-800"
@@ -81,90 +96,104 @@
                                 @endforeach
                             @endif
 
-                            @foreach ($pendingAttachments as $attachment)
-                                <span
-                                    class="inline-flex items-center gap-1.5 rounded-full border border-zinc-200 bg-zinc-50 py-1 pl-2.5 pr-1 text-xs dark:border-zinc-700 dark:bg-zinc-800"
-                                    wire:key="{{ $testPrefix }}-pending-attachment-{{ $attachment->id }}"
-                                    data-test="pending-attachment"
-                                >
-                                    <flux:icon.paper-clip variant="micro" class="text-zinc-500" />
-                                    <span class="max-w-[16ch] truncate font-medium text-zinc-700 dark:text-zinc-200">{{ $attachment->original_name }}</span>
-                                    <button
-                                        type="button"
-                                        wire:click="{{ $removeAttachmentAction }}({{ $attachment->id }})"
-                                        class="grid size-4 place-items-center rounded-full text-zinc-400 hover:bg-zinc-200 hover:text-zinc-700 dark:hover:bg-zinc-700"
-                                        aria-label="Remove attachment"
-                                        data-test="pending-attachment-remove"
+                            @if ($hasPendingAttachments)
+                                @foreach ($pendingAttachments as $attachment)
+                                    <span
+                                        class="inline-flex items-center gap-1.5 rounded-full border border-zinc-200 bg-zinc-50 py-1 pl-2.5 pr-1 text-xs dark:border-zinc-700 dark:bg-zinc-800"
+                                        wire:key="{{ $testPrefix }}-pending-attachment-{{ $attachment->id }}"
+                                        data-test="pending-attachment"
                                     >
-                                        <flux:icon.x-mark variant="micro" class="size-3" />
-                                    </button>
-                                </span>
-                            @endforeach
+                                        <flux:icon.paper-clip variant="micro" class="text-zinc-500" />
+                                        <span class="max-w-[16ch] truncate font-medium text-zinc-700 dark:text-zinc-200">{{ $attachment->original_name }}</span>
+                                        <button
+                                            type="button"
+                                            wire:click="{{ $removeAttachmentAction }}({{ $attachment->id }})"
+                                            class="grid size-4 place-items-center rounded-full text-zinc-400 hover:bg-zinc-200 hover:text-zinc-700 dark:hover:bg-zinc-700"
+                                            aria-label="Remove attachment"
+                                            data-test="pending-attachment-remove"
+                                        >
+                                            <flux:icon.x-mark variant="micro" class="size-3" />
+                                        </button>
+                                    </span>
+                                @endforeach
+                            @endif
                         </div>
                     @endif
                 </div>
             @endif
 
-            <flux:error name="{{ $newImageModel }}" />
-            <flux:error name="{{ $newAttachmentModel }}" />
+            @if ($hasImageUploads)
+                <flux:error name="{{ $newImageModel }}" />
+            @endif
+            @if ($hasAttachmentUploads)
+                <flux:error name="{{ $newAttachmentModel }}" />
+            @endif
         </x-slot>
 
         <x-slot name="footer">
-            <flux:tooltip content="Attach image">
+            @if ($hasImageUploads)
+                <flux:tooltip content="Attach image">
+                    <button
+                        type="button"
+                        x-on:click="$refs.imageInput.click()"
+                        class="inline-flex h-7 items-center gap-1.5 rounded-md px-2 text-xs font-semibold text-zinc-500 hover:bg-zinc-100 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-white"
+                        aria-label="Attach image"
+                        data-test="{{ $testPrefix }}-image-button"
+                    >
+                        <flux:icon.photo variant="micro" wire:loading.remove wire:target="{{ $newImageModel }}" />
+                        <flux:icon.arrow-path variant="micro" class="animate-spin" wire:loading wire:target="{{ $newImageModel }}" />
+                    </button>
+                </flux:tooltip>
+            @endif
+
+            @if ($hasAttachmentUploads)
+                <flux:tooltip content="Attach file">
+                    <button
+                        type="button"
+                        x-on:click="$refs.attachInput.click()"
+                        class="inline-flex h-7 items-center gap-1.5 rounded-md px-2 text-xs font-semibold text-zinc-500 hover:bg-zinc-100 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-white"
+                        aria-label="Attach file"
+                        data-test="{{ $testPrefix }}-attach-button"
+                    >
+                        <flux:icon.paper-clip variant="micro" wire:loading.remove wire:target="{{ $newAttachmentModel }}" />
+                        <flux:icon.arrow-path variant="micro" class="animate-spin" wire:loading wire:target="{{ $newAttachmentModel }}" />
+                    </button>
+                </flux:tooltip>
+            @endif
+
+            @if ($showPrayer)
                 <button
                     type="button"
-                    x-on:click="$refs.imageInput.click()"
-                    class="inline-flex h-7 items-center gap-1.5 rounded-md px-2 text-xs font-semibold text-zinc-500 hover:bg-zinc-100 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-white"
-                    aria-label="Attach image"
-                    data-test="{{ $testPrefix }}-image-button"
+                    wire:click="$toggle('{{ $prayerModel }}')"
+                    aria-pressed="{{ $prayerActive ? 'true' : 'false' }}"
+                    @class([
+                        'inline-flex h-7 items-center gap-1.5 rounded-full border px-3 text-xs font-semibold transition-colors',
+                        'border-yellow-300 bg-yellow-50 text-yellow-800 dark:border-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-200' => $prayerActive,
+                        'border-zinc-200 bg-white text-zinc-600 hover:bg-zinc-100 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700' => ! $prayerActive,
+                    ])
+                    data-test="{{ $testPrefix }}-prayer-toggle"
+                    @if ($prayerActive) data-test-active="true" @endif
                 >
-                    <flux:icon.photo variant="micro" wire:loading.remove wire:target="{{ $newImageModel }}" />
-                    <flux:icon.arrow-path variant="micro" class="animate-spin" wire:loading wire:target="{{ $newImageModel }}" />
+                    <flux:icon.hand-raised variant="micro" />
+                    <span class="lg:hidden">Prayer</span>
+                    <span class="hidden lg:inline">{{ $prayerActive ? 'Sending as prayer' : 'Mark as prayer' }}</span>
                 </button>
-            </flux:tooltip>
+            @endif
 
-            <flux:tooltip content="Attach file">
-                <button
-                    type="button"
-                    x-on:click="$refs.attachInput.click()"
-                    class="inline-flex h-7 items-center gap-1.5 rounded-md px-2 text-xs font-semibold text-zinc-500 hover:bg-zinc-100 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-white"
-                    aria-label="Attach file"
-                    data-test="{{ $testPrefix }}-attach-button"
-                >
-                    <flux:icon.paper-clip variant="micro" wire:loading.remove wire:target="{{ $newAttachmentModel }}" />
-                    <flux:icon.arrow-path variant="micro" class="animate-spin" wire:loading wire:target="{{ $newAttachmentModel }}" />
-                </button>
-            </flux:tooltip>
-
-            <button
-                type="button"
-                wire:click="$toggle('{{ $prayerModel }}')"
-                aria-pressed="{{ $prayerActive ? 'true' : 'false' }}"
-                @class([
-                    'inline-flex h-7 items-center gap-1.5 rounded-full border px-3 text-xs font-semibold transition-colors',
-                    'border-yellow-300 bg-yellow-50 text-yellow-800 dark:border-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-200' => $prayerActive,
-                    'border-zinc-200 bg-white text-zinc-600 hover:bg-zinc-100 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700' => ! $prayerActive,
-                ])
-                data-test="{{ $testPrefix }}-prayer-toggle"
-                @if ($prayerActive) data-test-active="true" @endif
-            >
-                <flux:icon.hand-raised variant="micro" />
-                <span class="lg:hidden">Prayer</span>
-                <span class="hidden lg:inline">{{ $prayerActive ? 'Sending as prayer' : 'Mark as prayer' }}</span>
-            </button>
-
-            <flux:tooltip content="Mention a member">
-                <button
-                    type="button"
-                    x-on:click="$root.querySelector('ui-editor')?.editor?.chain().focus().insertContent('@').run()"
-                    class="inline-flex h-7 items-center gap-1.5 rounded-md px-2 text-xs font-semibold text-zinc-500 hover:bg-zinc-100 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-white"
-                    data-test="{{ $testPrefix }}-mention"
-                >
-                    <flux:icon.at-symbol variant="micro" />
-                    <span class="lg:hidden">@</span>
-                    <span class="hidden lg:inline">Mention</span>
-                </button>
-            </flux:tooltip>
+            @if ($allowMentions)
+                <flux:tooltip content="Mention a member">
+                    <button
+                        type="button"
+                        x-on:click="$root.querySelector('ui-editor')?.editor?.chain().focus().insertContent('@').run()"
+                        class="inline-flex h-7 items-center gap-1.5 rounded-md px-2 text-xs font-semibold text-zinc-500 hover:bg-zinc-100 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-white"
+                        data-test="{{ $testPrefix }}-mention"
+                    >
+                        <flux:icon.at-symbol variant="micro" />
+                        <span class="lg:hidden">@</span>
+                        <span class="hidden lg:inline">Mention</span>
+                    </button>
+                </flux:tooltip>
+            @endif
 
             <div class="ms-auto flex items-center gap-2">
                 <span class="hidden items-center gap-1 text-xs text-zinc-400 lg:inline-flex" data-test="{{ $testPrefix }}-shortcut-hint">

--- a/resources/views/components/conversation/day-divider.blade.php
+++ b/resources/views/components/conversation/day-divider.blade.php
@@ -1,0 +1,7 @@
+@props(['label'])
+
+<div {{ $attributes->merge(['class' => 'my-2 flex items-center gap-3.5 px-2 py-3']) }} data-test="day-divider">
+    <div class="h-px flex-1 bg-zinc-200 dark:bg-zinc-700"></div>
+    <span class="text-xs font-semibold uppercase tracking-wider text-zinc-500">{{ $label }}</span>
+    <div class="h-px flex-1 bg-zinc-200 dark:bg-zinc-700"></div>
+</div>

--- a/resources/views/livewire/services/discussion.blade.php
+++ b/resources/views/livewire/services/discussion.blade.php
@@ -1,129 +1,648 @@
 <?php
 
+use App\Models\Comment;
 use App\Models\Service;
+use App\Models\User;
+use App\Services\ScriptureLinker;
+use Flux\Flux;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection as BaseCollection;
+use Illuminate\Support\Facades\Auth;
+use Livewire\Attributes\Computed;
 use Livewire\Attributes\Reactive;
 use Livewire\Component;
+use Spatie\Comments\Actions\ResolveMentionsAutocompleteAction;
+use Spatie\Comments\Support\Config;
 
-new class() extends Component
-{
+new class extends Component {
     #[Reactive]
     public int $serviceId;
 
-    public string $comment = '';
+    public string $reply = '';
 
-    public function getServiceProperty()
+    public ?int $sheetCommentId = null;
+
+    public ?int $commentToDeleteId = null;
+
+    public ?int $editingCommentId = null;
+
+    public string $editingText = '';
+
+    #[Computed]
+    public function service(): Service
     {
-        return Service::with('comments')->find($this->serviceId);
+        /** @var Service */
+        return Service::findOrFail($this->serviceId);
     }
 
-    public function saveComment(): void
+    /** @return Collection<int, Comment> */
+    #[Computed]
+    public function comments(): Collection
     {
-        if (empty(trim(strip_tags($this->comment)))) {
+        /** @var Collection<int, Comment> */
+        return $this->service->comments()
+            ->with(['commentator', 'reactions.commentator'])
+            ->orderBy('created_at')
+            ->get();
+    }
+
+    /** @return BaseCollection<int|string, Collection<int, Comment>> */
+    #[Computed]
+    public function groupedComments(): BaseCollection
+    {
+        return $this->comments->groupBy(fn (Comment $comment): string => $comment->created_at->toDateString())->collect();
+    }
+
+    #[Computed]
+    public function editingComment(): ?Comment
+    {
+        if ($this->editingCommentId === null) {
+            return null;
+        }
+
+        return $this->comments->firstWhere('id', $this->editingCommentId);
+    }
+
+    #[Computed]
+    public function sheetComment(): ?Comment
+    {
+        if ($this->sheetCommentId === null) {
+            return null;
+        }
+
+        return $this->comments->firstWhere('id', $this->sheetCommentId);
+    }
+
+    public function dayLabel(string $dateString): string
+    {
+        $date = Carbon::parse($dateString);
+
+        return match (true) {
+            $date->isToday() => 'Today',
+            $date->isYesterday() => 'Yesterday',
+            $date->isCurrentYear() => $date->format('M j'),
+            default => $date->format('M j, Y'),
+        };
+    }
+
+    /** @return array<int, array{id: int, name: string, gravatar: string}> */
+    public function mentionCandidates(string $query): array
+    {
+        /** @var ResolveMentionsAutocompleteAction $action */
+        $action = app(config('comments.actions.resolve_mentions_autocomplete'));
+
+        /** @var array<int, User> $candidates */
+        $candidates = $action->execute($query, $this->service);
+
+        return array_map(fn (User $user): array => [
+            'id' => $user->id,
+            'name' => $user->name,
+            'gravatar' => $user->gravatar,
+        ], $candidates);
+    }
+
+    private function sanitizeMentions(string $html): string
+    {
+        $allowedIds = $this->service->assignedUsers()->pluck('id');
+
+        return (string) preg_replace_callback(
+            '/<(\w+)(\s+[^>]*?)data-mention="([^"]+)"([^>]*?)>(.*?)<\/\1>/s',
+            function (array $match) use ($allowedIds): string {
+                if ($allowedIds->contains((int) $match[3])) {
+                    return $match[0];
+                }
+
+                return "<{$match[1]}{$match[2]}{$match[4]}>{$match[5]}</{$match[1]}>";
+            },
+            $html,
+        );
+    }
+
+    public function postReply(): void
+    {
+        $hasText = trim(strip_tags($this->reply)) !== '';
+
+        if (! $hasText) {
+            $this->addError('reply', 'Write a message.');
+
             return;
         }
 
-        $this->service->comment($this->comment);
-        $this->reset('comment');
-        unset($this->service);
+        $text = $this->sanitizeMentions(trim($this->reply));
+
+        $this->service->comment($text, Auth::user());
+
+        $this->reset('reply');
+        unset($this->comments);
     }
 
     public function react(int $commentId, string $reaction): void
     {
-        $comment = $this->service->comments()->find($commentId);
-        $comment->react($reaction);
-        unset($this->service);
+        abort_unless(in_array($reaction, Config::allowedReactions(), true), 422);
+
+        /** @var Comment $comment */
+        $comment = $this->service->comments()->findOrFail($commentId);
+        $user = Auth::user();
+
+        if ($comment->findReaction($reaction, $user)) {
+            $comment->deleteReaction($reaction, $user);
+        } else {
+            $comment->react($reaction, $user);
+        }
+
+        unset($this->comments);
+    }
+
+    public function startEditing(int $commentId): void
+    {
+        /** @var Comment $comment */
+        $comment = $this->service->comments()->findOrFail($commentId);
+
+        $this->authorize('update', $comment);
+
+        $this->editingCommentId = $comment->id;
+        $this->editingText = $comment->original_text;
+
+        $this->sheetCommentId = null;
+        Flux::modal('service-message-actions')->close();
+
+        unset($this->editingComment);
+    }
+
+    public function cancelEditing(): void
+    {
+        $this->reset('editingCommentId', 'editingText');
+        unset($this->editingComment);
+    }
+
+    public function saveEdit(): void
+    {
+        $comment = $this->editingComment;
+
+        if (! $comment instanceof Comment) {
+            return;
+        }
+
+        $this->authorize('update', $comment);
+
+        $newHtml = $this->sanitizeMentions(trim($this->editingText));
+        $plainText = trim(strip_tags($newHtml));
+
+        if ($plainText === '') {
+            $this->addError('editingText', 'Write a message.');
+
+            return;
+        }
+
+        $previousText = $comment->original_text;
+
+        $comment->original_text = $newHtml;
+        $comment->save();
+
+        if ($newHtml !== $previousText) {
+            $comment->markAsEdited();
+        }
+
+        $this->reset('editingCommentId', 'editingText');
+        unset($this->comments, $this->editingComment);
+
+        Flux::toast(variant: 'success', text: 'Message updated.');
+    }
+
+    public function confirmDeleteComment(int $commentId): void
+    {
+        /** @var Comment $comment */
+        $comment = $this->service->comments()->findOrFail($commentId);
+
+        $this->authorize('delete', $comment);
+
+        $this->commentToDeleteId = $commentId;
+
+        Flux::modal('service-message-actions')->close();
+        Flux::modal('service-delete-comment')->show();
+    }
+
+    public function deleteComment(): void
+    {
+        if ($this->commentToDeleteId === null) {
+            return;
+        }
+
+        /** @var Comment $comment */
+        $comment = $this->service->comments()->findOrFail($this->commentToDeleteId);
+
+        $this->authorize('delete', $comment);
+
+        $comment->delete();
+
+        if ($this->sheetCommentId === $comment->id) {
+            $this->sheetCommentId = null;
+        }
+
+        $this->commentToDeleteId = null;
+
+        unset($this->comments);
+
+        Flux::modal('service-delete-comment')->close();
+        Flux::toast(variant: 'success', text: 'Message deleted.');
+    }
+
+    public function openActions(int $commentId): void
+    {
+        $this->sheetCommentId = $commentId;
+
+        Flux::modal('service-message-actions')->show();
+    }
+
+    public function closeActions(): void
+    {
+        $this->sheetCommentId = null;
     }
 };
 ?>
 
-<div class="h-full">
-    <div class="max-w-3xl space-y-2">
-        @if($this->service->comments()->count() == 0)
-        <div class="flex items-center justify-center">
-            <flux:heading>No comments yet. Start the conversation!</flux:heading>
-        </div>
-        @else
-            <div class="flex flex-col overflow-scroll w-full space-y-2
-                **:[h1]:text-xl **:[h1]:font-semibold **:[h2]:text-lg **:[h2]:font-semibold **:[h3]:font-semibold
-                **:[strong]:font-semibold **:[em]:italic **:[u]:underline **:[s]:line-through
-                **:[ol]:list-decimal **:[ol]:ml-5 **:[ul]:list-disc **:[ul]:ml-5
-                **:[a]:underline
-                **:[blockquote]:border-l-4 **:[blockquote]:pl-2
-                **:[p]:not-first:mt-3
-                ">
-            @php
-                $prevUser = null;
-            @endphp
-            @foreach($this->service->comments as $comment)
-                <div wire:key="comment-{{ $comment->id }}" @class([
-                    'text-left max-w-3/4 space-y-2',
-                    'self-start' => !$comment->commentator?->is(auth()->user()),
-                    'self-end'=> $comment->commentator?->is(auth()->user()),
-                ])>
-                    @if($comment->commentator?->isNot($prevUser))
-                    <div class="flex items-center space-x-2">
-                        <flux:avatar size="xs" name="{{ $comment->commentator?->name }}" color="auto" />
-                        <flux:heading>{{ $comment->commentator?->name }}</flux:heading>
-                    </div>
-                    @endif
-                    <div @class([
-                        'rounded-md p-2 space-y-2',
-                        'bg-zinc-100' => !$comment->commentator?->is(auth()->user()),
-                        'bg-accent text-white' => $comment->commentator?->is(auth()->user()),
-                    ])>
-                        {!! $comment->text !!}
-                    </div>
-                    <div class="flex flex-row-reverse items-center space-x-3 -mt-1.5">
-                        <flux:dropdown hover position="{{ $comment->commentator?->is(auth()->user()) ? 'left' : 'right' }}" align="center">
-                            <flux:button size="sm" variant="ghost" icon="face-smile" />
-                            <flux:popover>
-                                <div class="flex">
-                                    <flux:button size="sm" variant="ghost" square wire:click="react({{$comment->id }}, '👍')">👍</flux:button>
-                                    <flux:button size="sm" variant="ghost" square wire:click="react({{$comment->id }}, '✅')">✅</flux:button>
-                                    <flux:button size="sm" variant="ghost" square wire:click="react({{$comment->id }}, '❤️')">❤️</flux:button>
-                                    <flux:button size="sm" variant="ghost" square wire:click="react({{$comment->id }}, '🔥')">🔥</flux:button>
-                                    <flux:button size="sm" variant="ghost" square wire:click="react({{$comment->id }}, '🙏')">🙏</flux:button>
-                                    <flux:button size="sm" variant="ghost" square wire:click="react({{$comment->id }}, '❓')">❓</flux:button>
-                                    <flux:button size="sm" variant="ghost" square wire:click="react({{$comment->id }}, '🤯')">🤯</flux:button>
-                                    <flux:button size="sm" variant="ghost" square wire:click="react({{$comment->id }}, '🎉')">🎉</flux:button>
-                                </div>
-                            </flux:popover>
-                        </flux:dropdown>
-                        @foreach($comment->reactions->summary() as $reaction)
-                            <span wire:key="reaction-{{ $comment->id }}-{{ $loop->index }}" class="bg-zinc-100 rounded-full py-1 px-2">{{ $reaction['reaction'] }} {{ $reaction['count'] }}</span>
-                        @endforeach
-                    </div>
+<section data-test="service-discussion">
+    @php($currentUser = Auth::user())
+    @php($quickReactions = Config::allowedReactions())
+
+    <div
+        class="mx-auto flex w-full max-w-3xl flex-col overflow-hidden rounded-xl border border-zinc-200 bg-white dark:border-zinc-700 dark:bg-zinc-800"
+        style="height: min(calc(100vh - 22rem), 48rem); min-height: 28rem;"
+    >
+        {{-- Messages --}}
+        <div class="min-h-0 flex-1 overflow-auto px-4 py-3 lg:px-6">
+            @if ($this->comments->isEmpty())
+                <div class="flex flex-col items-center justify-center px-6 py-16 text-center" data-test="empty-state">
+                    <flux:icon.chat-bubble-left-right class="size-10 text-zinc-300 dark:text-zinc-600" />
+                    <flux:heading size="lg" class="mt-4">No messages yet</flux:heading>
+                    <flux:subheading class="mt-1">Kick things off — your reply will start the thread.</flux:subheading>
                 </div>
-                @php
-                    $prevUser = $comment->commentator;
-                @endphp
+            @endif
+
+            @foreach ($this->groupedComments as $dateString => $dayComments)
+                <x-conversation.day-divider :label="$this->dayLabel($dateString)" />
+
+                @foreach ($dayComments as $comment)
+                    @php($isMine = $comment->commentator?->is($currentUser))
+
+                    <div
+                        wire:key="comment-{{ $comment->id }}"
+                        @class([
+                            'group/row relative mt-1 flex gap-2.5 rounded-md border-l-2 px-2.5 py-3 transition-colors lg:gap-3 lg:px-3',
+                            'border-transparent hover:bg-zinc-50 dark:hover:bg-zinc-900/60' => ! $isMine,
+                            'border-accent bg-accent/5 hover:bg-accent/10' => $isMine,
+                        ])
+                        data-test="message-row"
+                        @if ($isMine) data-test-mine="true" @endif
+                    >
+                        <flux:avatar size="sm" class="lg:hidden" name="{{ $comment->commentator?->name }}" src="{{ $comment->commentator?->gravatar }}" color="auto" />
+                        <flux:avatar size="md" class="hidden lg:flex" name="{{ $comment->commentator?->name }}" src="{{ $comment->commentator?->gravatar }}" color="auto" />
+
+                        <div class="min-w-0 flex-1 pr-8 lg:pr-0">
+                            {{-- Header --}}
+                            <div class="flex flex-col gap-y-0.5 lg:flex-row lg:flex-wrap lg:items-baseline lg:gap-x-2 lg:gap-y-1">
+                                <span @class([
+                                    'text-sm font-bold',
+                                    'text-accent' => $isMine,
+                                    'text-zinc-900 dark:text-white' => ! $isMine,
+                                ])>
+                                    {{ $comment->commentator?->name ?? 'Unknown' }}@if ($isMine) <span class="font-normal text-zinc-500">(you)</span>@endif
+                                </span>
+                                <div class="flex items-baseline gap-x-1.5 text-xs text-zinc-500">
+                                    <span class="text-zinc-400">{{ $comment->created_at->diffForHumans() }}</span>
+                                    @if ($comment->edited_at)
+                                        <span class="text-zinc-400" title="Edited {{ $comment->edited_at->diffForHumans() }}" data-test="edited-indicator">(edited)</span>
+                                    @endif
+                                </div>
+                            </div>
+
+                            @if ($editingCommentId === $comment->id)
+                                <div class="mt-2" data-test="inline-edit-composer">
+                                    <x-conversation-composer
+                                        editor-model="editingText"
+                                        :allow-prayer="false"
+                                        :allow-mentions="true"
+                                        submit-action="saveEdit"
+                                        submit-label="Save changes"
+                                        cancel-action="cancelEditing"
+                                        :editing="true"
+                                        test-prefix="edit-composer"
+                                    />
+                                </div>
+                            @else
+                                {{-- Body --}}
+                                <div class="mt-1 text-sm leading-relaxed text-zinc-700 dark:text-zinc-200
+                                    **:[h1]:text-xl **:[h1]:font-semibold **:[h2]:text-lg **:[h2]:font-semibold **:[h3]:font-semibold
+                                    **:[strong]:font-semibold **:[em]:italic **:[u]:underline **:[s]:line-through
+                                    **:[ol]:list-decimal **:[ol]:ml-5 **:[ul]:list-disc **:[ul]:ml-5
+                                    **:[a]:underline
+                                    **:[blockquote]:border-l-4 **:[blockquote]:pl-2
+                                    **:[h1]:not-first:mt-3 **:[h2]:not-first:mt-3 **:[h3]:not-first:mt-3
+                                    **:[ul]:not-first:mt-3 **:[ol]:not-first:mt-3
+                                    **:[blockquote]:not-first:mt-3
+                                    **:[p]:not-first:mt-3
+                                    **:[h1+p]:mt-0 **:[h2+p]:mt-0 **:[h3+p]:mt-0">
+                                    {!! app(ScriptureLinker::class)->linkify($comment->text) !!}
+                                </div>
+
+                                {{-- Reactions row --}}
+                                @php($summary = $comment->reactions->summary($currentUser))
+                                @if ($summary->isNotEmpty())
+                                    <div class="mt-2 flex flex-wrap items-center gap-1.5">
+                                        @foreach ($summary as $reaction)
+                                            @php($mine = (bool) ($reaction['commentator_reacted'] ?? false))
+                                            @php($reactorNames = $comment->reactions
+                                                ->where('reaction', $reaction['reaction'])
+                                                ->map(fn ($r) => $currentUser
+                                                    && $r->commentator_id === $currentUser->getKey()
+                                                    && $r->commentator_type === $currentUser->getMorphClass()
+                                                        ? 'You'
+                                                        : $r->commentator?->name)
+                                                ->filter()
+                                                ->sortBy(fn ($name) => $name === 'You' ? 0 : 1)
+                                                ->values()
+                                                ->implode(', '))
+                                            <flux:tooltip content="{{ $reactorNames }}">
+                                                <button
+                                                    wire:key="reaction-{{ $comment->id }}-{{ $reaction['reaction'] }}"
+                                                    wire:click="react({{ $comment->id }}, '{{ $reaction['reaction'] }}')"
+                                                    type="button"
+                                                    @class([
+                                                        'inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-semibold transition-colors',
+                                                        'border-accent bg-accent/10 text-accent' => $mine,
+                                                        'border-zinc-200 bg-white text-zinc-600 hover:bg-zinc-100 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700' => ! $mine,
+                                                    ])
+                                                    data-test="reaction-chip"
+                                                    @if ($mine) data-test-mine="true" @endif
+                                                >
+                                                    <span>{{ $reaction['reaction'] }}</span>
+                                                    <span>{{ $reaction['count'] }}</span>
+                                                </button>
+                                            </flux:tooltip>
+                                        @endforeach
+
+                                        {{-- Mobile: opens the action sheet --}}
+                                        <button
+                                            type="button"
+                                            wire:click="openActions({{ $comment->id }})"
+                                            class="inline-flex h-6 items-center justify-center rounded-full border border-dashed border-zinc-300 px-2 text-xs text-zinc-500 hover:bg-zinc-100 hover:text-zinc-900 lg:hidden dark:border-zinc-600 dark:hover:bg-zinc-800"
+                                            aria-label="Add reaction"
+                                            data-test="reaction-picker-trigger-mobile"
+                                        >
+                                            <flux:icon.face-smile variant="micro" />
+                                        </button>
+
+                                        {{-- Desktop: inline emoji popover --}}
+                                        <flux:dropdown align="start" class="hidden lg:inline-flex">
+                                            <button
+                                                type="button"
+                                                class="inline-flex h-6 items-center justify-center rounded-full border border-dashed border-zinc-300 px-2 text-xs text-zinc-500 hover:bg-zinc-100 hover:text-zinc-900 dark:border-zinc-600 dark:hover:bg-zinc-800"
+                                                aria-label="Add reaction"
+                                                data-test="reaction-picker-trigger"
+                                            >
+                                                <flux:icon.face-smile variant="micro" />
+                                            </button>
+                                            <flux:popover>
+                                                <div class="flex">
+                                                    @foreach ($quickReactions as $allowedReaction)
+                                                        <flux:button size="sm" variant="ghost" square wire:click="react({{ $comment->id }}, '{{ $allowedReaction }}')">{{ $allowedReaction }}</flux:button>
+                                                    @endforeach
+                                                </div>
+                                            </flux:popover>
+                                        </flux:dropdown>
+                                    </div>
+                                @endif
+                            @endif
+                        </div>
+
+                        {{-- Mobile action sheet trigger --}}
+                        @if ($editingCommentId !== $comment->id)
+                            <button
+                                type="button"
+                                wire:click="openActions({{ $comment->id }})"
+                                aria-label="Message actions"
+                                @class([
+                                    'absolute right-2 top-2 grid size-8 place-items-center rounded-md transition-colors duration-100 hover:bg-zinc-100 lg:hidden dark:hover:bg-zinc-800',
+                                    'text-accent' => $isMine,
+                                    'text-zinc-500 dark:text-zinc-400' => ! $isMine,
+                                ])
+                                data-test="message-actions-trigger"
+                            >
+                                <flux:icon.ellipsis-horizontal variant="micro" class="size-4" />
+                            </button>
+                        @endif
+
+                        {{-- Hover toolbar (desktop) --}}
+                        @if ($editingCommentId !== $comment->id)
+                            <div
+                                class="absolute right-3 top-2.5 z-10 hidden gap-0.5 group-hover/row:flex group-focus-within/row:flex group-has-[[data-flux-popover][data-open]]/row:flex"
+                                data-test="hover-toolbar"
+                                role="toolbar"
+                                aria-label="Message actions"
+                            >
+                                @can('update', $comment)
+                                    <flux:tooltip content="Edit message">
+                                        <button
+                                            type="button"
+                                            wire:click="startEditing({{ $comment->id }})"
+                                            aria-label="Edit message"
+                                            @class([
+                                                'flex size-[26px] cursor-pointer items-center justify-center rounded-md transition-colors duration-[120ms] focus-visible:outline-none',
+                                                'text-accent hover:bg-accent/20 focus-visible:bg-accent/20' => $isMine,
+                                                'text-zinc-500 hover:bg-zinc-200 hover:text-zinc-800 focus-visible:bg-zinc-200 focus-visible:text-zinc-800 dark:hover:bg-zinc-700 dark:hover:text-white dark:focus-visible:bg-zinc-700 dark:focus-visible:text-white' => ! $isMine,
+                                            ])
+                                            data-test="edit-toggle"
+                                        >
+                                            <flux:icon.pencil-square variant="micro" class="size-3.5" />
+                                        </button>
+                                    </flux:tooltip>
+                                @endcan
+
+                                <flux:dropdown align="end">
+                                    <flux:tooltip content="Add reaction">
+                                        <button
+                                            type="button"
+                                            aria-label="Add reaction"
+                                            @class([
+                                                'flex size-[26px] cursor-pointer items-center justify-center rounded-md transition-colors duration-[120ms] focus-visible:outline-none',
+                                                'text-accent hover:bg-accent/20 focus-visible:bg-accent/20' => $isMine,
+                                                'text-zinc-500 hover:bg-zinc-200 hover:text-zinc-800 focus-visible:bg-zinc-200 focus-visible:text-zinc-800 dark:hover:bg-zinc-700 dark:hover:text-white dark:focus-visible:bg-zinc-700 dark:focus-visible:text-white' => ! $isMine,
+                                            ])
+                                        >
+                                            <flux:icon.face-smile variant="micro" class="size-3.5" />
+                                        </button>
+                                    </flux:tooltip>
+                                    <flux:popover>
+                                        <div class="flex">
+                                            @foreach ($quickReactions as $allowedReaction)
+                                                <flux:button size="sm" variant="ghost" square wire:click="react({{ $comment->id }}, '{{ $allowedReaction }}')">{{ $allowedReaction }}</flux:button>
+                                            @endforeach
+                                        </div>
+                                    </flux:popover>
+                                </flux:dropdown>
+
+                                @can('delete', $comment)
+                                    <flux:tooltip content="Delete message">
+                                        <button
+                                            type="button"
+                                            wire:click="confirmDeleteComment({{ $comment->id }})"
+                                            aria-label="Delete message"
+                                            class="flex size-[26px] cursor-pointer items-center justify-center rounded-md text-zinc-500 transition-colors duration-[120ms] hover:bg-red-50 hover:text-red-600 focus-visible:bg-red-50 focus-visible:text-red-600 focus-visible:outline-none dark:hover:bg-red-950/40 dark:hover:text-red-400 dark:focus-visible:bg-red-950/40 dark:focus-visible:text-red-400"
+                                            data-test="delete-toggle"
+                                        >
+                                            <flux:icon.trash variant="micro" class="size-3.5" />
+                                        </button>
+                                    </flux:tooltip>
+                                @endcan
+                            </div>
+                        @endif
+                    </div>
+                @endforeach
             @endforeach
+        </div>
+
+        {{-- Composer --}}
+        @if (! $editingCommentId)
+            <div
+                class="border-t border-zinc-200 px-3.5 py-2.5 lg:px-6 lg:py-4 dark:border-zinc-700"
+                x-data="{ collapse() {} }"
+            >
+                <x-conversation-composer
+                    editor-model="reply"
+                    :allow-prayer="false"
+                    :allow-mentions="true"
+                    submit-action="postReply"
+                />
             </div>
         @endif
     </div>
-    <div class="max-w-3xl mt-6">
-        <form wire:submit.prevent="saveComment">
-            <flux:composer wire:model="comment" label="Comment" label:sr-only placeholder="Write your comment...">
-                <x-slot name="input">
-                    <flux:editor
-                        variant="borderless"
-                        toolbar="heading | bold italic underline strike | bullet ordered blockquote | link ~ undo redo"
-                        class="**:data-[slot=content]:min-h-[100px]!"
-                    />
-                </x-slot>
-                <x-slot name="actionsLeading">
 
-                </x-slot>
-                <x-slot name="actionsTrailing">
-                    <flux:button
-                        type="submit"
-                        variant="primary"
-                        size="sm"
-                        icon="paper-airplane"
-                        wire:loading.attr="disabled"
-                    />
-                </x-slot>
-            </flux:composer>
+    {{-- Mobile action sheet --}}
+    @php($sheetComment = $this->sheetComment)
+    <flux:modal
+        name="service-message-actions"
+        flyout
+        position="bottom"
+        variant="bare"
+        class="lg:hidden"
+        x-on:close="$wire.closeActions()"
+    >
+        @if ($sheetComment)
+            @php($myReactions = $sheetComment->reactions
+                ->filter(fn ($r) => $currentUser
+                    && $r->commentator_id === $currentUser->getKey()
+                    && $r->commentator_type === $currentUser->getMorphClass())
+                ->pluck('reaction')
+                ->all())
+            <div
+                role="dialog"
+                aria-label="Message actions"
+                class="rounded-t-2xl bg-white pb-[max(0.75rem,env(safe-area-inset-bottom))] dark:bg-zinc-900"
+                data-test="message-actions-sheet"
+            >
+                <div class="mx-auto mt-2.5 h-1 w-10 rounded-full bg-zinc-300 dark:bg-zinc-600"></div>
+
+                <div class="px-4 pb-3 pt-2.5">
+                    <div class="text-xs font-semibold text-zinc-500 dark:text-zinc-400">
+                        {{ $sheetComment->commentator?->name ?? 'Unknown' }}
+                        · {{ $sheetComment->created_at->diffForHumans() }}
+                    </div>
+                    <div class="mt-1 line-clamp-2 text-sm text-zinc-700 dark:text-zinc-200">
+                        {{ Str::limit(html_entity_decode(strip_tags($sheetComment->text), ENT_QUOTES | ENT_HTML5), 180) }}
+                    </div>
+                </div>
+
+                <div class="flex gap-1.5 border-t border-zinc-200 px-3.5 pb-3 pt-3.5 dark:border-zinc-700">
+                    @foreach ($quickReactions as $allowedReaction)
+                        @php($mine = in_array($allowedReaction, $myReactions, true))
+                        <button
+                            type="button"
+                            wire:click="react({{ $sheetComment->id }}, '{{ $allowedReaction }}')"
+                            x-on:click="$flux.modal('service-message-actions').close()"
+                            @class([
+                                'flex h-12 flex-1 items-center justify-center rounded-xl border text-[1.375rem] leading-none transition-colors',
+                                'border-accent bg-accent/10' => $mine,
+                                'border-zinc-200 bg-white hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800 dark:hover:bg-zinc-700' => ! $mine,
+                            ])
+                            data-test="sheet-reaction"
+                            @if ($mine) data-test-mine="true" @endif
+                        >{{ $allowedReaction }}</button>
+                    @endforeach
+                </div>
+
+                <div class="border-t border-zinc-200 dark:border-zinc-700">
+                    @can('update', $sheetComment)
+                        <button
+                            type="button"
+                            wire:click="startEditing({{ $sheetComment->id }})"
+                            x-on:click="$flux.modal('service-message-actions').close()"
+                            class="flex w-full items-center gap-3.5 border-b border-zinc-100 px-5 py-3.5 text-left text-[15px] font-medium dark:border-zinc-800"
+                            data-test="sheet-edit"
+                        >
+                            <span class="grid size-8 shrink-0 place-items-center rounded-md bg-zinc-100 text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400">
+                                <flux:icon.pencil-square variant="micro" />
+                            </span>
+                            Edit message
+                        </button>
+                    @endcan
+
+                    <button
+                        type="button"
+                        x-on:click="navigator.clipboard?.writeText($el.dataset.copyText); $flux.modal('service-message-actions').close()"
+                        data-copy-text="{{ html_entity_decode(strip_tags($sheetComment->text), ENT_QUOTES | ENT_HTML5) }}"
+                        class="flex w-full items-center gap-3.5 border-b border-zinc-100 px-5 py-3.5 text-left text-[15px] font-medium dark:border-zinc-800"
+                        data-test="sheet-copy"
+                    >
+                        <span class="grid size-8 shrink-0 place-items-center rounded-md bg-zinc-100 text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400">
+                            <flux:icon.clipboard-document variant="micro" />
+                        </span>
+                        Copy text
+                    </button>
+
+                    @can('delete', $sheetComment)
+                        <button
+                            type="button"
+                            wire:click="confirmDeleteComment({{ $sheetComment->id }})"
+                            class="flex w-full items-center gap-3.5 border-b border-zinc-100 px-5 py-3.5 text-left text-[15px] font-medium text-red-600 dark:border-zinc-800 dark:text-red-400"
+                            data-test="sheet-delete"
+                        >
+                            <span class="grid size-8 shrink-0 place-items-center rounded-md bg-red-50 text-red-600 dark:bg-red-950/40 dark:text-red-400">
+                                <flux:icon.trash variant="micro" />
+                            </span>
+                            Delete message
+                        </button>
+                    @endcan
+                </div>
+
+                <div class="px-3.5 pb-1 pt-2.5">
+                    <flux:modal.close>
+                        <button
+                            type="button"
+                            class="h-12 w-full rounded-xl border border-zinc-200 bg-white text-[15px] font-semibold text-zinc-700 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-200"
+                            data-test="sheet-cancel"
+                        >
+                            Cancel
+                        </button>
+                    </flux:modal.close>
+                </div>
+            </div>
+        @endif
+    </flux:modal>
+
+    <flux:modal name="service-delete-comment" class="min-w-[22rem]">
+        <form wire:submit="deleteComment" class="space-y-6">
+            <div>
+                <flux:heading size="lg">Delete message?</flux:heading>
+                <flux:subheading>This permanently removes the message and its reactions. This cannot be undone.</flux:subheading>
+            </div>
+            <div class="flex gap-2">
+                <flux:spacer />
+                <flux:modal.close>
+                    <flux:button variant="ghost" type="button">Cancel</flux:button>
+                </flux:modal.close>
+                <flux:button type="submit" variant="danger" data-test="confirm-delete-comment">Delete message</flux:button>
+            </div>
         </form>
-    </div>
-</div>
+    </flux:modal>
+</section>

--- a/resources/views/pages/groups/conversations/show.blade.php
+++ b/resources/views/pages/groups/conversations/show.blade.php
@@ -1066,13 +1066,7 @@ new class extends Component {
                 @endif
 
                 @foreach ($this->groupedComments as $dateString => $dayComments)
-                    <div class="my-2 flex items-center gap-3.5 px-2 py-3" data-test="day-divider">
-                        <div class="h-px flex-1 bg-zinc-200 dark:bg-zinc-700"></div>
-                        <span class="text-xs font-semibold uppercase tracking-wider text-zinc-500">
-                            {{ $this->dayLabel($dateString) }}
-                        </span>
-                        <div class="h-px flex-1 bg-zinc-200 dark:bg-zinc-700"></div>
-                    </div>
+                    <x-conversation.day-divider :label="$this->dayLabel($dateString)" />
 
                     @foreach ($dayComments as $comment)
                         @php($isMine = $comment->commentator?->is($currentUser))

--- a/tests/Feature/ConversationComposerTest.php
+++ b/tests/Feature/ConversationComposerTest.php
@@ -8,6 +8,7 @@ use App\Models\Conversation;
 use App\Models\Group;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Blade;
 use Livewire\Livewire;
 
 uses(RefreshDatabase::class);
@@ -148,4 +149,59 @@ test('the composer is hidden for users who cannot comment', function (): void {
         ->get(route('groups.conversations.show', ['group' => $group, 'conversation' => $conversation]))
         ->assertDontSeeHtml('data-test="composer-prayer-toggle"')
         ->assertDontSeeHtml('data-test="composer-shortcut-hint"');
+});
+
+test('omitting newImageModel hides the image attach button', function (): void {
+    $rendered = Blade::render(<<<'BLADE'
+        <x-conversation-composer
+            editor-model="reply"
+            new-attachment-model="newAttachment"
+            :pending-attachments="$pendingAttachments"
+            submit-action="postReply"
+        />
+    BLADE, ['pendingAttachments' => collect()]);
+
+    expect($rendered)
+        ->not->toContain('data-test="composer-image-button"')
+        ->and($rendered)->toContain('data-test="composer-attach-button"');
+});
+
+test('omitting newAttachmentModel hides the file attach button', function (): void {
+    $rendered = Blade::render(<<<'BLADE'
+        <x-conversation-composer
+            editor-model="reply"
+            new-image-model="newImage"
+            :pending-images="$pendingImages"
+            submit-action="postReply"
+        />
+    BLADE, ['pendingImages' => collect()]);
+
+    expect($rendered)
+        ->toContain('data-test="composer-image-button"')
+        ->and($rendered)->not->toContain('data-test="composer-attach-button"');
+});
+
+test('allowPrayer false hides the prayer toggle even with a prayer model', function (): void {
+    $rendered = Blade::render(<<<'BLADE'
+        <x-conversation-composer
+            editor-model="reply"
+            prayer-model="replyIsPrayer"
+            :allow-prayer="false"
+            submit-action="postReply"
+        />
+    BLADE);
+
+    expect($rendered)->not->toContain('data-test="composer-prayer-toggle"');
+});
+
+test('allowMentions false hides the mention button', function (): void {
+    $rendered = Blade::render(<<<'BLADE'
+        <x-conversation-composer
+            editor-model="reply"
+            :allow-mentions="false"
+            submit-action="postReply"
+        />
+    BLADE);
+
+    expect($rendered)->not->toContain('data-test="composer-mention"');
 });

--- a/tests/Feature/ServiceDiscussionTest.php
+++ b/tests/Feature/ServiceDiscussionTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Models\LiturgyElement;
 use App\Models\Service;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -19,45 +20,259 @@ test('authenticated user can view discussion component', function (): void {
         ->assertStatus(200);
 });
 
-test('authenticated user can submit a comment', function (): void {
+test('posting a reply creates a comment attributed to the current user', function (): void {
     $user = User::factory()->create();
     $service = Service::factory()->create();
 
     $this->actingAs($user);
 
     Livewire::test('services.discussion', ['serviceId' => $service->id])
-        ->set('comment', '<p>Test comment content</p>')
-        ->call('saveComment')
-        ->assertSet('comment', '');
-
-    expect($service->fresh()->comments()->count())->toBe(1);
-    expect($service->fresh()->comments()->first()->text)->toContain('Test comment content');
-});
-
-test('comment is associated with authenticated user', function (): void {
-    $user = User::factory()->create();
-    $service = Service::factory()->create();
-
-    $this->actingAs($user);
-
-    Livewire::test('services.discussion', ['serviceId' => $service->id])
-        ->set('comment', '<p>My comment</p>')
-        ->call('saveComment');
+        ->set('reply', '<p>Test comment content</p>')
+        ->call('postReply')
+        ->assertHasNoErrors()
+        ->assertSet('reply', '');
 
     $comment = $service->fresh()->comments()->first();
-    expect($comment->commentator->id)->toBe($user->id);
+    expect($comment)->not->toBeNull()
+        ->and($comment->text)->toContain('Test comment content')
+        ->and($comment->commentator->id)->toBe($user->id);
 });
 
-test('user can react to a comment', function (): void {
+test('empty replies are rejected with a validation error', function (): void {
     $user = User::factory()->create();
     $service = Service::factory()->create();
-    $service->comment('<p>Initial comment</p>', $user);
+
+    $this->actingAs($user);
+
+    Livewire::test('services.discussion', ['serviceId' => $service->id])
+        ->set('reply', '<p>   </p>')
+        ->call('postReply')
+        ->assertHasErrors('reply');
+
+    expect($service->fresh()->comments()->count())->toBe(0);
+});
+
+test('the composer hides attach buttons and the prayer toggle', function (): void {
+    $user = User::factory()->create();
+    $service = Service::factory()->create();
+
+    $this->actingAs($user);
+
+    Livewire::test('services.discussion', ['serviceId' => $service->id])
+        ->assertDontSeeHtml('data-test="composer-image-button"')
+        ->assertDontSeeHtml('data-test="composer-attach-button"')
+        ->assertDontSeeHtml('data-test="composer-prayer-toggle"');
+});
+
+test('the composer renders the mention button', function (): void {
+    $user = User::factory()->create();
+    $service = Service::factory()->create();
+
+    $this->actingAs($user);
+
+    Livewire::test('services.discussion', ['serviceId' => $service->id])
+        ->assertSeeHtml('data-test="composer-mention"');
+});
+
+test('the empty state appears when no comments exist', function (): void {
+    $user = User::factory()->create();
+    $service = Service::factory()->create();
+
+    $this->actingAs($user);
+
+    Livewire::test('services.discussion', ['serviceId' => $service->id])
+        ->assertSeeHtml('data-test="empty-state"')
+        ->assertSee('No messages yet');
+});
+
+test('a day divider appears once comments exist', function (): void {
+    $user = User::factory()->create();
+    $service = Service::factory()->create();
+    $service->comment('<p>hello</p>', $user);
+
+    $this->actingAs($user);
+
+    Livewire::test('services.discussion', ['serviceId' => $service->id])
+        ->assertSeeHtml('data-test="day-divider"')
+        ->assertSee('Today');
+});
+
+test('reacting twice with the same emoji removes the reaction', function (): void {
+    $user = User::factory()->create();
+    $service = Service::factory()->create();
+    $service->comment('<p>hi</p>', $user);
     $comment = $service->comments()->first();
 
     $this->actingAs($user);
 
     Livewire::test('services.discussion', ['serviceId' => $service->id])
+        ->call('react', $comment->id, '👍')
         ->call('react', $comment->id, '👍');
 
-    expect($comment->fresh()->reactions()->count())->toBe(1);
+    expect($comment->fresh()->reactions()->count())->toBe(0);
+});
+
+test('reactions outside the allowed set are rejected', function (): void {
+    $user = User::factory()->create();
+    $service = Service::factory()->create();
+    $service->comment('<p>hi</p>', $user);
+    $comment = $service->comments()->first();
+
+    $this->actingAs($user);
+
+    Livewire::test('services.discussion', ['serviceId' => $service->id])
+        ->call('react', $comment->id, '💀')
+        ->assertStatus(422);
+});
+
+test('author can edit their own comment and edited_at is set', function (): void {
+    $user = User::factory()->create();
+    $service = Service::factory()->create();
+    $service->comment('<p>original</p>', $user);
+    $comment = $service->comments()->first();
+
+    $this->actingAs($user);
+
+    Livewire::test('services.discussion', ['serviceId' => $service->id])
+        ->call('startEditing', $comment->id)
+        ->assertSet('editingCommentId', $comment->id)
+        ->set('editingText', '<p>rewritten</p>')
+        ->call('saveEdit')
+        ->assertHasNoErrors()
+        ->assertSet('editingCommentId', null);
+
+    $fresh = $comment->fresh();
+    expect($fresh->original_text)->toBe('<p>rewritten</p>')
+        ->and($fresh->edited_at)->not->toBeNull();
+});
+
+test('a non-author cannot start editing', function (): void {
+    $author = User::factory()->create();
+    $other = User::factory()->create();
+    $service = Service::factory()->create();
+    $service->comment('<p>mine</p>', $author);
+    $comment = $service->comments()->first();
+
+    $this->actingAs($other);
+
+    Livewire::test('services.discussion', ['serviceId' => $service->id])
+        ->call('startEditing', $comment->id)
+        ->assertStatus(403);
+});
+
+test('cancelEditing clears editing state without saving', function (): void {
+    $user = User::factory()->create();
+    $service = Service::factory()->create();
+    $service->comment('<p>original</p>', $user);
+    $comment = $service->comments()->first();
+
+    $this->actingAs($user);
+
+    Livewire::test('services.discussion', ['serviceId' => $service->id])
+        ->call('startEditing', $comment->id)
+        ->set('editingText', '<p>discarded</p>')
+        ->call('cancelEditing')
+        ->assertSet('editingCommentId', null);
+
+    expect($comment->fresh()->original_text)->toBe('<p>original</p>');
+});
+
+test('author can delete their own comment', function (): void {
+    $user = User::factory()->create();
+    $service = Service::factory()->create();
+    $service->comment('<p>delete me</p>', $user);
+    $comment = $service->comments()->first();
+
+    $this->actingAs($user);
+
+    Livewire::test('services.discussion', ['serviceId' => $service->id])
+        ->call('confirmDeleteComment', $comment->id)
+        ->assertSet('commentToDeleteId', $comment->id)
+        ->call('deleteComment')
+        ->assertSet('commentToDeleteId', null);
+
+    expect($service->fresh()->comments()->count())->toBe(0);
+});
+
+test('a non-author cannot delete a comment', function (): void {
+    $author = User::factory()->create();
+    $other = User::factory()->create();
+    $service = Service::factory()->create();
+    $service->comment('<p>theirs</p>', $author);
+    $comment = $service->comments()->first();
+
+    $this->actingAs($other);
+
+    Livewire::test('services.discussion', ['serviceId' => $service->id])
+        ->call('confirmDeleteComment', $comment->id)
+        ->assertStatus(403);
+
+    expect($service->fresh()->comments()->count())->toBe(1);
+});
+
+test('openActions sets the sheet comment id', function (): void {
+    $user = User::factory()->create();
+    $service = Service::factory()->create();
+    $service->comment('<p>hi</p>', $user);
+    $comment = $service->comments()->first();
+
+    $this->actingAs($user);
+
+    Livewire::test('services.discussion', ['serviceId' => $service->id])
+        ->call('openActions', $comment->id)
+        ->assertSet('sheetCommentId', $comment->id);
+});
+
+test('mention candidates are scoped to liturgy element assignees', function (): void {
+    $service = Service::factory()->create();
+    $caller = User::factory()->create(['name' => 'Caller Carla']);
+    $assignee = User::factory()->create(['name' => 'Assigned Alex']);
+    $outsider = User::factory()->create(['name' => 'Outside Ollie']);
+
+    LiturgyElement::factory()
+        ->assignedTo($assignee)
+        ->create([
+            'liturgy_type' => $service->getMorphClass(),
+            'liturgy_id' => $service->id,
+        ]);
+
+    $this->actingAs($caller);
+
+    Livewire::test('services.discussion', ['serviceId' => $service->id])
+        ->call('mentionCandidates', '')
+        ->assertReturned(function (array $result) use ($assignee): bool {
+            $ids = collect($result)->pluck('id')->all();
+
+            return $ids === [$assignee->id];
+        });
+
+    Livewire::test('services.discussion', ['serviceId' => $service->id])
+        ->call('mentionCandidates', 'Ollie')
+        ->assertReturned([]);
+});
+
+test('mentions targeting users outside the service are sanitized away', function (): void {
+    $service = Service::factory()->create();
+    $caller = User::factory()->create();
+    $assignee = User::factory()->create(['name' => 'Inside Iris']);
+    $outsider = User::factory()->create(['name' => 'Outside Oscar']);
+
+    LiturgyElement::factory()
+        ->assignedTo($assignee)
+        ->create([
+            'liturgy_type' => $service->getMorphClass(),
+            'liturgy_id' => $service->id,
+        ]);
+
+    $this->actingAs($caller);
+
+    Livewire::test('services.discussion', ['serviceId' => $service->id])
+        ->set('reply', '<p>Hi <span data-mention="'.$outsider->id.'">@Outside Oscar</span> and <span data-mention="'.$assignee->id.'">@Inside Iris</span></p>')
+        ->call('postReply')
+        ->assertHasNoErrors();
+
+    $comment = $service->fresh()->comments()->first();
+    expect($comment->original_text)
+        ->toContain('data-mention="'.$assignee->id.'"')
+        ->not->toContain('data-mention="'.$outsider->id.'"');
 });


### PR DESCRIPTION
## Summary

- Replaces the basic comment form on services with a full messaging interface: reactions with toggle, inline editing, delete with confirmation modal, day dividers, and a mobile action sheet.
- Makes the conversation composer component reusable by defaulting upload, prayer, and mention props to optional — the service discussion uses a lightweight configuration without file uploads or prayer.
- Extends `CommentPolicy` to authorize update/delete on service comments (author-only) and adds mention autocomplete scoped to liturgy-element assignees via `ResolveGroupMentionsAutocompleteAction`.
- Extracts a shared `<x-conversation.day-divider>` Blade component used by both conversations and services.

## Test plan

- [ ] Verify posting, editing, and deleting messages on a service discussion page
- [ ] Confirm reactions toggle on/off and display reactor names in tooltips
- [ ] Test mobile action sheet opens with correct options and closes properly
- [ ] Verify mention autocomplete only suggests users assigned to the service
- [ ] Ensure conversation page still functions correctly (day divider extraction, composer prop defaults)
- [ ] Run `php artisan test --filter=ServiceDiscussion` and `php artisan test --filter=ConversationComposer`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Service discussions now support full message threading with replies, reactions, and inline editing capabilities
  * Comments can be deleted with proper authorization checks
  * Improved mention suggestions when composing service discussion replies
  * Visual day dividers mark conversation timeline boundaries for clarity
  * Configurable toggles for prayer and mention features in the composer

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jpangborn/stave/pull/118?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->