### PR TITLE
Add per-conversation mute, push device manager, and iOS A2HS coachmark

### DIFF
--- a/app/Listeners/DispatchCommentNotifications.php
+++ b/app/Listeners/DispatchCommentNotifications.php
@@ -16,8 +16,6 @@ use App\Recipients\ResolveConversationReplyRecipients;
 use App\Recipients\ResolveMentionRecipients;
 use App\Recipients\ResolveServiceDiscussionRecipients;
 use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Notification;
 use Spatie\Comments\Events\CommentApprovedEvent;
 
@@ -61,7 +59,7 @@ class DispatchCommentNotifications implements ShouldQueue
             fn (User $user): bool => $mentionedIds->contains($user->id),
         )->values();
 
-        $primary = $this->rejectMuted($primary, $commentable);
+        $primary = MutedCommentable::filterMuted($primary, $commentable);
 
         if ($mentioned->isNotEmpty()) {
             Notification::send($mentioned, new CommentMentionNotification($comment, $author));
@@ -74,33 +72,5 @@ class DispatchCommentNotifications implements ShouldQueue
 
             Notification::send($primary, $primaryNotification);
         }
-    }
-
-    /**
-     * Remove users who have muted the given commentable.
-     *
-     * @param  Collection<int, User>  $users
-     * @return Collection<int, User>
-     */
-    private function rejectMuted(Collection $users, Model $commentable): Collection
-    {
-        if ($users->isEmpty()) {
-            return $users;
-        }
-
-        $mutedUserIds = MutedCommentable::query()
-            ->where('commentable_type', $commentable::class)
-            ->where('commentable_id', $commentable->getKey())
-            ->whereIn('user_id', $users->pluck('id')->all())
-            ->pluck('user_id')
-            ->all();
-
-        if ($mutedUserIds === []) {
-            return $users;
-        }
-
-        return $users
-            ->reject(fn (User $user): bool => in_array($user->id, $mutedUserIds, true))
-            ->values();
     }
 }

--- a/app/Listeners/DispatchCommentNotifications.php
+++ b/app/Listeners/DispatchCommentNotifications.php
@@ -6,6 +6,7 @@ namespace App\Listeners;
 
 use App\Models\Comment;
 use App\Models\Conversation;
+use App\Models\MutedCommentable;
 use App\Models\Service;
 use App\Models\User;
 use App\Notifications\CommentMentionNotification;
@@ -15,6 +16,8 @@ use App\Recipients\ResolveConversationReplyRecipients;
 use App\Recipients\ResolveMentionRecipients;
 use App\Recipients\ResolveServiceDiscussionRecipients;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Notification;
 use Spatie\Comments\Events\CommentApprovedEvent;
 
@@ -58,6 +61,8 @@ class DispatchCommentNotifications implements ShouldQueue
             fn (User $user): bool => $mentionedIds->contains($user->id),
         )->values();
 
+        $primary = $this->rejectMuted($primary, $commentable);
+
         if ($mentioned->isNotEmpty()) {
             Notification::send($mentioned, new CommentMentionNotification($comment, $author));
         }
@@ -69,5 +74,33 @@ class DispatchCommentNotifications implements ShouldQueue
 
             Notification::send($primary, $primaryNotification);
         }
+    }
+
+    /**
+     * Remove users who have muted the given commentable.
+     *
+     * @param  Collection<int, User>  $users
+     * @return Collection<int, User>
+     */
+    private function rejectMuted(Collection $users, Model $commentable): Collection
+    {
+        if ($users->isEmpty()) {
+            return $users;
+        }
+
+        $mutedUserIds = MutedCommentable::query()
+            ->where('commentable_type', $commentable::class)
+            ->where('commentable_id', $commentable->getKey())
+            ->whereIn('user_id', $users->pluck('id')->all())
+            ->pluck('user_id')
+            ->all();
+
+        if ($mutedUserIds === []) {
+            return $users;
+        }
+
+        return $users
+            ->reject(fn (User $user): bool => in_array($user->id, $mutedUserIds, true))
+            ->values();
     }
 }

--- a/app/Listeners/TouchPushSubscriptionLastUsed.php
+++ b/app/Listeners/TouchPushSubscriptionLastUsed.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Listeners;
+
+use Illuminate\Notifications\Events\NotificationSent;
+use NotificationChannels\WebPush\PushSubscription;
+use NotificationChannels\WebPush\WebPushChannel;
+
+/**
+ * Update the `last_used_at` timestamp on a user's push subscriptions whenever a
+ * web-push notification is successfully sent. We touch all of the notifiable's
+ * subscriptions in one query rather than tracking which specific endpoint
+ * succeeded — accurate enough for a "last seen" indicator, much simpler than
+ * patching the vendor channel.
+ */
+class TouchPushSubscriptionLastUsed
+{
+    public function handle(NotificationSent $event): void
+    {
+        if ($event->channel !== WebPushChannel::class) {
+            return;
+        }
+
+        $notifiable = $event->notifiable;
+
+        if (! is_object($notifiable) || ! isset($notifiable->id)) {
+            return;
+        }
+
+        PushSubscription::query()
+            ->where('subscribable_type', $notifiable::class)
+            ->where('subscribable_id', $notifiable->id)
+            ->update(['last_used_at' => now()]);
+    }
+}

--- a/app/Listeners/TouchPushSubscriptionLastUsed.php
+++ b/app/Listeners/TouchPushSubscriptionLastUsed.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Listeners;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Notifications\Events\NotificationSent;
 use NotificationChannels\WebPush\PushSubscription;
 use NotificationChannels\WebPush\WebPushChannel;
@@ -25,13 +26,13 @@ class TouchPushSubscriptionLastUsed
 
         $notifiable = $event->notifiable;
 
-        if (! is_object($notifiable) || ! isset($notifiable->id)) {
+        if (! $notifiable instanceof Model) {
             return;
         }
 
         PushSubscription::query()
             ->where('subscribable_type', $notifiable::class)
-            ->where('subscribable_id', $notifiable->id)
+            ->where('subscribable_id', $notifiable->getKey())
             ->update(['last_used_at' => now()]);
     }
 }

--- a/app/Models/MutedCommentable.php
+++ b/app/Models/MutedCommentable.php
@@ -45,16 +45,15 @@ class MutedCommentable extends Model
         $mutedUserIds = static::query()
             ->where('commentable_type', $commentable::class)
             ->where('commentable_id', $commentable->getKey())
-            ->whereIn('user_id', $users->pluck('id')->all())
-            ->pluck('user_id')
-            ->all();
+            ->whereIn('user_id', $users->pluck('id'))
+            ->pluck('user_id');
 
-        if ($mutedUserIds === []) {
+        if ($mutedUserIds->isEmpty()) {
             return $users;
         }
 
         return $users
-            ->reject(fn (User $user): bool => in_array($user->id, $mutedUserIds, true))
+            ->reject(fn (User $user): bool => $mutedUserIds->contains($user->id))
             ->values();
     }
 }

--- a/app/Models/MutedCommentable.php
+++ b/app/Models/MutedCommentable.php
@@ -43,7 +43,7 @@ class MutedCommentable extends Model
         }
 
         $mutedUserIds = static::query()
-            ->where('commentable_type', $commentable::class)
+            ->where('commentable_type', $commentable->getMorphClass())
             ->where('commentable_id', $commentable->getKey())
             ->whereIn('user_id', $users->pluck('id'))
             ->pluck('user_id');

--- a/app/Models/MutedCommentable.php
+++ b/app/Models/MutedCommentable.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Support\Collection;
 
 /**
  * @property int $user_id
@@ -27,5 +28,33 @@ class MutedCommentable extends Model
     public function commentable(): MorphTo
     {
         return $this->morphTo();
+    }
+
+    /**
+     * Reject users who have muted the given commentable.
+     *
+     * @param  Collection<int, User>  $users
+     * @return Collection<int, User>
+     */
+    public static function filterMuted(Collection $users, Model $commentable): Collection
+    {
+        if ($users->isEmpty()) {
+            return $users;
+        }
+
+        $mutedUserIds = static::query()
+            ->where('commentable_type', $commentable::class)
+            ->where('commentable_id', $commentable->getKey())
+            ->whereIn('user_id', $users->pluck('id')->all())
+            ->pluck('user_id')
+            ->all();
+
+        if ($mutedUserIds === []) {
+            return $users;
+        }
+
+        return $users
+            ->reject(fn (User $user): bool => in_array($user->id, $mutedUserIds, true))
+            ->values();
     }
 }

--- a/app/Models/MutedCommentable.php
+++ b/app/Models/MutedCommentable.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+/**
+ * @property int $user_id
+ * @property string $commentable_type
+ * @property int $commentable_id
+ */
+#[Fillable(['user_id', 'commentable_type', 'commentable_id'])]
+class MutedCommentable extends Model
+{
+    /** @return BelongsTo<User, $this> */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /** @return MorphTo<Model, $this> */
+    public function commentable(): MorphTo
+    {
+        return $this->morphTo();
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -101,7 +101,7 @@ class User extends Authenticatable implements CanComment
     public function hasMuted(Model $commentable): bool
     {
         return $this->mutedCommentables()
-            ->where('commentable_type', $commentable::class)
+            ->where('commentable_type', $commentable->getMorphClass())
             ->where('commentable_id', $commentable->getKey())
             ->exists();
     }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -10,6 +10,7 @@ use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -89,5 +90,19 @@ class User extends Authenticatable implements CanComment
     public function pendingDigestItems(): HasMany
     {
         return $this->emailDigestItems()->whereNull('sent_at');
+    }
+
+    /** @return HasMany<MutedCommentable, $this> */
+    public function mutedCommentables(): HasMany
+    {
+        return $this->hasMany(MutedCommentable::class);
+    }
+
+    public function hasMuted(Model $commentable): bool
+    {
+        return $this->mutedCommentables()
+            ->where('commentable_type', $commentable::class)
+            ->where('commentable_id', $commentable->getKey())
+            ->exists();
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,6 +4,8 @@ namespace App\Providers;
 
 use App\Channels\DigestChannel;
 use App\Listeners\DispatchCommentNotifications;
+use App\Listeners\TouchPushSubscriptionLastUsed;
+use Illuminate\Notifications\Events\NotificationSent;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\URL;
@@ -43,6 +45,7 @@ class AppServiceProvider extends ServiceProvider
         }
 
         Event::listen(CommentApprovedEvent::class, DispatchCommentNotifications::class);
+        Event::listen(NotificationSent::class, TouchPushSubscriptionLastUsed::class);
 
         Notification::extend('webpush', fn ($app) => $app->make(WebPushChannel::class));
         Notification::extend('digest', fn ($app) => $app->make(DigestChannel::class));

--- a/app/Support/DeviceLabel.php
+++ b/app/Support/DeviceLabel.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+/**
+ * Human-readable device label parsed from a User-Agent string.
+ *
+ * Intentionally tiny: we want a recognizable "Chrome on macOS" style label
+ * for the manage-devices UI, not a full UA database. Unknown UAs degrade
+ * to "Browser on device" so the row still renders.
+ */
+final class DeviceLabel
+{
+    public static function fromUserAgent(?string $userAgent): string
+    {
+        if ($userAgent === null || trim($userAgent) === '') {
+            return 'Unknown device';
+        }
+
+        return self::browser($userAgent).' on '.self::os($userAgent);
+    }
+
+    private static function browser(string $userAgent): string
+    {
+        // Order matters: Edge & Opera advertise "Chrome" too, so check them first.
+        return match (true) {
+            (bool) preg_match('/\b(Edg|Edge|EdgiOS|EdgA)\b/i', $userAgent) => 'Edge',
+            (bool) preg_match('/\b(OPR|Opera)\b/i', $userAgent) => 'Opera',
+            (bool) preg_match('/\bFirefox\b/i', $userAgent) => 'Firefox',
+            (bool) preg_match('/\bChrome\b/i', $userAgent) => 'Chrome',
+            (bool) preg_match('/\bSafari\b/i', $userAgent) => 'Safari',
+            default => 'Browser',
+        };
+    }
+
+    private static function os(string $userAgent): string
+    {
+        // iPadOS UAs sometimes look like macOS, so check iPad explicitly first.
+        return match (true) {
+            (bool) preg_match('/\biPad\b/i', $userAgent) => 'iPadOS',
+            (bool) preg_match('/\b(iPhone|iPod)\b/i', $userAgent) => 'iOS',
+            (bool) preg_match('/\bAndroid\b/i', $userAgent) => 'Android',
+            (bool) preg_match('/\b(Windows NT|Windows)\b/i', $userAgent) => 'Windows',
+            (bool) preg_match('/\bMac OS X\b/i', $userAgent) => 'macOS',
+            (bool) preg_match('/\b(Linux|X11)\b/i', $userAgent) => 'Linux',
+            default => 'device',
+        };
+    }
+}

--- a/database/migrations/2026_05_19_172503_add_device_metadata_to_push_subscriptions_table.php
+++ b/database/migrations/2026_05_19_172503_add_device_metadata_to_push_subscriptions_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        Schema::connection(config('webpush.database_connection'))
+            ->table(config('webpush.table_name'), function (Blueprint $table): void {
+                $table->string('user_agent', 512)->nullable()->after('content_encoding');
+                $table->timestamp('last_used_at')->nullable()->after('user_agent');
+            });
+    }
+
+    public function down(): void
+    {
+        Schema::connection(config('webpush.database_connection'))
+            ->table(config('webpush.table_name'), function (Blueprint $table): void {
+                $table->dropColumn(['user_agent', 'last_used_at']);
+            });
+    }
+};

--- a/database/migrations/2026_05_19_174138_create_muted_commentables_table.php
+++ b/database/migrations/2026_05_19_174138_create_muted_commentables_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('muted_commentables', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->morphs('commentable');
+            $table->timestamps();
+
+            $table->unique(['user_id', 'commentable_type', 'commentable_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('muted_commentables');
+    }
+};

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,4 +1,8 @@
 import './mentions.js';
+// Loaded before echo.js so the install coachmark registers even when
+// optional services (Reverb/Pusher) fail to initialise in restricted
+// environments such as CI browsers without VITE_REVERB_APP_KEY.
+import './ios-a2hs.js';
 import './echo.js';
 import './push.js';
 import './sw-register.js';

--- a/resources/js/ios-a2hs.js
+++ b/resources/js/ios-a2hs.js
@@ -55,8 +55,12 @@ export function maybeShowCoachmark(overrides = {}) {
     if (!isIOS || isStandalone) {
         return;
     }
-    if (localStorage.getItem(DISMISSED_KEY)) {
-        return;
+    try {
+        if (localStorage.getItem(DISMISSED_KEY)) {
+            return;
+        }
+    } catch (error) {
+        // storage unavailable; show banner as if not dismissed
     }
     showBanner();
 }

--- a/resources/js/ios-a2hs.js
+++ b/resources/js/ios-a2hs.js
@@ -1,0 +1,110 @@
+/**
+ * iOS Add-to-Home-Screen coachmark.
+ *
+ * Shows a small banner to iOS Safari users (not already running as a PWA)
+ * suggesting they install Stave to their home screen so they can receive
+ * push notifications. Dismissals are stored in localStorage; users will not
+ * see the banner again on this device unless they reset the flag.
+ *
+ * The "Show install instructions" link in settings dispatches a
+ * `show-a2hs-coachmark` CustomEvent which force-shows the banner regardless
+ * of platform — so a desktop user can preview what their phone-using
+ * teammate sees.
+ */
+
+export const DISMISSED_KEY = 'stave_ios_a2hs_dismissed';
+export const BANNER_ID = 'ios-a2hs-banner';
+
+export function detectIOS() {
+    return /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
+}
+
+export function detectStandalone() {
+    return (
+        window.navigator.standalone === true ||
+        (window.matchMedia && window.matchMedia('(display-mode: standalone)').matches)
+    );
+}
+
+function showBanner() {
+    const banner = document.getElementById(BANNER_ID);
+    if (banner) {
+        banner.removeAttribute('hidden');
+    }
+}
+
+function hideBanner() {
+    const banner = document.getElementById(BANNER_ID);
+    if (banner) {
+        banner.setAttribute('hidden', '');
+    }
+}
+
+/**
+ * Show the coachmark only when running on iOS Safari, not standalone, and
+ * not previously dismissed.
+ *
+ * @param {{ isIOS?: boolean, isStandalone?: boolean }} [overrides] Optional
+ *   detection overrides — primarily for tests. Production callers should
+ *   omit this argument and let the module sniff the real environment.
+ */
+export function maybeShowCoachmark(overrides = {}) {
+    const isIOS = overrides.isIOS ?? detectIOS();
+    const isStandalone = overrides.isStandalone ?? detectStandalone();
+
+    if (!isIOS || isStandalone) {
+        return;
+    }
+    if (localStorage.getItem(DISMISSED_KEY)) {
+        return;
+    }
+    showBanner();
+}
+
+export function dismissCoachmark() {
+    try {
+        localStorage.setItem(DISMISSED_KEY, String(Date.now()));
+    } catch (error) {
+        // localStorage unavailable (private mode, quota); fall back to hiding only.
+    }
+    hideBanner();
+}
+
+export function resetCoachmarkDismissal() {
+    try {
+        localStorage.removeItem(DISMISSED_KEY);
+    } catch (error) {
+        // ignore
+    }
+}
+
+export function forceShowCoachmark() {
+    resetCoachmarkDismissal();
+    showBanner();
+}
+
+function init() {
+    maybeShowCoachmark();
+}
+
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init, { once: true });
+} else {
+    init();
+}
+
+window.addEventListener('show-a2hs-coachmark', () => {
+    forceShowCoachmark();
+});
+
+// Expose the API for the banner buttons (called via inline onclick) and tests.
+window.StaveA2HS = {
+    DISMISSED_KEY,
+    BANNER_ID,
+    detectIOS,
+    detectStandalone,
+    maybeShowCoachmark,
+    dismissCoachmark,
+    resetCoachmarkDismissal,
+    forceShowCoachmark,
+};

--- a/resources/views/components/ios-a2hs-banner.blade.php
+++ b/resources/views/components/ios-a2hs-banner.blade.php
@@ -1,0 +1,60 @@
+{{--
+    iOS Add-to-Home-Screen coachmark banner.
+    Rendered hidden by default; the `ios-a2hs.js` module reveals it when the
+    visitor is on iOS Safari, not already running standalone, and has not
+    previously dismissed it. Buttons call `window.StaveA2HS.dismissCoachmark()`.
+--}}
+<div
+    id="ios-a2hs-banner"
+    role="dialog"
+    aria-labelledby="ios-a2hs-banner-heading"
+    aria-describedby="ios-a2hs-banner-body"
+    hidden
+    class="fixed inset-x-0 bottom-0 z-50 px-3 pb-[env(safe-area-inset-bottom)]"
+>
+    <div
+        class="mx-auto mb-3 max-w-md rounded-2xl border border-zinc-200/80 bg-white/95 p-4 shadow-lg backdrop-blur dark:border-zinc-700/80 dark:bg-zinc-900/95"
+    >
+        <div class="flex items-start gap-3">
+            <img
+                src="/apple-touch-icon.png"
+                alt=""
+                aria-hidden="true"
+                class="size-10 shrink-0 rounded-lg"
+            />
+
+            <div class="min-w-0 flex-1">
+                <p id="ios-a2hs-banner-heading" class="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+                    {{ __('Install Stave for notifications') }}
+                </p>
+                <p id="ios-a2hs-banner-body" class="mt-1 flex flex-wrap items-center gap-1 text-xs text-zinc-600 dark:text-zinc-400">
+                    <span>{{ __('Tap the share button') }}</span>
+                    <flux:icon.arrow-up-on-square class="inline size-4 text-zinc-500 dark:text-zinc-400" />
+                    <span>{{ __('below, then') }}</span>
+                    <span class="font-medium text-zinc-800 dark:text-zinc-200">{{ __('Add to Home Screen') }}</span>
+                    <span>.</span>
+                </p>
+            </div>
+        </div>
+
+        <div class="mt-3 flex justify-end gap-2">
+            <flux:button
+                size="sm"
+                variant="ghost"
+                type="button"
+                onclick="window.StaveA2HS && window.StaveA2HS.dismissCoachmark()"
+            >
+                {{ __('Not now') }}
+            </flux:button>
+
+            <flux:button
+                size="sm"
+                variant="primary"
+                type="button"
+                onclick="window.StaveA2HS && window.StaveA2HS.dismissCoachmark()"
+            >
+                {{ __('Got it') }}
+            </flux:button>
+        </div>
+    </div>
+</div>

--- a/resources/views/components/ios-a2hs-banner.blade.php
+++ b/resources/views/components/ios-a2hs-banner.blade.php
@@ -6,9 +6,9 @@
 --}}
 <div
     id="ios-a2hs-banner"
-    role="dialog"
+    role="region"
     aria-labelledby="ios-a2hs-banner-heading"
-    aria-describedby="ios-a2hs-banner-body"
+    aria-live="polite"
     hidden
     class="fixed inset-x-0 bottom-0 z-50 px-3 pb-[env(safe-area-inset-bottom)]"
 >

--- a/resources/views/components/layouts/app/sidebar.blade.php
+++ b/resources/views/components/layouts/app/sidebar.blade.php
@@ -127,7 +127,9 @@
 
         {{ $slot }}
 
-        <x-ios-a2hs-banner />
+        @persist('ios-a2hs-banner')
+            <x-ios-a2hs-banner />
+        @endpersist
 
         @persist('toast')
             <flux:toast.group>

--- a/resources/views/components/layouts/app/sidebar.blade.php
+++ b/resources/views/components/layouts/app/sidebar.blade.php
@@ -127,6 +127,8 @@
 
         {{ $slot }}
 
+        <x-ios-a2hs-banner />
+
         @persist('toast')
             <flux:toast.group>
                 <flux:toast />

--- a/resources/views/livewire/mute-toggle.blade.php
+++ b/resources/views/livewire/mute-toggle.blade.php
@@ -1,26 +1,33 @@
 <?php
 
+use App\Models\Conversation;
 use App\Models\MutedCommentable;
+use App\Models\Service;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Str;
 use Livewire\Attributes\Computed;
 use Livewire\Component;
 
 new class extends Component {
     public Model $commentable;
 
-    public string $noun = 'conversation';
+    public string $noun = '';
 
-    public function mount(Model $commentable, string $noun = 'conversation'): void
+    public function mount(Model $commentable, ?string $noun = null): void
     {
         $this->commentable = $commentable;
-        $this->noun = $noun;
+        $this->noun = $noun ?? Str::lower(class_basename($commentable));
     }
 
     #[Computed]
     public function isMuted(): bool
     {
+        if (! ($this->commentable instanceof Conversation || $this->commentable instanceof Service)) {
+            return false;
+        }
+
         /** @var User|null $user */
         $user = Auth::user();
 
@@ -37,6 +44,10 @@ new class extends Component {
         $user = Auth::user();
 
         if ($user === null) {
+            return;
+        }
+
+        if (! ($this->commentable instanceof Conversation || $this->commentable instanceof Service)) {
             return;
         }
 

--- a/resources/views/livewire/mute-toggle.blade.php
+++ b/resources/views/livewire/mute-toggle.blade.php
@@ -15,6 +15,9 @@ new class extends Component {
 
     public string $noun = '';
 
+    /** @var list<class-string> */
+    private const ALLOWED_TYPES = [Conversation::class, Service::class];
+
     public function mount(Model $commentable, ?string $noun = null): void
     {
         $this->commentable = $commentable;
@@ -24,18 +27,14 @@ new class extends Component {
     #[Computed]
     public function isMuted(): bool
     {
-        if (! ($this->commentable instanceof Conversation || $this->commentable instanceof Service)) {
+        if (! $this->isSupportedCommentable()) {
             return false;
         }
 
         /** @var User|null $user */
         $user = Auth::user();
 
-        if ($user === null) {
-            return false;
-        }
-
-        return $user->hasMuted($this->commentable);
+        return $user !== null && $user->hasMuted($this->commentable);
     }
 
     public function toggle(): void
@@ -43,11 +42,7 @@ new class extends Component {
         /** @var User|null $user */
         $user = Auth::user();
 
-        if ($user === null) {
-            return;
-        }
-
-        if (! ($this->commentable instanceof Conversation || $this->commentable instanceof Service)) {
+        if ($user === null || ! $this->isSupportedCommentable()) {
             return;
         }
 
@@ -57,15 +52,18 @@ new class extends Component {
             'commentable_id' => $this->commentable->getKey(),
         ];
 
-        $existing = MutedCommentable::query()->where($attributes)->first();
+        $deleted = MutedCommentable::query()->where($attributes)->delete();
 
-        if ($existing !== null) {
-            $existing->delete();
-        } else {
+        if ($deleted === 0) {
             MutedCommentable::query()->create($attributes);
         }
 
         unset($this->isMuted);
+    }
+
+    private function isSupportedCommentable(): bool
+    {
+        return in_array($this->commentable::class, self::ALLOWED_TYPES, true);
     }
 }; ?>
 

--- a/resources/views/livewire/mute-toggle.blade.php
+++ b/resources/views/livewire/mute-toggle.blade.php
@@ -1,0 +1,90 @@
+<?php
+
+use App\Models\MutedCommentable;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Auth;
+use Livewire\Attributes\Computed;
+use Livewire\Component;
+
+new class extends Component {
+    public Model $commentable;
+
+    public string $noun = 'conversation';
+
+    public function mount(Model $commentable, string $noun = 'conversation'): void
+    {
+        $this->commentable = $commentable;
+        $this->noun = $noun;
+    }
+
+    #[Computed]
+    public function isMuted(): bool
+    {
+        /** @var User|null $user */
+        $user = Auth::user();
+
+        if ($user === null) {
+            return false;
+        }
+
+        return $user->hasMuted($this->commentable);
+    }
+
+    public function toggle(): void
+    {
+        /** @var User|null $user */
+        $user = Auth::user();
+
+        if ($user === null) {
+            return;
+        }
+
+        $attributes = [
+            'user_id' => $user->id,
+            'commentable_type' => $this->commentable::class,
+            'commentable_id' => $this->commentable->getKey(),
+        ];
+
+        $existing = MutedCommentable::query()->where($attributes)->first();
+
+        if ($existing !== null) {
+            $existing->delete();
+        } else {
+            MutedCommentable::query()->create($attributes);
+        }
+
+        unset($this->isMuted);
+    }
+}; ?>
+
+<div>
+    @if (Auth::check())
+        <flux:dropdown align="end">
+            <flux:tooltip content="{{ $this->isMuted ? __('Notifications muted') : __('Notifications on') }}">
+                <flux:button
+                    variant="ghost"
+                    size="sm"
+                    icon="{{ $this->isMuted ? 'bell-slash' : 'bell' }}"
+                    square
+                    data-test="mute-toggle"
+                    data-test-muted="{{ $this->isMuted ? 'true' : 'false' }}"
+                />
+            </flux:tooltip>
+            <flux:menu>
+                <flux:menu.item
+                    wire:click="toggle"
+                    icon="{{ $this->isMuted ? 'bell' : 'bell-slash' }}"
+                    data-test="mute-toggle-action"
+                >
+                    {{ $this->isMuted
+                        ? __('Unmute :noun', ['noun' => $noun])
+                        : __('Mute :noun', ['noun' => $noun]) }}
+                </flux:menu.item>
+                <div class="px-3 py-2 text-xs text-zinc-500 dark:text-zinc-400">
+                    {{ __('You\'ll still get notifications when @mentioned.') }}
+                </div>
+            </flux:menu>
+        </flux:dropdown>
+    @endif
+</div>

--- a/resources/views/livewire/mute-toggle.blade.php
+++ b/resources/views/livewire/mute-toggle.blade.php
@@ -48,7 +48,7 @@ new class extends Component {
 
         $attributes = [
             'user_id' => $user->id,
-            'commentable_type' => $this->commentable::class,
+            'commentable_type' => $this->commentable->getMorphClass(),
             'commentable_id' => $this->commentable->getKey(),
         ];
 

--- a/resources/views/livewire/services/discussion.blade.php
+++ b/resources/views/livewire/services/discussion.blade.php
@@ -545,9 +545,16 @@ new class extends Component {
             class="hidden w-64 shrink-0 flex-col overflow-hidden border-l border-zinc-200 lg:flex dark:border-zinc-700"
             data-test="discussion-participants"
         >
-            <div class="border-b border-zinc-200 px-4 py-3 dark:border-zinc-700">
-                <flux:heading size="sm">In this discussion</flux:heading>
-                <flux:subheading size="sm">{{ $this->participants->count() }} {{ Str::plural('person', $this->participants->count()) }}</flux:subheading>
+            <div class="flex items-start justify-between gap-2 border-b border-zinc-200 px-4 py-3 dark:border-zinc-700">
+                <div>
+                    <flux:heading size="sm">In this discussion</flux:heading>
+                    <flux:subheading size="sm">{{ $this->participants->count() }} {{ Str::plural('person', $this->participants->count()) }}</flux:subheading>
+                </div>
+                <livewire:mute-toggle
+                    :commentable="$this->service"
+                    noun="discussion"
+                    :key="'mute-toggle-service-'.$this->service->id"
+                />
             </div>
 
             <div class="min-h-0 flex-1 overflow-auto px-2 py-2">

--- a/resources/views/livewire/settings/push-subscription-manager.blade.php
+++ b/resources/views/livewire/settings/push-subscription-manager.blade.php
@@ -39,6 +39,9 @@ new class extends Component {
         }
 
         $user = Auth::user();
+        if ($user === null) {
+            return;
+        }
 
         $user->updatePushSubscription(
             $endpoint,
@@ -59,14 +62,24 @@ new class extends Component {
 
     public function removeSubscription(string $endpoint): void
     {
-        Auth::user()->deletePushSubscription($endpoint);
+        $user = Auth::user();
+        if ($user === null) {
+            return;
+        }
+
+        $user->deletePushSubscription($endpoint);
 
         $this->refreshSubscriptions();
     }
 
     public function sendTest(): void
     {
-        Auth::user()->notify(new TestNotification);
+        $user = Auth::user();
+        if ($user === null) {
+            return;
+        }
+
+        $user->notify(new TestNotification);
     }
 
     private function refreshSubscriptions(): void

--- a/resources/views/livewire/settings/push-subscription-manager.blade.php
+++ b/resources/views/livewire/settings/push-subscription-manager.blade.php
@@ -84,8 +84,12 @@ new class extends Component {
 
     private function refreshSubscriptions(): void
     {
-        /** @var User $user */
         $user = Auth::user();
+        if (! $user instanceof User) {
+            $this->subscriptions = [];
+
+            return;
+        }
 
         $this->subscriptions = $user
             ->pushSubscriptions()

--- a/resources/views/livewire/settings/push-subscription-manager.blade.php
+++ b/resources/views/livewire/settings/push-subscription-manager.blade.php
@@ -1,0 +1,214 @@
+<?php
+
+use App\Models\User;
+use App\Notifications\TestNotification;
+use App\Support\DeviceLabel;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Str;
+use Livewire\Component;
+use NotificationChannels\WebPush\PushSubscription;
+
+new class extends Component {
+    /**
+     * @var array<int, array{
+     *     endpoint: string,
+     *     label: string,
+     *     created_at: string|null,
+     *     last_used_at: string|null,
+     *     has_user_agent: bool
+     * }>
+     */
+    public array $subscriptions = [];
+
+    public function mount(): void
+    {
+        $this->refreshSubscriptions();
+    }
+
+    /**
+     * Persist a Web Push subscription supplied by the browser.
+     *
+     * @param  array{endpoint?: string, keys?: array{p256dh?: string, auth?: string}, contentEncoding?: string}  $subscription
+     */
+    public function storeSubscription(array $subscription, ?string $userAgent = null): void
+    {
+        $endpoint = $subscription['endpoint'] ?? null;
+        if (! $endpoint) {
+            return;
+        }
+
+        $user = Auth::user();
+
+        $user->updatePushSubscription(
+            $endpoint,
+            $subscription['keys']['p256dh'] ?? null,
+            $subscription['keys']['auth'] ?? null,
+            $subscription['contentEncoding'] ?? null,
+        );
+
+        PushSubscription::query()
+            ->where('endpoint', $endpoint)
+            ->update([
+                'user_agent' => $userAgent !== null ? Str::limit($userAgent, 512, '') : null,
+                'last_used_at' => now(),
+            ]);
+
+        $this->refreshSubscriptions();
+    }
+
+    public function removeSubscription(string $endpoint): void
+    {
+        Auth::user()->deletePushSubscription($endpoint);
+
+        $this->refreshSubscriptions();
+    }
+
+    public function sendTest(): void
+    {
+        Auth::user()->notify(new TestNotification);
+    }
+
+    private function refreshSubscriptions(): void
+    {
+        /** @var User $user */
+        $user = Auth::user();
+
+        $this->subscriptions = $user
+            ->pushSubscriptions()
+            ->orderByDesc('created_at')
+            ->get(['endpoint', 'user_agent', 'created_at', 'last_used_at'])
+            ->map(function (PushSubscription $subscription): array {
+                $userAgent = $subscription->getAttribute('user_agent');
+                $createdAt = $subscription->getAttribute('created_at');
+                $lastUsedAt = $subscription->getAttribute('last_used_at');
+
+                $label = $userAgent
+                    ? DeviceLabel::fromUserAgent($userAgent)
+                    : Str::limit($subscription->endpoint, 60);
+
+                return [
+                    'endpoint' => (string) $subscription->endpoint,
+                    'label' => $label,
+                    'created_at' => $createdAt instanceof Carbon ? $createdAt->isoFormat('MMM D, YYYY') : null,
+                    'last_used_at' => $lastUsedAt instanceof Carbon ? $lastUsedAt->diffForHumans() : null,
+                    'has_user_agent' => (bool) $userAgent,
+                ];
+            })
+            ->all();
+    }
+}; ?>
+
+<section
+    class="w-full"
+    x-data="{
+        permission: 'default',
+        async init() {
+            this.permission = (window.StavePush && await window.StavePush.getPermissionState()) || 'default';
+        },
+        async enable() {
+            try {
+                const subscription = await window.StavePush.subscribeToPush(
+                    @js(config('webpush.vapid.public_key'))
+                );
+                this.permission = 'granted';
+                $wire.storeSubscription(subscription, navigator.userAgent);
+            } catch (e) {
+                console.error(e);
+            }
+        },
+        async disable() {
+            const endpoint = await window.StavePush.unsubscribeFromPush();
+            if (endpoint) {
+                await $wire.removeSubscription(endpoint);
+            }
+            this.permission = 'default';
+        },
+    }"
+>
+    <div class="space-y-8">
+        <div>
+            <flux:heading>{{ __('Push notifications') }}</flux:heading>
+            <flux:subheading>{{ __('Receive a banner when teammates message you, even when Stave is closed.') }}</flux:subheading>
+
+            <template x-if="permission === 'unsupported'">
+                <flux:callout variant="warning" icon="exclamation-triangle" class="mt-4">
+                    <flux:callout.text>
+                        {{ __('Push notifications are not supported in this browser.') }}
+                    </flux:callout.text>
+                </flux:callout>
+            </template>
+
+            <template x-if="permission !== 'unsupported'">
+                <div>
+                    <div class="mt-4 flex flex-wrap items-center gap-3">
+                        <template x-if="permission !== 'granted'">
+                            <flux:button variant="primary" icon="bell" x-on:click="enable()">{{ __('Enable on this device') }}</flux:button>
+                        </template>
+
+                        <template x-if="permission === 'granted'">
+                            <flux:button variant="filled" icon="bell-slash" x-on:click="disable()">{{ __('Disable on this device') }}</flux:button>
+                        </template>
+
+                        <flux:button variant="ghost" icon="paper-airplane" wire:click="sendTest">{{ __('Send test push') }}</flux:button>
+                    </div>
+
+                    <template x-if="permission === 'denied'">
+                        <flux:callout variant="warning" icon="exclamation-triangle" class="mt-4">
+                            <flux:callout.text>
+                                {{ __('Notifications are blocked in your browser. Update the site permissions to enable push.') }}
+                            </flux:callout.text>
+                        </flux:callout>
+                    </template>
+                </div>
+            </template>
+        </div>
+
+        @if ($subscriptions)
+            <div>
+                <flux:heading size="sm">{{ __('Registered devices') }}</flux:heading>
+                <ul class="mt-3 space-y-2">
+                    @foreach ($subscriptions as $subscription)
+                        <li
+                            wire:key="sub-{{ md5($subscription['endpoint']) }}"
+                            class="flex items-center justify-between gap-3 rounded-md border border-zinc-200 px-3 py-2 dark:border-zinc-700"
+                        >
+                            <div class="flex min-w-0 items-center gap-3">
+                                <flux:icon.device-phone-mobile class="size-5 shrink-0 text-zinc-500 dark:text-zinc-400" />
+                                <div class="min-w-0">
+                                    <flux:text @class([
+                                        'truncate font-medium',
+                                        'font-mono text-xs' => ! $subscription['has_user_agent'],
+                                    ])>
+                                        {{ $subscription['label'] }}
+                                    </flux:text>
+                                    @if ($subscription['created_at'] || $subscription['last_used_at'])
+                                        <flux:subheading size="sm">
+                                            @if ($subscription['created_at'])
+                                                {{ __('Added :date', ['date' => $subscription['created_at']]) }}
+                                            @endif
+                                            @if ($subscription['created_at'] && $subscription['last_used_at'])
+                                                <span class="mx-1">&middot;</span>
+                                            @endif
+                                            @if ($subscription['last_used_at'])
+                                                {{ __('Last active :time', ['time' => $subscription['last_used_at']]) }}
+                                            @endif
+                                        </flux:subheading>
+                                    @endif
+                                </div>
+                            </div>
+                            <flux:button
+                                size="sm"
+                                variant="ghost"
+                                icon="trash"
+                                wire:click="removeSubscription({{ json_encode($subscription['endpoint']) }})"
+                            >
+                                {{ __('Remove') }}
+                            </flux:button>
+                        </li>
+                    @endforeach
+                </ul>
+            </div>
+        @endif
+    </div>
+</section>

--- a/resources/views/pages/groups/conversations/create.blade.php
+++ b/resources/views/pages/groups/conversations/create.blade.php
@@ -3,7 +3,6 @@
 use App\Models\Conversation;
 use App\Models\Group;
 use App\Models\MutedCommentable;
-use App\Models\User;
 use App\Notifications\NewConversationNotification;
 use Flux\Flux;
 use Illuminate\Database\Eloquent\Collection;
@@ -99,22 +98,7 @@ new class extends Component {
             ->where('users.id', '!=', Auth::id())
             ->get();
 
-        if ($recipients->isEmpty()) {
-            return;
-        }
-
-        $mutedUserIds = MutedCommentable::query()
-            ->where('commentable_type', $conversation::class)
-            ->where('commentable_id', $conversation->getKey())
-            ->whereIn('user_id', $recipients->pluck('id')->all())
-            ->pluck('user_id')
-            ->all();
-
-        if ($mutedUserIds !== []) {
-            $recipients = $recipients
-                ->reject(fn (User $user): bool => in_array($user->id, $mutedUserIds, true))
-                ->values();
-        }
+        $recipients = MutedCommentable::filterMuted($recipients, $conversation);
 
         if ($recipients->isEmpty()) {
             return;

--- a/resources/views/pages/groups/conversations/create.blade.php
+++ b/resources/views/pages/groups/conversations/create.blade.php
@@ -2,6 +2,8 @@
 
 use App\Models\Conversation;
 use App\Models\Group;
+use App\Models\MutedCommentable;
+use App\Models\User;
 use App\Notifications\NewConversationNotification;
 use Flux\Flux;
 use Illuminate\Database\Eloquent\Collection;
@@ -96,6 +98,27 @@ new class extends Component {
         $recipients = $this->group->members()
             ->where('users.id', '!=', Auth::id())
             ->get();
+
+        if ($recipients->isEmpty()) {
+            return;
+        }
+
+        $mutedUserIds = MutedCommentable::query()
+            ->where('commentable_type', $conversation::class)
+            ->where('commentable_id', $conversation->getKey())
+            ->whereIn('user_id', $recipients->pluck('id')->all())
+            ->pluck('user_id')
+            ->all();
+
+        if ($mutedUserIds !== []) {
+            $recipients = $recipients
+                ->reject(fn (User $user): bool => in_array($user->id, $mutedUserIds, true))
+                ->values();
+        }
+
+        if ($recipients->isEmpty()) {
+            return;
+        }
 
         Notification::send($recipients, new NewConversationNotification($conversation, Auth::user()));
     }

--- a/resources/views/pages/groups/conversations/show.blade.php
+++ b/resources/views/pages/groups/conversations/show.blade.php
@@ -993,6 +993,12 @@ new class extends Component {
                         <flux:button variant="ghost" size="sm" icon="magnifying-glass" square disabled />
                     </flux:tooltip>
 
+                    <livewire:mute-toggle
+                        :commentable="$conversation"
+                        noun="conversation"
+                        :key="'mute-toggle-conversation-'.$conversation->id"
+                    />
+
                     @can('delete', $conversation)
                         <flux:dropdown align="end">
                             <flux:button variant="ghost" size="sm" icon="ellipsis-horizontal" square />

--- a/resources/views/pages/settings/notifications.blade.php
+++ b/resources/views/pages/settings/notifications.blade.php
@@ -1,100 +1,12 @@
 <?php
 
-use App\Notifications\TestNotification;
-use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Str;
 use Livewire\Component;
 
 new class extends Component {
-    /** @var array<int, array{endpoint: string, created_at: string|null}> */
-    public array $subscriptions = [];
-
-    public function mount(): void
-    {
-        $this->refreshSubscriptions();
-    }
-
-    /**
-     * Persist a Web Push subscription supplied by the browser.
-     *
-     * @param  array{endpoint?: string, keys?: array{p256dh?: string, auth?: string}, contentEncoding?: string}  $subscription
-     */
-    public function storeSubscription(array $subscription): void
-    {
-        $endpoint = $subscription['endpoint'] ?? null;
-        if (! $endpoint) {
-            return;
-        }
-
-        Auth::user()->updatePushSubscription(
-            $endpoint,
-            $subscription['keys']['p256dh'] ?? null,
-            $subscription['keys']['auth'] ?? null,
-            $subscription['contentEncoding'] ?? null,
-        );
-
-        $this->refreshSubscriptions();
-    }
-
-    public function removeSubscription(string $endpoint): void
-    {
-        Auth::user()->deletePushSubscription($endpoint);
-
-        $this->refreshSubscriptions();
-    }
-
-    public function sendTest(): void
-    {
-        Auth::user()->notify(new TestNotification);
-    }
-
-    public function truncateEndpoint(string $endpoint): string
-    {
-        return Str::limit($endpoint, 60);
-    }
-
-    private function refreshSubscriptions(): void
-    {
-        $this->subscriptions = Auth::user()
-            ->pushSubscriptions()
-            ->orderByDesc('created_at')
-            ->get(['endpoint', 'created_at'])
-            ->map(fn ($subscription) => [
-                'endpoint' => (string) $subscription->endpoint,
-                // @phpstan-ignore-next-line property.notFound (timestamps exist on push_subscriptions table)
-                'created_at' => $subscription->created_at?->toDateTimeString(),
-            ])
-            ->all();
-    }
+    //
 }; ?>
 
-<section
-    class="w-full"
-    x-data="{
-        permission: 'default',
-        async init() {
-            this.permission = (window.StavePush && await window.StavePush.getPermissionState()) || 'default';
-        },
-        async enable() {
-            try {
-                const subscription = await window.StavePush.subscribeToPush(
-                    @js(config('webpush.vapid.public_key'))
-                );
-                this.permission = 'granted';
-                $wire.storeSubscription(subscription);
-            } catch (e) {
-                console.error(e);
-            }
-        },
-        async disable() {
-            const endpoint = await window.StavePush.unsubscribeFromPush();
-            if (endpoint) {
-                await $wire.removeSubscription(endpoint);
-            }
-            this.permission = 'default';
-        },
-    }"
->
+<section class="w-full">
     @include('partials.settings-heading')
 
     <x-settings.layout
@@ -106,65 +18,7 @@ new class extends Component {
 
             <flux:separator />
 
-            <div class="space-y-8">
-            <div>
-                <flux:heading>{{ __('Push notifications') }}</flux:heading>
-                <flux:subheading>{{ __('Receive a banner when teammates message you, even when Stave is closed.') }}</flux:subheading>
-
-                <template x-if="permission === 'unsupported'">
-                    <flux:callout variant="warning" icon="exclamation-triangle" class="mt-4">
-                        <flux:callout.text>
-                            {{ __('Push notifications are not supported in this browser.') }}
-                        </flux:callout.text>
-                    </flux:callout>
-                </template>
-
-                <template x-if="permission !== 'unsupported'">
-                    <div>
-                        <div class="mt-4 flex flex-wrap items-center gap-3">
-                            <template x-if="permission !== 'granted'">
-                                <flux:button variant="primary" icon="bell" x-on:click="enable()">{{ __('Enable on this device') }}</flux:button>
-                            </template>
-
-                            <template x-if="permission === 'granted'">
-                                <flux:button variant="filled" icon="bell-slash" x-on:click="disable()">{{ __('Disable on this device') }}</flux:button>
-                            </template>
-
-                            <flux:button variant="ghost" icon="paper-airplane" wire:click="sendTest">{{ __('Send test push') }}</flux:button>
-                        </div>
-
-                        <template x-if="permission === 'denied'">
-                            <flux:callout variant="warning" icon="exclamation-triangle" class="mt-4">
-                                <flux:callout.text>
-                                    {{ __('Notifications are blocked in your browser. Update the site permissions to enable push.') }}
-                                </flux:callout.text>
-                            </flux:callout>
-                        </template>
-                    </div>
-                </template>
-            </div>
-
-            @if ($subscriptions)
-                <div>
-                    <flux:heading size="sm">{{ __('Registered devices') }}</flux:heading>
-                    <ul class="mt-3 space-y-2">
-                        @foreach ($subscriptions as $subscription)
-                            <li wire:key="sub-{{ md5($subscription['endpoint']) }}" class="flex items-center justify-between gap-3 rounded-md border border-zinc-200 px-3 py-2 dark:border-zinc-700">
-                                <div class="min-w-0">
-                                    <flux:text class="truncate font-mono text-xs">{{ $this->truncateEndpoint($subscription['endpoint']) }}</flux:text>
-                                    @if ($subscription['created_at'])
-                                        <flux:subheading size="sm">{{ __('Added :date', ['date' => $subscription['created_at']]) }}</flux:subheading>
-                                    @endif
-                                </div>
-                                <flux:button size="sm" variant="ghost" icon="trash" wire:click="removeSubscription({{ json_encode($subscription['endpoint']) }})">
-                                    {{ __('Remove') }}
-                                </flux:button>
-                            </li>
-                        @endforeach
-                    </ul>
-                </div>
-            @endif
-            </div>
+            <livewire:settings.push-subscription-manager />
         </div>
     </x-settings.layout>
 </section>

--- a/resources/views/pages/settings/notifications.blade.php
+++ b/resources/views/pages/settings/notifications.blade.php
@@ -18,6 +18,23 @@ new class extends Component {
 
             <flux:separator />
 
+            <div class="rounded-lg border border-zinc-200 bg-zinc-50 p-4 text-sm dark:border-zinc-700 dark:bg-zinc-800/40">
+                <p class="text-zinc-700 dark:text-zinc-300">
+                    {{ __('On iPhone or iPad? Push notifications require installing Stave to your home screen first.') }}
+                </p>
+                <div class="mt-3">
+                    <flux:button
+                        size="sm"
+                        variant="ghost"
+                        type="button"
+                        icon="arrow-up-on-square"
+                        onclick="window.dispatchEvent(new CustomEvent('show-a2hs-coachmark'))"
+                    >
+                        {{ __('Show install instructions') }}
+                    </flux:button>
+                </div>
+            </div>
+
             <livewire:settings.push-subscription-manager />
         </div>
     </x-settings.layout>

--- a/tests/Browser/IosA2hsCoachmarkTest.php
+++ b/tests/Browser/IosA2hsCoachmarkTest.php
@@ -107,7 +107,8 @@ it('force-shows the banner via the show-a2hs-coachmark event regardless of platf
     $page = visit(route('dashboard'));
 
     $page->script(<<<'JS'
-        try { localStorage.setItem('stave_ios_a2hs_dismissed', String(Date.now())); } catch (e) {}
+        try { localStorage.removeItem('stave_ios_a2hs_dismissed'); } catch (e) {}
+        localStorage.setItem('stave_ios_a2hs_dismissed', String(Date.now()));
         window.dispatchEvent(new CustomEvent('show-a2hs-coachmark'));
     JS);
 
@@ -117,4 +118,8 @@ it('force-shows the banner via the show-a2hs-coachmark event regardless of platf
         '(() => JSON.stringify(localStorage.getItem("stave_ios_a2hs_dismissed")))()'
     );
     expect($flagAfterForceShow)->toBe('null');
+
+    // Defensive cleanup: ensure the key is cleared regardless of whether the
+    // force-show handler ran, so this test cannot leak state to others.
+    $page->script("try { localStorage.removeItem('stave_ios_a2hs_dismissed'); } catch (e) {}");
 });

--- a/tests/Browser/IosA2hsCoachmarkTest.php
+++ b/tests/Browser/IosA2hsCoachmarkTest.php
@@ -1,0 +1,120 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Contract for the iOS Add-to-Home-Screen coachmark banner.
+ *
+ * The banner is shown only when:
+ *   - the visitor is on iOS Safari (UA contains iPhone/iPad/iPod);
+ *   - the app is not running in standalone (installed) mode; and
+ *   - the user has not already dismissed it on this device.
+ *
+ * Detection is JS-only (no UA sniffing server-side). The module exposes
+ * `window.StaveA2HS.maybeShowCoachmark({isIOS, isStandalone})` so we can
+ * lock in the contract here without fighting Playwright's userAgent
+ * spoofing semantics.
+ */
+
+/** @group browser */
+it('shows the banner on iOS Safari when not standalone and not dismissed', function (): void {
+    $user = User::factory()->create();
+    $this->actingAs($user);
+
+    $page = visit(route('dashboard'));
+
+    $page->script(<<<'JS'
+        try { localStorage.removeItem('stave_ios_a2hs_dismissed'); } catch (e) {}
+        window.StaveA2HS.maybeShowCoachmark({ isIOS: true, isStandalone: false });
+    JS);
+
+    $page
+        ->assertVisible('#ios-a2hs-banner')
+        ->assertSee('Install Stave for notifications');
+});
+
+/** @group browser */
+it('persists dismissal via localStorage so the banner stays hidden after reload', function (): void {
+    $user = User::factory()->create();
+    $this->actingAs($user);
+
+    $page = visit(route('dashboard'));
+
+    $flagAfterDismiss = $page->script(<<<'JS'
+        (() => {
+            try { localStorage.removeItem('stave_ios_a2hs_dismissed'); } catch (e) {}
+            window.StaveA2HS.maybeShowCoachmark({ isIOS: true, isStandalone: false });
+            window.StaveA2HS.dismissCoachmark();
+            return JSON.stringify(localStorage.getItem('stave_ios_a2hs_dismissed'));
+        })()
+    JS);
+    expect($flagAfterDismiss)->not->toBe('null');
+
+    // Reload the same page/context so localStorage persists, then assert the
+    // banner stays hidden because the dismissal flag survived.
+    $page->refresh();
+    $hiddenAttr = $page->script(<<<'JS'
+        (() => {
+            window.StaveA2HS.maybeShowCoachmark({ isIOS: true, isStandalone: false });
+            return JSON.stringify(document.getElementById('ios-a2hs-banner').getAttribute('hidden'));
+        })()
+    JS);
+    expect($hiddenAttr)->not->toBe('null');
+});
+
+/** @group browser */
+it('keeps the banner hidden on non-iOS user agents', function (): void {
+    $user = User::factory()->create();
+    $this->actingAs($user);
+
+    $page = visit(route('dashboard'));
+
+    $hiddenAttr = $page->script(<<<'JS'
+        (() => {
+            try { localStorage.removeItem('stave_ios_a2hs_dismissed'); } catch (e) {}
+            window.StaveA2HS.maybeShowCoachmark({ isIOS: false, isStandalone: false });
+            return JSON.stringify(document.getElementById('ios-a2hs-banner').getAttribute('hidden'));
+        })()
+    JS);
+    expect($hiddenAttr)->not->toBe('null');
+});
+
+/** @group browser */
+it('keeps the banner hidden when running standalone on iOS', function (): void {
+    $user = User::factory()->create();
+    $this->actingAs($user);
+
+    $page = visit(route('dashboard'));
+
+    $hiddenAttr = $page->script(<<<'JS'
+        (() => {
+            try { localStorage.removeItem('stave_ios_a2hs_dismissed'); } catch (e) {}
+            window.StaveA2HS.maybeShowCoachmark({ isIOS: true, isStandalone: true });
+            return JSON.stringify(document.getElementById('ios-a2hs-banner').getAttribute('hidden'));
+        })()
+    JS);
+    expect($hiddenAttr)->not->toBe('null');
+});
+
+/** @group browser */
+it('force-shows the banner via the show-a2hs-coachmark event regardless of platform', function (): void {
+    $user = User::factory()->create();
+    $this->actingAs($user);
+
+    $page = visit(route('dashboard'));
+
+    $page->script(<<<'JS'
+        try { localStorage.setItem('stave_ios_a2hs_dismissed', String(Date.now())); } catch (e) {}
+        window.dispatchEvent(new CustomEvent('show-a2hs-coachmark'));
+    JS);
+
+    $page->assertVisible('#ios-a2hs-banner');
+
+    $flagAfterForceShow = $page->script(
+        '(() => JSON.stringify(localStorage.getItem("stave_ios_a2hs_dismissed")))()'
+    );
+    expect($flagAfterForceShow)->toBe('null');
+});

--- a/tests/Feature/MuteConversationTest.php
+++ b/tests/Feature/MuteConversationTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Enums\GroupMessaging;
 use App\Enums\MembershipStatus;
 use App\Models\Conversation;
 use App\Models\Group;
@@ -157,47 +158,42 @@ test('muting suppresses NewConversationNotification at create time', function ()
     $creator = User::factory()->create();
     $muter = User::factory()->create();
     $other = User::factory()->create();
-    $group = Group::factory()->create();
+    $group = Group::factory()->create([
+        'messaging' => GroupMessaging::ALL_MEMBERS,
+    ]);
     activateGroupMember($group, $creator);
     activateGroupMember($group, $muter);
     activateGroupMember($group, $other);
 
-    /** @var Conversation $conversation */
-    $conversation = Conversation::factory()->for($group)->create([
-        'user_id' => $creator->id,
-        'title' => 'Pre-muted',
-    ]);
+    // Pre-register a mute pointing at the Conversation row the Volt component is
+    // about to create. With RefreshDatabase, the next Conversation::id is
+    // predictable as max(id) + 1, so this exercises the real notifyMembers()
+    // path with an active mute when the conversation is created.
+    $predictedConversationId = (int) (Conversation::max('id') ?? 0) + 1;
 
     MutedCommentable::create([
         'user_id' => $muter->id,
         'commentable_type' => Conversation::class,
-        'commentable_id' => $conversation->id,
+        'commentable_id' => $predictedConversationId,
     ]);
 
     Notification::fake();
 
     $this->actingAs($creator);
 
-    $recipients = $group->members()
-        ->where('users.id', '!=', $creator->id)
-        ->get();
+    Livewire::test('pages::groups.conversations.create', ['group' => $group])
+        ->set('title', 'Heads up')
+        ->set('body', '<p>Welcome!</p>')
+        ->call('save')
+        ->assertHasNoErrors()
+        ->assertRedirect();
 
-    // Mirror the notifyMembers() path in conversations/create.blade.php.
-    $mutedUserIds = MutedCommentable::query()
-        ->where('commentable_type', Conversation::class)
-        ->where('commentable_id', $conversation->id)
-        ->whereIn('user_id', $recipients->pluck('id')->all())
-        ->pluck('user_id')
-        ->all();
-
-    $filtered = $recipients
-        ->reject(fn (User $user): bool => in_array($user->id, $mutedUserIds, true))
-        ->values();
-
-    Notification::send($filtered, new NewConversationNotification($conversation, $creator));
+    $conversation = Conversation::where('group_id', $group->id)->firstOrFail();
+    expect($conversation->id)->toBe($predictedConversationId);
 
     Notification::assertNotSentTo($muter, NewConversationNotification::class);
     Notification::assertSentTo($other, NewConversationNotification::class);
+    Notification::assertNotSentTo($creator, NewConversationNotification::class);
 });
 
 test('mute toggle Livewire component creates and deletes the mute row', function (): void {

--- a/tests/Feature/MuteConversationTest.php
+++ b/tests/Feature/MuteConversationTest.php
@@ -1,0 +1,251 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\MembershipStatus;
+use App\Models\Conversation;
+use App\Models\Group;
+use App\Models\MutedCommentable;
+use App\Models\User;
+use App\Notifications\CommentMentionNotification;
+use App\Notifications\ConversationReplyNotification;
+use App\Notifications\NewConversationNotification;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+function activateGroupMember(Group $group, User $user): void
+{
+    $group->allUsers()->attach($user, [
+        'role' => 'member',
+        'status' => MembershipStatus::ACTIVE,
+    ]);
+}
+
+test('muting a conversation suppresses ConversationReplyNotification for that user only', function (): void {
+    $author = User::factory()->create();
+    $muter = User::factory()->create();
+    $other = User::factory()->create();
+    $group = Group::factory()->create();
+    activateGroupMember($group, $author);
+    activateGroupMember($group, $muter);
+    activateGroupMember($group, $other);
+
+    /** @var Conversation $conversation */
+    $conversation = $group->conversations()->create([
+        'user_id' => $author->id,
+        'title' => 'Topic',
+        'allow_replies' => true,
+    ]);
+    $conversation->postComment('<p>Opening</p>', $author);
+    $conversation->postComment('<p>Hi</p>', $muter);
+    $conversation->postComment('<p>Hi</p>', $other);
+
+    MutedCommentable::create([
+        'user_id' => $muter->id,
+        'commentable_type' => Conversation::class,
+        'commentable_id' => $conversation->id,
+    ]);
+
+    Notification::fake();
+
+    $conversation->postComment('<p>Another from author</p>', $author);
+
+    Notification::assertNotSentTo($muter, ConversationReplyNotification::class);
+    Notification::assertSentTo($other, ConversationReplyNotification::class);
+});
+
+test('muting a conversation does not suppress CommentMentionNotification', function (): void {
+    $author = User::factory()->create();
+    $muter = User::factory()->create();
+    $group = Group::factory()->create();
+    activateGroupMember($group, $author);
+    activateGroupMember($group, $muter);
+
+    /** @var Conversation $conversation */
+    $conversation = $group->conversations()->create([
+        'user_id' => $author->id,
+        'title' => 'Topic',
+        'allow_replies' => true,
+    ]);
+
+    MutedCommentable::create([
+        'user_id' => $muter->id,
+        'commentable_type' => Conversation::class,
+        'commentable_id' => $conversation->id,
+    ]);
+
+    Notification::fake();
+
+    $conversation->postComment(
+        "<p>Hey <span data-mention=\"{$muter->id}\">@muter</span></p>",
+        $author,
+    );
+
+    Notification::assertSentTo($muter, CommentMentionNotification::class);
+    Notification::assertNotSentTo($muter, ConversationReplyNotification::class);
+});
+
+test('unmuting restores ConversationReplyNotification delivery', function (): void {
+    $author = User::factory()->create();
+    $muter = User::factory()->create();
+    $group = Group::factory()->create();
+    activateGroupMember($group, $author);
+    activateGroupMember($group, $muter);
+
+    /** @var Conversation $conversation */
+    $conversation = $group->conversations()->create([
+        'user_id' => $author->id,
+        'title' => 'Topic',
+        'allow_replies' => true,
+    ]);
+    $conversation->postComment('<p>Opening</p>', $author);
+    $conversation->postComment('<p>Hi</p>', $muter);
+
+    $mute = MutedCommentable::create([
+        'user_id' => $muter->id,
+        'commentable_type' => Conversation::class,
+        'commentable_id' => $conversation->id,
+    ]);
+
+    $mute->delete();
+
+    Notification::fake();
+
+    $conversation->postComment('<p>After unmute</p>', $author);
+
+    Notification::assertSentTo($muter, ConversationReplyNotification::class);
+});
+
+test('one user muting does not affect notifications for other users', function (): void {
+    $author = User::factory()->create();
+    $muter = User::factory()->create();
+    $other = User::factory()->create();
+    $group = Group::factory()->create();
+    activateGroupMember($group, $author);
+    activateGroupMember($group, $muter);
+    activateGroupMember($group, $other);
+
+    /** @var Conversation $conversation */
+    $conversation = $group->conversations()->create([
+        'user_id' => $author->id,
+        'title' => 'Topic',
+        'allow_replies' => true,
+    ]);
+    $conversation->postComment('<p>Opening</p>', $author);
+    $conversation->postComment('<p>Hi</p>', $muter);
+    $conversation->postComment('<p>Hi</p>', $other);
+
+    MutedCommentable::create([
+        'user_id' => $muter->id,
+        'commentable_type' => Conversation::class,
+        'commentable_id' => $conversation->id,
+    ]);
+
+    Notification::fake();
+
+    $conversation->postComment('<p>Author posts again</p>', $author);
+
+    Notification::assertSentTo($other, ConversationReplyNotification::class);
+    Notification::assertNotSentTo($muter, ConversationReplyNotification::class);
+    Notification::assertNotSentTo($author, ConversationReplyNotification::class);
+});
+
+test('muting suppresses NewConversationNotification at create time', function (): void {
+    $creator = User::factory()->create();
+    $muter = User::factory()->create();
+    $other = User::factory()->create();
+    $group = Group::factory()->create();
+    activateGroupMember($group, $creator);
+    activateGroupMember($group, $muter);
+    activateGroupMember($group, $other);
+
+    /** @var Conversation $conversation */
+    $conversation = Conversation::factory()->for($group)->create([
+        'user_id' => $creator->id,
+        'title' => 'Pre-muted',
+    ]);
+
+    MutedCommentable::create([
+        'user_id' => $muter->id,
+        'commentable_type' => Conversation::class,
+        'commentable_id' => $conversation->id,
+    ]);
+
+    Notification::fake();
+
+    $this->actingAs($creator);
+
+    $recipients = $group->members()
+        ->where('users.id', '!=', $creator->id)
+        ->get();
+
+    // Mirror the notifyMembers() path in conversations/create.blade.php.
+    $mutedUserIds = MutedCommentable::query()
+        ->where('commentable_type', Conversation::class)
+        ->where('commentable_id', $conversation->id)
+        ->whereIn('user_id', $recipients->pluck('id')->all())
+        ->pluck('user_id')
+        ->all();
+
+    $filtered = $recipients
+        ->reject(fn (User $user): bool => in_array($user->id, $mutedUserIds, true))
+        ->values();
+
+    Notification::send($filtered, new NewConversationNotification($conversation, $creator));
+
+    Notification::assertNotSentTo($muter, NewConversationNotification::class);
+    Notification::assertSentTo($other, NewConversationNotification::class);
+});
+
+test('mute toggle Livewire component creates and deletes the mute row', function (): void {
+    $user = User::factory()->create();
+    $conversation = Conversation::factory()->create();
+
+    $this->actingAs($user);
+
+    Livewire::test('mute-toggle', [
+        'commentable' => $conversation,
+        'noun' => 'conversation',
+    ])
+        ->assertSet('isMuted', false)
+        ->call('toggle')
+        ->assertSet('isMuted', true);
+
+    expect(MutedCommentable::query()->where([
+        'user_id' => $user->id,
+        'commentable_type' => Conversation::class,
+        'commentable_id' => $conversation->id,
+    ])->exists())->toBeTrue();
+
+    Livewire::test('mute-toggle', [
+        'commentable' => $conversation,
+        'noun' => 'conversation',
+    ])
+        ->assertSet('isMuted', true)
+        ->call('toggle')
+        ->assertSet('isMuted', false);
+
+    expect(MutedCommentable::query()->where([
+        'user_id' => $user->id,
+        'commentable_type' => Conversation::class,
+        'commentable_id' => $conversation->id,
+    ])->exists())->toBeFalse();
+});
+
+test('User::hasMuted reflects mute state for a commentable', function (): void {
+    $user = User::factory()->create();
+    $conversation = Conversation::factory()->create();
+
+    expect($user->hasMuted($conversation))->toBeFalse();
+
+    MutedCommentable::create([
+        'user_id' => $user->id,
+        'commentable_type' => Conversation::class,
+        'commentable_id' => $conversation->id,
+    ]);
+
+    expect($user->hasMuted($conversation))->toBeTrue();
+});

--- a/tests/Feature/MuteConversationTest.php
+++ b/tests/Feature/MuteConversationTest.php
@@ -231,6 +231,26 @@ test('mute toggle Livewire component creates and deletes the mute row', function
     ])->exists())->toBeFalse();
 });
 
+test('mute toggle ignores disallowed commentable types', function (): void {
+    $user = User::factory()->create();
+    $other = User::factory()->create();
+
+    $this->actingAs($user);
+
+    Livewire::test('mute-toggle', [
+        'commentable' => $other,
+        'noun' => 'user',
+    ])->call('toggle');
+
+    expect(MutedCommentable::query()->where([
+        'user_id' => $user->id,
+        'commentable_type' => User::class,
+        'commentable_id' => $other->id,
+    ])->exists())->toBeFalse();
+
+    expect(MutedCommentable::query()->count())->toBe(0);
+});
+
 test('User::hasMuted reflects mute state for a commentable', function (): void {
     $user = User::factory()->create();
     $conversation = Conversation::factory()->create();

--- a/tests/Feature/MuteServiceDiscussionTest.php
+++ b/tests/Feature/MuteServiceDiscussionTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\LiturgyElement;
+use App\Models\MutedCommentable;
+use App\Models\Service;
+use App\Models\User;
+use App\Notifications\CommentMentionNotification;
+use App\Notifications\ServiceDiscussionCommentNotification;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+test('muting a service discussion suppresses ServiceDiscussionCommentNotification', function (): void {
+    Notification::fake();
+
+    $author = User::factory()->create();
+    $muter = User::factory()->create();
+    $other = User::factory()->create();
+    $service = Service::factory()->create();
+
+    LiturgyElement::factory()->assignedTo($muter)->create([
+        'liturgy_type' => Service::class, 'liturgy_id' => $service->id,
+    ]);
+    LiturgyElement::factory()->assignedTo($other)->create([
+        'liturgy_type' => Service::class, 'liturgy_id' => $service->id,
+    ]);
+
+    MutedCommentable::create([
+        'user_id' => $muter->id,
+        'commentable_type' => Service::class,
+        'commentable_id' => $service->id,
+    ]);
+
+    $service->comment('<p>A note</p>', $author);
+
+    Notification::assertNotSentTo($muter, ServiceDiscussionCommentNotification::class);
+    Notification::assertSentTo($other, ServiceDiscussionCommentNotification::class);
+});
+
+test('muting a service discussion does not suppress CommentMentionNotification', function (): void {
+    Notification::fake();
+
+    $author = User::factory()->create();
+    $muter = User::factory()->create();
+    $service = Service::factory()->create();
+
+    LiturgyElement::factory()->assignedTo($muter)->create([
+        'liturgy_type' => Service::class, 'liturgy_id' => $service->id,
+    ]);
+
+    MutedCommentable::create([
+        'user_id' => $muter->id,
+        'commentable_type' => Service::class,
+        'commentable_id' => $service->id,
+    ]);
+
+    $service->comment(
+        "<p>Hey <span data-mention=\"{$muter->id}\">@muter</span></p>",
+        $author,
+    );
+
+    Notification::assertSentTo($muter, CommentMentionNotification::class);
+    Notification::assertNotSentTo($muter, ServiceDiscussionCommentNotification::class);
+});
+
+test('unmuting a service discussion restores notification delivery', function (): void {
+    $author = User::factory()->create();
+    $muter = User::factory()->create();
+    $service = Service::factory()->create();
+
+    LiturgyElement::factory()->assignedTo($muter)->create([
+        'liturgy_type' => Service::class, 'liturgy_id' => $service->id,
+    ]);
+
+    $mute = MutedCommentable::create([
+        'user_id' => $muter->id,
+        'commentable_type' => Service::class,
+        'commentable_id' => $service->id,
+    ]);
+
+    $mute->delete();
+
+    Notification::fake();
+
+    $service->comment('<p>Welcome back</p>', $author);
+
+    Notification::assertSentTo($muter, ServiceDiscussionCommentNotification::class);
+});
+
+test('one user muting a service discussion does not affect other assignees', function (): void {
+    Notification::fake();
+
+    $author = User::factory()->create();
+    $muter = User::factory()->create();
+    $other = User::factory()->create();
+    $service = Service::factory()->create();
+
+    LiturgyElement::factory()->assignedTo($muter)->create([
+        'liturgy_type' => Service::class, 'liturgy_id' => $service->id,
+    ]);
+    LiturgyElement::factory()->assignedTo($other)->create([
+        'liturgy_type' => Service::class, 'liturgy_id' => $service->id,
+    ]);
+
+    MutedCommentable::create([
+        'user_id' => $muter->id,
+        'commentable_type' => Service::class,
+        'commentable_id' => $service->id,
+    ]);
+
+    $service->comment('<p>Hi all</p>', $author);
+
+    Notification::assertNotSentTo($muter, ServiceDiscussionCommentNotification::class);
+    Notification::assertSentTo($other, ServiceDiscussionCommentNotification::class);
+});
+
+test('mute toggle Livewire component toggles mute state for a service', function (): void {
+    $user = User::factory()->create();
+    $service = Service::factory()->create();
+
+    $this->actingAs($user);
+
+    Livewire::test('mute-toggle', [
+        'commentable' => $service,
+        'noun' => 'discussion',
+    ])
+        ->assertSet('isMuted', false)
+        ->call('toggle')
+        ->assertSet('isMuted', true);
+
+    expect(MutedCommentable::query()->where([
+        'user_id' => $user->id,
+        'commentable_type' => Service::class,
+        'commentable_id' => $service->id,
+    ])->exists())->toBeTrue();
+
+    Livewire::test('mute-toggle', [
+        'commentable' => $service,
+        'noun' => 'discussion',
+    ])
+        ->call('toggle')
+        ->assertSet('isMuted', false);
+
+    expect(MutedCommentable::query()->where([
+        'user_id' => $user->id,
+        'commentable_type' => Service::class,
+        'commentable_id' => $service->id,
+    ])->exists())->toBeFalse();
+});

--- a/tests/Feature/PushSubscriptionManagerTest.php
+++ b/tests/Feature/PushSubscriptionManagerTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use App\Notifications\TestNotification;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Livewire\Livewire;
+use NotificationChannels\WebPush\PushSubscription;
+
+uses(RefreshDatabase::class);
+
+const CHROME_MAC_UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
+
+test('storeSubscription persists the user agent and last_used_at', function (): void {
+    $user = User::factory()->create();
+    $this->actingAs($user);
+
+    Livewire::test('settings.push-subscription-manager')
+        ->call('storeSubscription', [
+            'endpoint' => 'https://example.com/push/abc',
+            'keys' => ['p256dh' => 'p256dh-key', 'auth' => 'auth-token'],
+            'contentEncoding' => 'aes128gcm',
+        ], CHROME_MAC_UA)
+        ->assertHasNoErrors();
+
+    $row = PushSubscription::query()
+        ->where('endpoint', 'https://example.com/push/abc')
+        ->first();
+
+    expect($row)->not->toBeNull();
+    expect($row->getAttribute('user_agent'))->toBe(CHROME_MAC_UA);
+    expect($row->getAttribute('last_used_at'))->not->toBeNull();
+});
+
+test('storeSubscription tolerates a missing user agent', function (): void {
+    $user = User::factory()->create();
+    $this->actingAs($user);
+
+    Livewire::test('settings.push-subscription-manager')
+        ->call('storeSubscription', [
+            'endpoint' => 'https://example.com/push/no-ua',
+            'keys' => ['p256dh' => 'p256dh-key', 'auth' => 'auth-token'],
+            'contentEncoding' => 'aes128gcm',
+        ])
+        ->assertHasNoErrors();
+
+    $row = PushSubscription::query()
+        ->where('endpoint', 'https://example.com/push/no-ua')
+        ->first();
+
+    expect($row)->not->toBeNull();
+    expect($row->getAttribute('user_agent'))->toBeNull();
+});
+
+test('storeSubscription is a no-op when no endpoint is provided', function (): void {
+    $user = User::factory()->create();
+    $this->actingAs($user);
+
+    Livewire::test('settings.push-subscription-manager')
+        ->call('storeSubscription', [], CHROME_MAC_UA)
+        ->assertHasNoErrors();
+
+    expect($user->pushSubscriptions()->count())->toBe(0);
+});
+
+test('removeSubscription deletes the row for the user', function (): void {
+    $user = User::factory()->create();
+    $this->actingAs($user);
+
+    $user->updatePushSubscription(
+        'https://example.com/push/remove-me',
+        'p256dh-key',
+        'auth-token',
+        'aes128gcm',
+    );
+
+    Livewire::test('settings.push-subscription-manager')
+        ->call('removeSubscription', 'https://example.com/push/remove-me')
+        ->assertHasNoErrors();
+
+    expect($user->pushSubscriptions()->where('endpoint', 'https://example.com/push/remove-me')->exists())
+        ->toBeFalse();
+});
+
+test('sendTest dispatches the TestNotification to the current user', function (): void {
+    Notification::fake();
+
+    $user = User::factory()->create();
+    $this->actingAs($user);
+
+    Livewire::test('settings.push-subscription-manager')
+        ->call('sendTest')
+        ->assertHasNoErrors();
+
+    Notification::assertSentTo($user, TestNotification::class);
+});
+
+test('list renders the device label parsed from the user agent', function (): void {
+    $user = User::factory()->create();
+    $this->actingAs($user);
+
+    $user->updatePushSubscription(
+        'https://example.com/push/labelled',
+        'p256dh-key',
+        'auth-token',
+        'aes128gcm',
+    );
+
+    PushSubscription::query()
+        ->where('endpoint', 'https://example.com/push/labelled')
+        ->update(['user_agent' => CHROME_MAC_UA]);
+
+    Livewire::test('settings.push-subscription-manager')
+        ->assertSeeText('Chrome on macOS');
+});
+
+test('list falls back to the truncated endpoint when user_agent is null', function (): void {
+    $user = User::factory()->create();
+    $this->actingAs($user);
+
+    $user->updatePushSubscription(
+        'https://example.com/push/legacy-no-ua-aaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        'p256dh-key',
+        'auth-token',
+        'aes128gcm',
+    );
+
+    Livewire::test('settings.push-subscription-manager')
+        ->assertSeeText('https://example.com/push/legacy-no-ua')
+        ->assertDontSeeText('Chrome on macOS');
+});

--- a/tests/Feature/Settings/NotificationsSettingsTest.php
+++ b/tests/Feature/Settings/NotificationsSettingsTest.php
@@ -3,10 +3,7 @@
 declare(strict_types=1);
 
 use App\Models\User;
-use App\Notifications\TestNotification;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Facades\Notification;
-use Livewire\Livewire;
 
 uses(RefreshDatabase::class);
 
@@ -29,50 +26,11 @@ test('notifications settings page mounts the preferences sub-component', functio
         ->assertSeeText(__('Quiet hours'));
 });
 
-test('storing a subscription persists a push subscription for the user', function (): void {
+test('notifications settings page mounts the push subscription manager sub-component', function (): void {
     $user = User::factory()->create();
     $this->actingAs($user);
 
-    Livewire::test('pages::settings.notifications')
-        ->call('storeSubscription', [
-            'endpoint' => 'https://example.com/push/abc',
-            'keys' => ['p256dh' => 'p256dh-key', 'auth' => 'auth-token'],
-            'contentEncoding' => 'aes128gcm',
-        ])
-        ->assertHasNoErrors();
-
-    expect($user->pushSubscriptions()->where('endpoint', 'https://example.com/push/abc')->exists())
-        ->toBeTrue();
-});
-
-test('removing a subscription deletes it for the user', function (): void {
-    $user = User::factory()->create();
-    $this->actingAs($user);
-
-    $user->updatePushSubscription(
-        'https://example.com/push/abc',
-        'p256dh-key',
-        'auth-token',
-        'aes128gcm',
-    );
-
-    Livewire::test('pages::settings.notifications')
-        ->call('removeSubscription', 'https://example.com/push/abc')
-        ->assertHasNoErrors();
-
-    expect($user->pushSubscriptions()->where('endpoint', 'https://example.com/push/abc')->exists())
-        ->toBeFalse();
-});
-
-test('sending a test push dispatches the TestNotification to the current user', function (): void {
-    Notification::fake();
-
-    $user = User::factory()->create();
-    $this->actingAs($user);
-
-    Livewire::test('pages::settings.notifications')
-        ->call('sendTest')
-        ->assertHasNoErrors();
-
-    Notification::assertSentTo($user, TestNotification::class);
+    $this->get(route('settings.notifications'))
+        ->assertSuccessful()
+        ->assertSeeText(__('Receive a banner when teammates message you, even when Stave is closed.'));
 });

--- a/tests/Feature/TouchPushSubscriptionLastUsedTest.php
+++ b/tests/Feature/TouchPushSubscriptionLastUsedTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Listeners\TouchPushSubscriptionLastUsed;
+use App\Models\User;
+use App\Notifications\TestNotification;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Notifications\Channels\MailChannel;
+use Illuminate\Notifications\Events\NotificationSent;
+use NotificationChannels\WebPush\PushSubscription;
+use NotificationChannels\WebPush\WebPushChannel;
+
+uses(RefreshDatabase::class);
+
+test('touches last_used_at on all of the notifiables push subscriptions when a webpush notification is sent', function (): void {
+    $user = User::factory()->create();
+
+    $user->updatePushSubscription('https://example.com/push/one', 'p256dh-1', 'auth-1', 'aes128gcm');
+    $user->updatePushSubscription('https://example.com/push/two', 'p256dh-2', 'auth-2', 'aes128gcm');
+
+    // Force last_used_at to null so we can see the listener writing it.
+    PushSubscription::query()
+        ->whereIn('endpoint', ['https://example.com/push/one', 'https://example.com/push/two'])
+        ->update(['last_used_at' => null]);
+
+    $listener = new TouchPushSubscriptionLastUsed();
+    $listener->handle(new NotificationSent($user, new TestNotification(), WebPushChannel::class));
+
+    $rows = PushSubscription::query()
+        ->whereIn('endpoint', ['https://example.com/push/one', 'https://example.com/push/two'])
+        ->get();
+
+    expect($rows)->toHaveCount(2);
+    foreach ($rows as $row) {
+        expect($row->getAttribute('last_used_at'))->not->toBeNull();
+    }
+});
+
+test('ignores notifications sent over channels other than WebPushChannel', function (): void {
+    $user = User::factory()->create();
+
+    $user->updatePushSubscription('https://example.com/push/ignored', 'p256dh', 'auth', 'aes128gcm');
+
+    PushSubscription::query()
+        ->where('endpoint', 'https://example.com/push/ignored')
+        ->update(['last_used_at' => null]);
+
+    $listener = new TouchPushSubscriptionLastUsed();
+    $listener->handle(new NotificationSent($user, new TestNotification(), MailChannel::class));
+
+    $row = PushSubscription::query()
+        ->where('endpoint', 'https://example.com/push/ignored')
+        ->first();
+
+    expect($row->getAttribute('last_used_at'))->toBeNull();
+});
+
+test('does not touch push subscriptions belonging to other users', function (): void {
+    $userA = User::factory()->create();
+    $userB = User::factory()->create();
+
+    $userA->updatePushSubscription('https://example.com/push/a', 'p256dh-a', 'auth-a', 'aes128gcm');
+    $userB->updatePushSubscription('https://example.com/push/b', 'p256dh-b', 'auth-b', 'aes128gcm');
+
+    PushSubscription::query()
+        ->whereIn('endpoint', ['https://example.com/push/a', 'https://example.com/push/b'])
+        ->update(['last_used_at' => null]);
+
+    $listener = new TouchPushSubscriptionLastUsed();
+    $listener->handle(new NotificationSent($userA, new TestNotification(), WebPushChannel::class));
+
+    expect(
+        PushSubscription::query()->where('endpoint', 'https://example.com/push/a')->first()->getAttribute('last_used_at')
+    )->not->toBeNull();
+
+    expect(
+        PushSubscription::query()->where('endpoint', 'https://example.com/push/b')->first()->getAttribute('last_used_at')
+    )->toBeNull();
+});
+
+test('is registered on the NotificationSent event so push notifications keep last_used_at fresh end-to-end', function (): void {
+    $user = User::factory()->create();
+    $user->updatePushSubscription('https://example.com/push/registered', 'p256dh', 'auth', 'aes128gcm');
+
+    PushSubscription::query()
+        ->where('endpoint', 'https://example.com/push/registered')
+        ->update(['last_used_at' => null]);
+
+    event(new NotificationSent($user, new TestNotification(), WebPushChannel::class));
+
+    $row = PushSubscription::query()->where('endpoint', 'https://example.com/push/registered')->first();
+    expect($row->getAttribute('last_used_at'))->not->toBeNull();
+});

--- a/tests/Unit/DeviceLabelTest.php
+++ b/tests/Unit/DeviceLabelTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Support\DeviceLabel;
+
+it('returns "Unknown device" when the user agent is null', function (): void {
+    expect(DeviceLabel::fromUserAgent(null))->toBe('Unknown device');
+});
+
+it('returns "Unknown device" when the user agent is an empty string', function (): void {
+    expect(DeviceLabel::fromUserAgent(''))->toBe('Unknown device');
+    expect(DeviceLabel::fromUserAgent('   '))->toBe('Unknown device');
+});
+
+it('parses a representative fixture table of user agents', function (string $userAgent, string $expected): void {
+    expect(DeviceLabel::fromUserAgent($userAgent))->toBe($expected);
+})->with([
+    'Chrome on macOS' => [
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+        'Chrome on macOS',
+    ],
+    'Safari on iPhone' => [
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Mobile/15E148 Safari/604.1',
+        'Safari on iOS',
+    ],
+    'Firefox on Windows' => [
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:120.0) Gecko/20100101 Firefox/120.0',
+        'Firefox on Windows',
+    ],
+    'Edge on Android' => [
+        'Mozilla/5.0 (Linux; Android 10; SM-G973F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36 EdgA/120.0.0.0',
+        'Edge on Android',
+    ],
+    'Stave PWA standalone on iOS' => [
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148',
+        'Browser on iOS',
+    ],
+    'Chrome on Windows' => [
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+        'Chrome on Windows',
+    ],
+    'Edge on Windows' => [
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0',
+        'Edge on Windows',
+    ],
+    'Safari on iPad' => [
+        'Mozilla/5.0 (iPad; CPU OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Mobile/15E148 Safari/604.1',
+        'Safari on iPadOS',
+    ],
+    'Firefox on Linux' => [
+        'Mozilla/5.0 (X11; Linux x86_64; rv:120.0) Gecko/20100101 Firefox/120.0',
+        'Firefox on Linux',
+    ],
+    'Opera on macOS' => [
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 OPR/106.0.0.0',
+        'Opera on macOS',
+    ],
+    'Completely unknown UA' => [
+        'CustomBot/1.0 (compatible; some-crawler)',
+        'Browser on device',
+    ],
+]);


### PR DESCRIPTION
## Summary
- Adds per-conversation and per-service-discussion mute toggle (bell icon) that suppresses reply/comment notifications while still delivering @mention notifications
- Extracts the push subscription UI into a dedicated `push-subscription-manager` Livewire component with device labels parsed from User-Agent, "last active" timestamps, and a "send test push" action
- Adds an iOS Add-to-Home-Screen coachmark banner that prompts Safari users to install the PWA for push notification support, with localStorage-based dismissal and a force-show trigger from settings
- Includes migrations for `muted_commentables` table and `user_agent`/`last_used_at` columns on `push_subscriptions`

## Test plan
- [ ] Verify muting a conversation/service suppresses reply notifications but not @mention notifications
- [ ] Verify unmuting restores notification delivery
- [ ] Verify the push subscription manager shows device labels, allows removal, and sends test pushes
- [ ] Verify the iOS A2HS banner appears on iOS Safari, dismisses via localStorage, and can be force-shown from settings
- [ ] Run `php artisan test --compact` — all new and existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to mute/unmute notifications for conversations and service discussions.
  * Added iOS Add-to-Home-Screen installation coachmark banner.
  * Introduced device management in notifications settings with device labels and last activity tracking.

* **Bug Fixes**
  * Muted users are now excluded from receiving comment notifications.
  * Push subscriptions now track last-used timestamp for activity monitoring.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jpangborn/stave/pull/124?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->