### PR TITLE
Add Kamal reverb role for broadcast channel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,16 @@ RUN composer dump-autoload --optimize
 FROM node:22 AS assets
 WORKDIR /app
 
+# Vite reads VITE_* from process.env at build time and inlines them into the bundle
+ARG VITE_REVERB_APP_KEY
+ARG VITE_REVERB_HOST
+ARG VITE_REVERB_PORT
+ARG VITE_REVERB_SCHEME
+ENV VITE_REVERB_APP_KEY=${VITE_REVERB_APP_KEY} \
+    VITE_REVERB_HOST=${VITE_REVERB_HOST} \
+    VITE_REVERB_PORT=${VITE_REVERB_PORT} \
+    VITE_REVERB_SCHEME=${VITE_REVERB_SCHEME}
+
 # Copy composer vendor so assets build can see CSS/JS from PHP packages
 COPY --from=composer /app/vendor ./vendor
 

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -11,6 +11,11 @@ deploy_timeout: 60
 
 builder:
   arch: amd64
+  args:
+    VITE_REVERB_APP_KEY: <%= ENV['REVERB_APP_KEY'] %>
+    VITE_REVERB_HOST: reverb.stave.pangborn.cloud
+    VITE_REVERB_PORT: "443"
+    VITE_REVERB_SCHEME: https
   secrets:
     - COMPOSER_AUTH_JSON_BASE64
 
@@ -25,6 +30,17 @@ servers:
     cmd: php artisan queue:work --sleep=3 --tries=3 --max-time=3600
     options:
       health-cmd: "healthcheck-queue"
+      health-interval: "10s"
+  reverb:
+    hosts:
+      - 129.212.180.73
+    cmd: php artisan reverb:start --host=0.0.0.0 --port=8080 --hostname=reverb.stave.pangborn.cloud
+    proxy:
+      ssl: true
+      host: reverb.stave.pangborn.cloud
+      app_port: 8080
+    options:
+      health-cmd: "healthcheck-reverb"
       health-interval: "10s"
 
 # Credentials for your image host.


### PR DESCRIPTION
## Summary

- Adds a dedicated `reverb` role to `config/deploy.yml` that runs `php artisan reverb:start` on the existing droplet behind kamal-proxy at `reverb.stave.pangborn.cloud`, using serversideup's bundled `healthcheck-reverb` for container health.
- Threads `VITE_REVERB_*` through `builder.args` (with ERB-interpolated `REVERB_APP_KEY`) and matching `ARG`/`ENV` in the Dockerfile's assets stage so Vite bakes the websocket connection config into the JS bundle at build time. Runtime `REVERB_*` / `VAPID_*` values continue to live in the encrypted `.env.production`.

## Test plan

- [ ] Add `REVERB_APP_*`, `VAPID_*` to encrypted `.env.production` and re-encrypt.
- [ ] DNS: `A` record `reverb.stave.pangborn.cloud` → existing droplet.
- [ ] Export `REVERB_APP_KEY` in shell; run `kamal env push && kamal build push && kamal deploy`.
- [ ] `curl -I https://reverb.stave.pangborn.cloud/up` returns 200.
- [ ] Browser devtools shows a sustained WS connection to `wss://reverb.stave.pangborn.cloud`; two-browser test confirms `stave:notification` event fires cross-session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to support Reverb service integration during application deployment.
  * Added Reverb accessory service to deployment infrastructure with HTTPS support and dedicated host configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jpangborn/stave/pull/125?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->