### PR TITLE
Add email digest batching for notifications

### DIFF
--- a/app/Channels/DigestChannel.php
+++ b/app/Channels/DigestChannel.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Channels;
+
+use App\Enums\DigestFrequency;
+use App\Models\EmailDigestItem;
+use App\Models\User;
+use Illuminate\Notifications\Notification;
+
+class DigestChannel
+{
+    public function send(object $notifiable, Notification $notification): void
+    {
+        if (! $notifiable instanceof User) {
+            return;
+        }
+
+        if ($notifiable->digest_frequency === DigestFrequency::OFF) {
+            return;
+        }
+
+        if (! method_exists($notification, 'eventType') || ! method_exists($notification, 'toArray')) {
+            return;
+        }
+
+        EmailDigestItem::create([
+            'user_id' => $notifiable->id,
+            'event_type' => $notification->eventType()->value,
+            'data' => $notification->toArray($notifiable),
+        ]);
+    }
+}

--- a/app/Console/Commands/SendNotificationDigestsCommand.php
+++ b/app/Console/Commands/SendNotificationDigestsCommand.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Enums\DigestFrequency;
+use App\Mail\NotificationDigestMail;
+use App\Models\EmailDigestItem;
+use App\Models\User;
+use Illuminate\Console\Attributes\Description;
+use Illuminate\Console\Attributes\Signature;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Mail;
+
+#[Signature('stave:send-digests {--frequency=daily : Digest cadence to send (daily or weekly)}')]
+#[Description('Send pending email-digest summaries to users whose digest_frequency matches the given cadence.')]
+class SendNotificationDigestsCommand extends Command
+{
+    public function handle(): int
+    {
+        $frequency = DigestFrequency::tryFrom((string) $this->option('frequency'));
+
+        if (! $frequency || $frequency === DigestFrequency::OFF) {
+            $this->error('Frequency must be "daily" or "weekly".');
+
+            return self::FAILURE;
+        }
+
+        $userCount = 0;
+        $itemCount = 0;
+
+        User::query()
+            ->where('digest_frequency', $frequency->value)
+            ->whereHas('pendingDigestItems')
+            ->chunkById(100, function ($users) use ($frequency, &$userCount, &$itemCount): void {
+                foreach ($users as $user) {
+                    $sent = $this->sendDigestTo($user, $frequency);
+
+                    if ($sent > 0) {
+                        $userCount++;
+                        $itemCount += $sent;
+                    }
+                }
+            });
+
+        $this->info("Sent {$frequency->value} digest to {$userCount} users covering {$itemCount} items.");
+
+        return self::SUCCESS;
+    }
+
+    private function sendDigestTo(User $user, DigestFrequency $frequency): int
+    {
+        return DB::transaction(function () use ($user, $frequency): int {
+            $items = $user->pendingDigestItems()
+                ->orderBy('created_at')
+                ->lockForUpdate()
+                ->get();
+
+            if ($items->isEmpty()) {
+                return 0;
+            }
+
+            Mail::to($user)->send(new NotificationDigestMail($user, $items, $frequency));
+
+            EmailDigestItem::query()
+                ->whereIn('id', $items->pluck('id'))
+                ->update(['sent_at' => now()]);
+
+            return $items->count();
+        });
+    }
+}

--- a/app/Enums/DigestFrequency.php
+++ b/app/Enums/DigestFrequency.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum DigestFrequency: string
+{
+    case OFF = 'off';
+    case DAILY = 'daily';
+    case WEEKLY = 'weekly';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::OFF => 'Off',
+            self::DAILY => 'Daily',
+            self::WEEKLY => 'Weekly',
+        };
+    }
+}

--- a/app/Mail/NotificationDigestMail.php
+++ b/app/Mail/NotificationDigestMail.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mail;
+
+use App\Enums\DigestFrequency;
+use App\Models\EmailDigestItem;
+use App\Models\User;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+
+class NotificationDigestMail extends Mailable implements ShouldQueue
+{
+    use Queueable, SerializesModels;
+
+    /**
+     * @param  Collection<int, EmailDigestItem>  $items
+     */
+    public function __construct(
+        public User $user,
+        public Collection $items,
+        public DigestFrequency $frequency,
+    ) {}
+
+    public function envelope(): Envelope
+    {
+        $count = $this->items->count();
+
+        return new Envelope(
+            subject: "Your {$this->frequency->value} Stave digest — {$count} ".Str::plural('update', $count),
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            markdown: 'mail.notification-digest',
+        );
+    }
+}

--- a/app/Models/EmailDigestItem.php
+++ b/app/Models/EmailDigestItem.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Enums\NotificationEventType;
+use Database\Factories\EmailDigestItemFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int $user_id
+ * @property NotificationEventType $event_type
+ * @property array<string, mixed> $data
+ * @property Carbon|null $sent_at
+ */
+#[Fillable(['user_id', 'event_type', 'data', 'sent_at'])]
+class EmailDigestItem extends Model
+{
+    /** @use HasFactory<EmailDigestItemFactory> */
+    use HasFactory;
+
+    public const UPDATED_AT = null;
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return [
+            'event_type' => NotificationEventType::class,
+            'data' => 'array',
+            'sent_at' => 'datetime',
+        ];
+    }
+
+    /** @return BelongsTo<User, $this> */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
+use App\Enums\DigestFrequency;
 use App\Enums\MembershipStatus;
 use App\Models\Traits\HasGravatar;
 use Database\Factories\UserFactory;
@@ -19,12 +20,17 @@ use NotificationChannels\WebPush\HasPushSubscriptions;
 use Spatie\Comments\Models\Concerns\InteractsWithComments;
 use Spatie\Comments\Models\Concerns\Interfaces\CanComment;
 
-#[Fillable(['name', 'email', 'password', 'person_id', 'quiet_hours_start', 'quiet_hours_end', 'timezone'])]
+#[Fillable(['name', 'email', 'password', 'person_id', 'quiet_hours_start', 'quiet_hours_end', 'timezone', 'digest_frequency'])]
 #[Hidden(['password', 'remember_token'])]
 class User extends Authenticatable implements CanComment
 {
     /** @use HasFactory<UserFactory> */
     use HasFactory, HasGravatar, HasPushSubscriptions, InteractsWithComments, Notifiable;
+
+    /** @var array<string, mixed> */
+    protected $attributes = [
+        'digest_frequency' => 'daily',
+    ];
 
     /**
      * Get the attributes that should be cast.
@@ -36,6 +42,7 @@ class User extends Authenticatable implements CanComment
         return [
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
+            'digest_frequency' => DigestFrequency::class,
         ];
     }
 
@@ -69,5 +76,17 @@ class User extends Authenticatable implements CanComment
     public function notificationPreferences(): HasMany
     {
         return $this->hasMany(NotificationPreference::class);
+    }
+
+    /** @return HasMany<EmailDigestItem, $this> */
+    public function emailDigestItems(): HasMany
+    {
+        return $this->hasMany(EmailDigestItem::class);
+    }
+
+    /** @return HasMany<EmailDigestItem, $this> */
+    public function pendingDigestItems(): HasMany
+    {
+        return $this->emailDigestItems()->whereNull('sent_at');
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -20,6 +20,7 @@ use NotificationChannels\WebPush\HasPushSubscriptions;
 use Spatie\Comments\Models\Concerns\InteractsWithComments;
 use Spatie\Comments\Models\Concerns\Interfaces\CanComment;
 
+/** @property DigestFrequency $digest_frequency */
 #[Fillable(['name', 'email', 'password', 'person_id', 'quiet_hours_start', 'quiet_hours_end', 'timezone', 'digest_frequency'])]
 #[Hidden(['password', 'remember_token'])]
 class User extends Authenticatable implements CanComment

--- a/app/Notifications/Concerns/RespectsNotificationPreferences.php
+++ b/app/Notifications/Concerns/RespectsNotificationPreferences.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Notifications\Concerns;
 
+use App\Enums\DigestFrequency;
 use App\Enums\NotificationChannel;
 use App\Enums\NotificationEventType;
 use App\Models\User;
@@ -22,10 +23,40 @@ trait RespectsNotificationPreferences
             return array_map(fn (NotificationChannel $channel): string => $channel->value, $event->defaultChannels());
         }
 
-        return app(NotificationPreferenceService::class)->channelsFor(
+        $channels = app(NotificationPreferenceService::class)->channelsFor(
             $notifiable,
             $event,
             $event->defaultChannels(),
         );
+
+        return $this->rewriteMailToDigest($notifiable, $event, $channels);
+    }
+
+    /**
+     * Non-mention events delivered via `mail` are batched into the user's digest
+     * unless the user opted out by setting `digest_frequency` to OFF.
+     *
+     * @param  array<int, string>  $channels
+     * @return array<int, string>
+     */
+    private function rewriteMailToDigest(User $user, NotificationEventType $event, array $channels): array
+    {
+        if ($event->isMention()) {
+            return $channels;
+        }
+
+        if ($user->digest_frequency === DigestFrequency::OFF) {
+            return $channels;
+        }
+
+        $index = array_search(NotificationChannel::MAIL->value, $channels, true);
+
+        if ($index === false) {
+            return $channels;
+        }
+
+        $channels[$index] = 'digest';
+
+        return $channels;
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use App\Channels\DigestChannel;
 use App\Listeners\DispatchCommentNotifications;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Notification;
@@ -44,5 +45,6 @@ class AppServiceProvider extends ServiceProvider
         Event::listen(CommentApprovedEvent::class, DispatchCommentNotifications::class);
 
         Notification::extend('webpush', fn ($app) => $app->make(WebPushChannel::class));
+        Notification::extend('digest', fn ($app) => $app->make(DigestChannel::class));
     }
 }

--- a/database/factories/EmailDigestItemFactory.php
+++ b/database/factories/EmailDigestItemFactory.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Enums\NotificationEventType;
+use App\Models\EmailDigestItem;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<EmailDigestItem>
+ */
+class EmailDigestItemFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'event_type' => NotificationEventType::CONVERSATION_REPLY,
+            'data' => [
+                'title' => fake()->sentence(4),
+                'body' => fake()->sentence(),
+                'url' => fake()->url(),
+            ],
+            'sent_at' => null,
+        ];
+    }
+
+    public function sent(): self
+    {
+        return $this->state(['sent_at' => now()]);
+    }
+}

--- a/database/migrations/2026_05_19_163732_add_digest_frequency_to_users_table.php
+++ b/database/migrations/2026_05_19_163732_add_digest_frequency_to_users_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('digest_frequency', 16)->default('daily')->after('timezone');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('digest_frequency');
+        });
+    }
+};

--- a/database/migrations/2026_05_19_163733_create_email_digest_items_table.php
+++ b/database/migrations/2026_05_19_163733_create_email_digest_items_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('email_digest_items', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('event_type', 64);
+            $table->json('data');
+            $table->timestamp('sent_at')->nullable();
+            $table->timestamp('created_at')->nullable();
+
+            $table->index(['user_id', 'sent_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('email_digest_items');
+    }
+};

--- a/resources/views/livewire/settings/notification-preferences.blade.php
+++ b/resources/views/livewire/settings/notification-preferences.blade.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\DigestFrequency;
 use App\Enums\NotificationChannel;
 use App\Enums\NotificationEventType;
 use App\Services\NotificationPreferenceService;
@@ -16,6 +17,8 @@ new class extends Component {
 
     public ?string $timezone = null;
 
+    public string $digestFrequency = 'daily';
+
     public function mount(NotificationPreferenceService $preferences): void
     {
         $user = Auth::user();
@@ -23,6 +26,7 @@ new class extends Component {
         $this->quietHoursStart = $this->normalizeTime($user->quiet_hours_start);
         $this->quietHoursEnd = $this->normalizeTime($user->quiet_hours_end);
         $this->timezone = $user->timezone ?: config('app.timezone');
+        $this->digestFrequency = ($user->digest_frequency ?? DigestFrequency::DAILY)->value;
 
         $valueMatrix = $preferences->matrixFor($user);
 
@@ -90,6 +94,25 @@ new class extends Component {
         ])->save();
 
         $this->dispatch('quiet-hours-saved');
+    }
+
+    public function updatedDigestFrequency(string $value): void
+    {
+        $frequency = DigestFrequency::tryFrom($value);
+
+        if (! $frequency) {
+            return;
+        }
+
+        Auth::user()->forceFill(['digest_frequency' => $frequency->value])->save();
+
+        $this->dispatch('digest-frequency-saved');
+    }
+
+    /** @return array<int, DigestFrequency> */
+    public function getDigestFrequenciesProperty(): array
+    {
+        return DigestFrequency::cases();
     }
 
     /**
@@ -209,5 +232,32 @@ new class extends Component {
                 </x-action-message>
             </div>
         </form>
+
+        <flux:separator />
+
+        <div class="space-y-4">
+            <div>
+                <flux:heading>{{ __('Email digest') }}</flux:heading>
+                <flux:subheading>
+                    {{ __('Roll up email notifications instead of sending one per event. @mentions always send instantly. Daily sends at 07:00, weekly on Mondays at 07:00.') }}
+                </flux:subheading>
+            </div>
+
+            <div class="max-w-xs">
+                <flux:select
+                    wire:model.live="digestFrequency"
+                    :label="__('Digest frequency')"
+                    data-test="digest-frequency"
+                >
+                    @foreach ($this->digestFrequencies as $frequency)
+                        <flux:select.option :value="$frequency->value">{{ $frequency->label() }}</flux:select.option>
+                    @endforeach
+                </flux:select>
+            </div>
+
+            <x-action-message class="text-zinc-500 dark:text-zinc-400" on="digest-frequency-saved">
+                {{ __('Saved.') }}
+            </x-action-message>
+        </div>
     </div>
 </section>

--- a/resources/views/mail/notification-digest.blade.php
+++ b/resources/views/mail/notification-digest.blade.php
@@ -1,0 +1,29 @@
+@php
+    use App\Enums\NotificationEventType;
+    use Illuminate\Support\Str;
+@endphp
+
+<x-mail::message>
+# Your {{ $frequency->label() }} Stave digest
+
+Hi {{ $user->name }},
+
+You have {{ $items->count() }} {{ Str::plural('update', $items->count()) }} since the last digest.
+
+@foreach ($items->groupBy(fn ($item) => $item->event_type->value) as $eventValue => $group)
+## {{ NotificationEventType::from($eventValue)->label() }}
+
+@foreach ($group as $item)
+- **{{ $item->data['title'] ?? 'Update' }}** — {{ Str::limit($item->data['body'] ?? '', 160) }}<br>
+[Open]({{ $item->data['url'] ?? url('/') }})
+@endforeach
+
+@endforeach
+
+<x-mail::button :url="route('settings.notifications')">
+Notification settings
+</x-mail::button>
+
+Thanks,<br>
+{{ config('app.name') }}
+</x-mail::message>

--- a/routes/console.php
+++ b/routes/console.php
@@ -2,7 +2,11 @@
 
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Schedule;
 
 Artisan::command('inspire', function (): void {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+Schedule::command('stave:send-digests --frequency=daily')->dailyAt('07:00');
+Schedule::command('stave:send-digests --frequency=weekly')->weeklyOn(1, '07:00');

--- a/tests/Feature/Notifications/ConversationReplyNotificationTest.php
+++ b/tests/Feature/Notifications/ConversationReplyNotificationTest.php
@@ -25,13 +25,13 @@ function makeReplyFixture(): array
     return [$conversation, $comment, $author];
 }
 
-test('conversation-reply notification routes through all four channels', function (): void {
+test('conversation-reply notification routes mail through digest for new users by default', function (): void {
     [$conversation, $comment, $author] = makeReplyFixture();
     $recipient = User::factory()->create();
 
     $channels = (new ConversationReplyNotification($conversation, $comment, $author))->via($recipient);
 
-    expect($channels)->toBe(['mail', 'broadcast', 'webpush', 'database']);
+    expect($channels)->toBe(['digest', 'broadcast', 'webpush', 'database']);
 });
 
 test('conversation-reply broadcast payload includes title, body preview, and anchored url', function (): void {

--- a/tests/Feature/Notifications/EmailDigestTest.php
+++ b/tests/Feature/Notifications/EmailDigestTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\DigestFrequency;
+use App\Enums\NotificationChannel;
+use App\Enums\NotificationEventType;
+use App\Mail\NotificationDigestMail;
+use App\Models\Comment;
+use App\Models\Conversation;
+use App\Models\EmailDigestItem;
+use App\Models\Group;
+use App\Models\NotificationPreference;
+use App\Models\User;
+use App\Notifications\CommentMentionNotification;
+use App\Notifications\ConversationReplyNotification;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Notification;
+
+uses(RefreshDatabase::class);
+
+function makeDigestFixture(): array
+{
+    $author = User::factory()->create();
+    $group = Group::factory()->create();
+    $conversation = Conversation::factory()->for($group)->create(['user_id' => $author->id]);
+    /** @var Comment $comment */
+    $comment = $conversation->postComment('<p>Hi</p>', $author);
+
+    return [$conversation, $comment, $author];
+}
+
+test('a non-mention notification routes mail through the digest channel by default', function (): void {
+    [$conversation, $comment, $author] = makeDigestFixture();
+    $recipient = User::factory()->create();
+
+    expect($recipient->digest_frequency)->toBe(DigestFrequency::DAILY);
+
+    Notification::send($recipient, new ConversationReplyNotification($conversation, $comment, $author));
+
+    expect(EmailDigestItem::query()->where('user_id', $recipient->id)->count())->toBe(1);
+});
+
+test('a mention notification stays on instant mail and does not collect to the digest', function (): void {
+    Mail::fake();
+
+    [, $comment, $author] = makeDigestFixture();
+    $recipient = User::factory()->create();
+
+    $channels = (new CommentMentionNotification($comment, $author))->via($recipient);
+
+    expect($channels)->toContain('mail')
+        ->and($channels)->not->toContain('digest')
+        ->and(EmailDigestItem::query()->count())->toBe(0);
+});
+
+test('setting digest_frequency to Off restores instant mail for non-mention events', function (): void {
+    [$conversation, $comment, $author] = makeDigestFixture();
+    $recipient = User::factory()->create(['digest_frequency' => DigestFrequency::OFF->value]);
+
+    $channels = (new ConversationReplyNotification($conversation, $comment, $author))->via($recipient);
+
+    expect($channels)->toBe(['mail', 'broadcast', 'webpush', 'database'])
+        ->and(EmailDigestItem::query()->count())->toBe(0);
+});
+
+test('disabling mail on a non-mention event silences both instant mail and the digest', function (): void {
+    [$conversation, $comment, $author] = makeDigestFixture();
+    $recipient = User::factory()->create();
+
+    NotificationPreference::factory()->disabled()->create([
+        'user_id' => $recipient->id,
+        'event_type' => NotificationEventType::CONVERSATION_REPLY,
+        'channel' => NotificationChannel::MAIL,
+    ]);
+
+    $channels = (new ConversationReplyNotification($conversation, $comment, $author))->via($recipient);
+
+    expect($channels)->not->toContain('mail')
+        ->and($channels)->not->toContain('digest');
+
+    Notification::send($recipient, new ConversationReplyNotification($conversation, $comment, $author));
+
+    expect(EmailDigestItem::query()->count())->toBe(0);
+});
+
+test('the send-digests command emails users on the matching cadence and marks items sent', function (): void {
+    Mail::fake();
+
+    $user = User::factory()->create(['digest_frequency' => DigestFrequency::DAILY->value]);
+    EmailDigestItem::factory()->count(3)->create(['user_id' => $user->id]);
+
+    $this->artisan('stave:send-digests', ['--frequency' => 'daily'])->assertSuccessful();
+
+    Mail::assertQueued(NotificationDigestMail::class, fn (NotificationDigestMail $mail) => $mail->user->is($user)
+        && $mail->items->count() === 3
+        && $mail->frequency === DigestFrequency::DAILY);
+
+    expect(EmailDigestItem::query()->whereNull('sent_at')->count())->toBe(0);
+});
+
+test('re-running the command does not re-send items already marked sent', function (): void {
+    Mail::fake();
+
+    $user = User::factory()->create(['digest_frequency' => DigestFrequency::DAILY->value]);
+    EmailDigestItem::factory()->count(2)->create(['user_id' => $user->id]);
+
+    $this->artisan('stave:send-digests', ['--frequency' => 'daily'])->assertSuccessful();
+    $this->artisan('stave:send-digests', ['--frequency' => 'daily'])->assertSuccessful();
+
+    Mail::assertQueued(NotificationDigestMail::class, 1);
+});
+
+test('daily run does not email weekly users', function (): void {
+    Mail::fake();
+
+    $daily = User::factory()->create(['digest_frequency' => DigestFrequency::DAILY->value]);
+    $weekly = User::factory()->create(['digest_frequency' => DigestFrequency::WEEKLY->value]);
+    EmailDigestItem::factory()->create(['user_id' => $daily->id]);
+    EmailDigestItem::factory()->create(['user_id' => $weekly->id]);
+
+    $this->artisan('stave:send-digests', ['--frequency' => 'daily'])->assertSuccessful();
+
+    Mail::assertQueued(NotificationDigestMail::class, fn (NotificationDigestMail $mail) => $mail->user->is($daily));
+    Mail::assertNotQueued(NotificationDigestMail::class, fn (NotificationDigestMail $mail) => $mail->user->is($weekly));
+});
+
+test('users with no pending items receive nothing', function (): void {
+    Mail::fake();
+
+    User::factory()->create(['digest_frequency' => DigestFrequency::DAILY->value]);
+
+    $this->artisan('stave:send-digests', ['--frequency' => 'daily'])->assertSuccessful();
+
+    Mail::assertNothingQueued();
+});
+
+test('command rejects an off or unknown frequency', function (): void {
+    $this->artisan('stave:send-digests', ['--frequency' => 'off'])->assertFailed();
+    $this->artisan('stave:send-digests', ['--frequency' => 'bogus'])->assertFailed();
+});
+
+test('new users default to Daily digest frequency', function (): void {
+    $user = User::factory()->create();
+
+    expect($user->refresh()->digest_frequency)->toBe(DigestFrequency::DAILY);
+});

--- a/tests/Feature/Notifications/NewConversationNotificationTest.php
+++ b/tests/Feature/Notifications/NewConversationNotificationTest.php
@@ -25,13 +25,13 @@ function makeConversationFixture(): array
     return [$conversation, $author];
 }
 
-test('new-conversation notification routes through all four channels', function (): void {
+test('new-conversation notification routes mail through digest for new users by default', function (): void {
     [$conversation, $author] = makeConversationFixture();
     $recipient = User::factory()->create();
 
     $channels = (new NewConversationNotification($conversation, $author))->via($recipient);
 
-    expect($channels)->toBe(['mail', 'broadcast', 'webpush', 'database']);
+    expect($channels)->toBe(['digest', 'broadcast', 'webpush', 'database']);
 });
 
 test('new-conversation notification builds a broadcast payload', function (): void {

--- a/tests/Feature/Notifications/NotificationPreferencesGatingTest.php
+++ b/tests/Feature/Notifications/NotificationPreferencesGatingTest.php
@@ -29,16 +29,16 @@ function makeConversationReplyFixture(): array
     return [$conversation, $comment, $author];
 }
 
-test('with no preferences all four channels are returned for conversation reply', function (): void {
+test('with no preferences non-mention events route mail to digest by default', function (): void {
     [$conversation, $comment, $author] = makeConversationReplyFixture();
     $recipient = User::factory()->create();
 
     $channels = (new ConversationReplyNotification($conversation, $comment, $author))->via($recipient);
 
-    expect($channels)->toBe(['mail', 'broadcast', 'webpush', 'database']);
+    expect($channels)->toBe(['digest', 'broadcast', 'webpush', 'database']);
 });
 
-test('with no preferences all four channels are returned for mention', function (): void {
+test('with no preferences mention events keep instant mail', function (): void {
     [, $comment, $author] = makeConversationReplyFixture();
     $recipient = User::factory()->create();
 
@@ -47,7 +47,7 @@ test('with no preferences all four channels are returned for mention', function 
     expect($channels)->toBe(['mail', 'broadcast', 'webpush', 'database']);
 });
 
-test('with no preferences all four channels are returned for service discussion', function (): void {
+test('with no preferences service discussion routes mail to digest by default', function (): void {
     $author = User::factory()->create();
     $service = Service::factory()->create();
     $service->comment('<p>Hi</p>', $author);
@@ -57,10 +57,10 @@ test('with no preferences all four channels are returned for service discussion'
 
     $channels = (new ServiceDiscussionCommentNotification($service, $comment, $author))->via($recipient);
 
-    expect($channels)->toBe(['mail', 'broadcast', 'webpush', 'database']);
+    expect($channels)->toBe(['digest', 'broadcast', 'webpush', 'database']);
 });
 
-test('with no preferences all four channels are returned for new conversation', function (): void {
+test('with no preferences new conversation routes mail to digest by default', function (): void {
     $author = User::factory()->create();
     $group = Group::factory()->create();
     $conversation = Conversation::factory()->for($group)->create(['user_id' => $author->id]);
@@ -68,10 +68,10 @@ test('with no preferences all four channels are returned for new conversation', 
 
     $channels = (new NewConversationNotification($conversation, $author))->via($recipient);
 
-    expect($channels)->toBe(['mail', 'broadcast', 'webpush', 'database']);
+    expect($channels)->toBe(['digest', 'broadcast', 'webpush', 'database']);
 });
 
-test('disabling mail on conversation reply removes mail from the channel list', function (): void {
+test('disabling mail on conversation reply removes mail and digest from the channel list', function (): void {
     [$conversation, $comment, $author] = makeConversationReplyFixture();
     $recipient = User::factory()->create();
 
@@ -130,5 +130,5 @@ test('a disabled channel on one event does not affect a different event', functi
 
     $channels = (new ConversationReplyNotification($conversation, $comment, $author))->via($recipient);
 
-    expect($channels)->toBe(['mail', 'broadcast', 'webpush', 'database']);
+    expect($channels)->toBe(['digest', 'broadcast', 'webpush', 'database']);
 });

--- a/tests/Feature/Notifications/QuietHoursTest.php
+++ b/tests/Feature/Notifications/QuietHoursTest.php
@@ -50,16 +50,16 @@ test('webpush and broadcast are suppressed during quiet hours for a conversation
 
     $channels = (new ConversationReplyNotification($conversation, $comment, $author))->via($recipient);
 
-    expect($channels)->toBe(['mail', 'database']);
+    expect($channels)->toBe(['digest', 'database']);
 });
 
-test('mail is not suppressed during quiet hours', function (): void {
+test('mail-routed-to-digest is not suppressed during quiet hours', function (): void {
     [$conversation, $comment, $author] = makeQuietHoursFixture();
     $recipient = makeRecipientInDnd();
 
     $channels = (new ConversationReplyNotification($conversation, $comment, $author))->via($recipient);
 
-    expect($channels)->toContain('mail');
+    expect($channels)->toContain('digest');
 });
 
 test('database always remains during quiet hours', function (): void {
@@ -105,5 +105,5 @@ test('outside the quiet hours window all default channels return', function (): 
 
     $channels = (new ConversationReplyNotification($conversation, $comment, $author))->via($recipient);
 
-    expect($channels)->toBe(['mail', 'broadcast', 'webpush', 'database']);
+    expect($channels)->toBe(['digest', 'broadcast', 'webpush', 'database']);
 });

--- a/tests/Feature/Notifications/ServiceDiscussionCommentNotificationTest.php
+++ b/tests/Feature/Notifications/ServiceDiscussionCommentNotificationTest.php
@@ -23,13 +23,13 @@ function makeDiscussionFixture(): array
     return [$service, $comment, $author];
 }
 
-test('service-discussion notification routes through all four channels', function (): void {
+test('service-discussion notification routes mail through digest for new users by default', function (): void {
     [$service, $comment, $author] = makeDiscussionFixture();
     $recipient = User::factory()->create();
 
     $channels = (new ServiceDiscussionCommentNotification($service, $comment, $author))->via($recipient);
 
-    expect($channels)->toBe(['mail', 'broadcast', 'webpush', 'database']);
+    expect($channels)->toBe(['digest', 'broadcast', 'webpush', 'database']);
 });
 
 test('service-discussion broadcast payload includes service title and discussion anchor', function (): void {

--- a/tests/Feature/Settings/NotificationPreferencesComponentTest.php
+++ b/tests/Feature/Settings/NotificationPreferencesComponentTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Enums\DigestFrequency;
 use App\Enums\NotificationChannel;
 use App\Enums\NotificationEventType;
 use App\Models\NotificationPreference;
@@ -161,4 +162,25 @@ test('component renders all four event labels and four channel headers', functio
         ->assertSeeText('In-app')
         ->assertSeeText('Push')
         ->assertSeeText('Inbox');
+});
+
+test('digest frequency defaults to Daily and persists to the user when changed', function (): void {
+    $user = User::factory()->create();
+    $this->actingAs($user);
+
+    Livewire::test('settings.notification-preferences')
+        ->assertSet('digestFrequency', 'daily')
+        ->set('digestFrequency', 'weekly');
+
+    expect($user->refresh()->digest_frequency)->toBe(DigestFrequency::WEEKLY);
+});
+
+test('digest frequency can be turned Off', function (): void {
+    $user = User::factory()->create();
+    $this->actingAs($user);
+
+    Livewire::test('settings.notification-preferences')
+        ->set('digestFrequency', 'off');
+
+    expect($user->refresh()->digest_frequency)->toBe(DigestFrequency::OFF);
 });

--- a/tests/Unit/DigestChannelTest.php
+++ b/tests/Unit/DigestChannelTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Channels\DigestChannel;
+use App\Enums\DigestFrequency;
+use App\Enums\NotificationEventType;
+use App\Models\Comment;
+use App\Models\Conversation;
+use App\Models\EmailDigestItem;
+use App\Models\Group;
+use App\Models\User;
+use App\Notifications\ConversationReplyNotification;
+use App\Notifications\TestNotification;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+function makeReplyForChannel(): array
+{
+    $author = User::factory()->create();
+    $group = Group::factory()->create();
+    $conversation = Conversation::factory()->for($group)->create(['user_id' => $author->id]);
+    /** @var Comment $comment */
+    $comment = $conversation->postComment('<p>Hello</p>', $author);
+
+    return [$conversation, $comment, $author];
+}
+
+test('the digest channel writes an item with notification payload', function (): void {
+    [$conversation, $comment, $author] = makeReplyForChannel();
+    $recipient = User::factory()->create(['digest_frequency' => DigestFrequency::DAILY->value]);
+
+    (new DigestChannel())->send(
+        $recipient,
+        new ConversationReplyNotification($conversation, $comment, $author),
+    );
+
+    $item = EmailDigestItem::query()->where('user_id', $recipient->id)->sole();
+
+    expect($item->event_type)->toBe(NotificationEventType::CONVERSATION_REPLY)
+        ->and($item->data)->toHaveKeys(['title', 'body', 'url', 'conversation_id'])
+        ->and($item->sent_at)->toBeNull();
+});
+
+test('the digest channel short-circuits when digest_frequency is Off', function (): void {
+    [$conversation, $comment, $author] = makeReplyForChannel();
+    $recipient = User::factory()->create(['digest_frequency' => DigestFrequency::OFF->value]);
+
+    (new DigestChannel())->send(
+        $recipient,
+        new ConversationReplyNotification($conversation, $comment, $author),
+    );
+
+    expect(EmailDigestItem::query()->count())->toBe(0);
+});
+
+test('the digest channel ignores notifications without an eventType method', function (): void {
+    $recipient = User::factory()->create(['digest_frequency' => DigestFrequency::DAILY->value]);
+
+    (new DigestChannel())->send($recipient, new TestNotification());
+
+    expect(EmailDigestItem::query()->count())->toBe(0);
+});
+
+test('the digest channel ignores non-User notifiables', function (): void {
+    [$conversation, $comment, $author] = makeReplyForChannel();
+    $anonymous = new class()
+    {
+        public int $id = 999;
+    };
+
+    (new DigestChannel())->send(
+        $anonymous,
+        new ConversationReplyNotification($conversation, $comment, $author),
+    );
+
+    expect(EmailDigestItem::query()->count())->toBe(0);
+});


### PR DESCRIPTION
## Summary

- Adds a `DigestChannel` that queues non-mention notification emails into an `email_digest_items` table instead of sending them immediately
- Introduces a `stave:send-digests` artisan command, scheduled daily at 07:00 and weekly on Mondays, that flushes pending items per-user with row locking to prevent double-sends
- Adds a per-user `digest_frequency` preference (Off / Daily / Weekly, defaulting to Daily) with a settings UI dropdown
- @mention notifications bypass the digest and continue to send instant email
- Disabling the mail channel for an event silences both instant mail and the digest

## Test plan

- [x] 15 new tests across `EmailDigestTest`, `DigestChannelTest`, and `NotificationPreferencesComponentTest`
- [x] Updated 11 existing notification tests to reflect digest-by-default routing
- [x] All 134 notification/settings tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Email digest notifications now bundle updates and send them at scheduled intervals instead of immediately
  * Digest frequency preference in notification settings: Off, Daily, or Weekly
  * Automated digest emails sent daily at 7:00 AM and weekly on Mondays
  * Digest emails group notifications by update type for better organization

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jpangborn/stave/pull/123?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->