### PR TITLE
Redesign people section with membership, offices, and drawer UI

### DIFF
--- a/app/Enums/AccessRole.php
+++ b/app/Enums/AccessRole.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Enums;
+
+enum AccessRole: string
+{
+    case ADMIN = 'admin';
+    case LITURGY_ADMIN = 'liturgy_admin';
+    case LITURGY_USER = 'liturgy_user';
+    case PASTORAL_CARE_ADMIN = 'pastoral_care_admin';
+    case PASTORAL_CARE_USER = 'pastoral_care_user';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::ADMIN => 'Administrator',
+            self::LITURGY_ADMIN => 'Liturgy Admin',
+            self::LITURGY_USER => 'Liturgy User',
+            self::PASTORAL_CARE_ADMIN => 'Pastoral Care Admin',
+            self::PASTORAL_CARE_USER => 'Pastoral Care User',
+        };
+    }
+
+    public function shortLabel(): string
+    {
+        return match ($this) {
+            self::ADMIN => 'Admin',
+            self::LITURGY_ADMIN => 'Liturgy +',
+            self::LITURGY_USER => 'Liturgy',
+            self::PASTORAL_CARE_ADMIN => 'Care +',
+            self::PASTORAL_CARE_USER => 'Care',
+        };
+    }
+
+    public function color(): string
+    {
+        return match ($this) {
+            self::ADMIN => 'zinc',
+            self::LITURGY_ADMIN, self::LITURGY_USER => 'emerald',
+            self::PASTORAL_CARE_ADMIN, self::PASTORAL_CARE_USER => 'rose',
+        };
+    }
+
+    public function icon(): string
+    {
+        return match ($this) {
+            self::ADMIN => 'shield-check',
+            self::LITURGY_ADMIN, self::LITURGY_USER => 'book-open',
+            self::PASTORAL_CARE_ADMIN, self::PASTORAL_CARE_USER => 'heart',
+        };
+    }
+
+    public function description(): string
+    {
+        return match ($this) {
+            self::ADMIN => 'Full access to all areas including billing, settings, and people.',
+            self::LITURGY_ADMIN => 'Can manage the song & reading library, templates, and assign other Liturgy users.',
+            self::LITURGY_USER => 'Can plan and edit services, view the song & reading library.',
+            self::PASTORAL_CARE_ADMIN => 'Can manage all pastoral assignments, view all notes, and reassign care relationships.',
+            self::PASTORAL_CARE_USER => 'Can see assigned congregants, message them, and write private pastoral notes.',
+        };
+    }
+}

--- a/app/Enums/GroupMembershipStatus.php
+++ b/app/Enums/GroupMembershipStatus.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Enums;
+
+enum GroupMembershipStatus: string
+{
+    case PENDING = 'pending';
+    case ACTIVE = 'active';
+    case REJECTED = 'rejected';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::PENDING => 'Pending',
+            self::ACTIVE => 'Active',
+            self::REJECTED => 'Rejected',
+        };
+    }
+
+    public function color(): string
+    {
+        return match ($this) {
+            self::PENDING => 'amber',
+            self::ACTIVE => 'green',
+            self::REJECTED => 'red',
+        };
+    }
+}

--- a/app/Enums/MembershipStatus.php
+++ b/app/Enums/MembershipStatus.php
@@ -4,25 +4,53 @@ namespace App\Enums;
 
 enum MembershipStatus: string
 {
-    case PENDING = 'pending';
-    case ACTIVE = 'active';
-    case REJECTED = 'rejected';
+    case VISITOR = 'visitor';
+    case ADHERENT = 'adherent';
+    case CATECHUMEN = 'catechumen';
+    case MEMBER = 'member';
+    case TERMINATED = 'terminated';
 
     public function label(): string
     {
         return match ($this) {
-            self::PENDING => 'Pending',
-            self::ACTIVE => 'Active',
-            self::REJECTED => 'Rejected',
+            self::VISITOR => 'Visitor',
+            self::ADHERENT => 'Adherent',
+            self::CATECHUMEN => 'Catechumen',
+            self::MEMBER => 'Member',
+            self::TERMINATED => 'Terminated',
         };
     }
 
     public function color(): string
     {
         return match ($this) {
-            self::PENDING => 'amber',
-            self::ACTIVE => 'green',
-            self::REJECTED => 'red',
+            self::VISITOR => 'zinc',
+            self::ADHERENT => 'sky',
+            self::CATECHUMEN => 'amber',
+            self::MEMBER => 'emerald',
+            self::TERMINATED => 'zinc',
+        };
+    }
+
+    public function icon(): string
+    {
+        return match ($this) {
+            self::VISITOR => 'face-smile',
+            self::ADHERENT => 'users',
+            self::CATECHUMEN => 'book-open',
+            self::MEMBER => 'home-modern',
+            self::TERMINATED => 'archive-box',
+        };
+    }
+
+    public function description(): string
+    {
+        return match ($this) {
+            self::VISITOR => 'First-time or occasional attender.',
+            self::ADHERENT => 'Regular attender, not yet pursuing membership.',
+            self::CATECHUMEN => 'In catechesis, pursuing communing membership.',
+            self::MEMBER => 'Communing member of the congregation.',
+            self::TERMINATED => 'No longer a member or attender.',
         };
     }
 }

--- a/app/Enums/Office.php
+++ b/app/Enums/Office.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Enums;
+
+enum Office: string
+{
+    case ELDER = 'elder';
+    case DEACON = 'deacon';
+    case STAFF = 'staff';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::ELDER => 'Elder',
+            self::DEACON => 'Deacon',
+            self::STAFF => 'Staff',
+        };
+    }
+
+    public function color(): string
+    {
+        return match ($this) {
+            self::ELDER => 'amber',
+            self::DEACON => 'indigo',
+            self::STAFF => 'zinc',
+        };
+    }
+
+    public function icon(): string
+    {
+        return match ($this) {
+            self::ELDER => 'star',
+            self::DEACON => 'hand-raised',
+            self::STAFF => 'briefcase',
+        };
+    }
+
+    public function description(): string
+    {
+        return match ($this) {
+            self::ELDER => 'Spiritual oversight, teaching, and pastoral care.',
+            self::DEACON => 'Mercy ministry and practical service to the congregation.',
+            self::STAFF => 'Paid staff member of the church.',
+        };
+    }
+}

--- a/app/Enums/TerminationReason.php
+++ b/app/Enums/TerminationReason.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Enums;
+
+enum TerminationReason: string
+{
+    case DECEASED = 'deceased';
+    case TRANSFERRED = 'transferred';
+    case EXCOMMUNICATED = 'excommunicated';
+    case OTHER = 'other';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::DECEASED => 'Deceased',
+            self::TRANSFERRED => 'Transferred',
+            self::EXCOMMUNICATED => 'Excommunicated',
+            self::OTHER => 'Other',
+        };
+    }
+}

--- a/app/Livewire/Forms/GroupForm.php
+++ b/app/Livewire/Forms/GroupForm.php
@@ -2,10 +2,10 @@
 
 namespace App\Livewire\Forms;
 
+use App\Enums\GroupMembershipStatus;
 use App\Enums\GroupMessaging;
 use App\Enums\GroupRole;
 use App\Enums\GroupVisibility;
-use App\Enums\MembershipStatus;
 use App\Models\Group;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
@@ -54,7 +54,7 @@ class GroupForm extends Form
 
             $group->allUsers()->attach(Auth::id(), [
                 'role' => GroupRole::LEADER,
-                'status' => MembershipStatus::ACTIVE,
+                'status' => GroupMembershipStatus::ACTIVE,
             ]);
         });
     }

--- a/app/Livewire/Forms/PersonForm.php
+++ b/app/Livewire/Forms/PersonForm.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace App\Livewire\Forms;
+
+use App\Enums\Gender;
+use App\Enums\MembershipStatus;
+use App\Enums\TerminationReason;
+use App\Models\Person;
+use Illuminate\Validation\Rule;
+use Livewire\Attributes\Validate;
+use Livewire\Form;
+
+class PersonForm extends Form
+{
+    public ?Person $person = null;
+
+    #[Validate('required|string|max:255')]
+    public string $first_name = '';
+
+    #[Validate('required|string|max:255')]
+    public string $last_name = '';
+
+    #[Validate('nullable|email|max:255')]
+    public ?string $email = null;
+
+    #[Validate('nullable|string|max:32')]
+    public ?string $phone = null;
+
+    #[Validate('nullable|string|max:255')]
+    public ?string $address_line1 = null;
+
+    #[Validate('nullable|string|max:255')]
+    public ?string $address_city = null;
+
+    #[Validate('nullable|string|size:2')]
+    public ?string $address_state = null;
+
+    #[Validate('nullable|string|max:16')]
+    public ?string $address_zip = null;
+
+    public ?string $gender = null;
+
+    public string $membership_status = MembershipStatus::VISITOR->value;
+
+    public ?string $membership_since = null;
+
+    public ?string $termination_reason = null;
+
+    public ?int $pastoral_care_elder_id = null;
+
+    public function rules(): array
+    {
+        return [
+            'gender' => ['nullable', Rule::enum(Gender::class)],
+            'membership_status' => ['required', Rule::enum(MembershipStatus::class)],
+            'termination_reason' => ['nullable', Rule::enum(TerminationReason::class)],
+            'pastoral_care_elder_id' => ['nullable', 'integer', Rule::exists('people', 'id')],
+        ];
+    }
+
+    public function setPerson(Person $person): void
+    {
+        $this->person = $person;
+
+        $this->first_name = $person->first_name;
+        $this->last_name = $person->last_name;
+        $this->email = $person->email;
+        $this->phone = $person->phone;
+        $this->address_line1 = $person->address_line1;
+        $this->address_city = $person->address_city;
+        $this->address_state = $person->address_state;
+        $this->address_zip = $person->address_zip;
+        $this->gender = $person->gender?->value;
+        $this->membership_status = $person->membership_status->value;
+        $this->membership_since = $person->membership_since?->toDateString();
+        $this->termination_reason = $person->termination_reason?->value;
+        $this->pastoral_care_elder_id = $person->pastoral_care_elder_id;
+    }
+
+    public function store(): Person
+    {
+        $this->validate();
+
+        return Person::create($this->data());
+    }
+
+    public function update(): void
+    {
+        $this->validate();
+
+        $this->person->update($this->data());
+    }
+
+    /** @return array<string, mixed> */
+    private function data(): array
+    {
+        $data = $this->only([
+            'first_name',
+            'last_name',
+            'email',
+            'phone',
+            'address_line1',
+            'address_city',
+            'address_state',
+            'address_zip',
+            'gender',
+            'membership_status',
+            'membership_since',
+            'pastoral_care_elder_id',
+        ]);
+
+        $data['termination_reason'] = $this->membership_status === MembershipStatus::TERMINATED->value
+            ? $this->termination_reason
+            : null;
+
+        return $data;
+    }
+}

--- a/app/Livewire/Forms/PersonForm.php
+++ b/app/Livewire/Forms/PersonForm.php
@@ -53,6 +53,7 @@ class PersonForm extends Form
         return [
             'gender' => ['nullable', Rule::enum(Gender::class)],
             'membership_status' => ['required', Rule::enum(MembershipStatus::class)],
+            'membership_since' => ['nullable', 'date'],
             'termination_reason' => ['nullable', Rule::enum(TerminationReason::class)],
             'pastoral_care_elder_id' => ['nullable', 'integer', Rule::exists('people', 'id')],
         ];

--- a/app/Models/Group.php
+++ b/app/Models/Group.php
@@ -2,10 +2,10 @@
 
 namespace App\Models;
 
+use App\Enums\GroupMembershipStatus;
 use App\Enums\GroupMessaging;
 use App\Enums\GroupRole;
 use App\Enums\GroupVisibility;
-use App\Enums\MembershipStatus;
 use Database\Factories\GroupFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Casts\Attribute;
@@ -51,7 +51,7 @@ class Group extends Model
     public function members(): BelongsToMany
     {
         return $this->allUsers()
-            ->wherePivot('status', MembershipStatus::ACTIVE);
+            ->wherePivot('status', GroupMembershipStatus::ACTIVE);
     }
 
     /** @return BelongsToMany<User, $this, GroupUser> */
@@ -59,14 +59,14 @@ class Group extends Model
     {
         return $this->allUsers()
             ->wherePivot('role', GroupRole::LEADER)
-            ->wherePivot('status', MembershipStatus::ACTIVE);
+            ->wherePivot('status', GroupMembershipStatus::ACTIVE);
     }
 
     /** @return BelongsToMany<User, $this, GroupUser> */
     public function pendingRequests(): BelongsToMany
     {
         return $this->allUsers()
-            ->wherePivot('status', MembershipStatus::PENDING);
+            ->wherePivot('status', GroupMembershipStatus::PENDING);
     }
 
     /** @return BelongsToMany<User, $this, GroupUser> */

--- a/app/Models/GroupUser.php
+++ b/app/Models/GroupUser.php
@@ -2,14 +2,14 @@
 
 namespace App\Models;
 
+use App\Enums\GroupMembershipStatus;
 use App\Enums\GroupRole;
-use App\Enums\MembershipStatus;
 use Illuminate\Database\Eloquent\Attributes\Table;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 
 /**
  * @property GroupRole $role
- * @property MembershipStatus $status
+ * @property GroupMembershipStatus $status
  */
 #[Table(name: 'group_user')]
 class GroupUser extends Pivot
@@ -19,7 +19,7 @@ class GroupUser extends Pivot
     {
         return [
             'role' => GroupRole::class,
-            'status' => MembershipStatus::class,
+            'status' => GroupMembershipStatus::class,
         ];
     }
 }

--- a/app/Models/Person.php
+++ b/app/Models/Person.php
@@ -108,7 +108,8 @@ class Person extends Model
      */
     public function scopeSearchedBy(Builder $query, ?string $term): void
     {
-        if (! $term) {
+        $term = trim((string) $term);
+        if ($term === '') {
             return;
         }
 

--- a/app/Models/Person.php
+++ b/app/Models/Person.php
@@ -3,20 +3,44 @@
 namespace App\Models;
 
 use App\Enums\Gender;
+use App\Enums\MembershipStatus;
+use App\Enums\TerminationReason;
 use App\Models\Traits\HasGravatar;
 use Database\Factories\PersonFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Support\Carbon;
 
+/**
+ * @property ?Gender $gender
+ * @property MembershipStatus $membership_status
+ * @property ?TerminationReason $termination_reason
+ * @property ?Carbon $membership_since
+ * @property ?Carbon $last_active_at
+ * @property ?Carbon $birth_date
+ */
 #[Fillable([
     'first_name',
     'last_name',
     'email',
+    'phone',
+    'address_line1',
+    'address_city',
+    'address_state',
+    'address_zip',
     'birth_date',
     'gender',
+    'membership_status',
+    'membership_since',
+    'termination_reason',
+    'pastoral_care_elder_id',
+    'last_active_at',
 ])]
 class Person extends Model
 {
@@ -24,8 +48,6 @@ class Person extends Model
     use HasFactory, HasGravatar;
 
     /**
-     * Get the attributes that should be cast.
-     *
      * @return array<string, string>
      */
     protected function casts(): array
@@ -33,6 +55,10 @@ class Person extends Model
         return [
             'gender' => Gender::class,
             'birth_date' => 'date',
+            'membership_status' => MembershipStatus::class,
+            'membership_since' => 'date',
+            'termination_reason' => TerminationReason::class,
+            'last_active_at' => 'datetime',
         ];
     }
 
@@ -40,6 +66,30 @@ class Person extends Model
     public function user(): HasOne
     {
         return $this->hasOne(User::class);
+    }
+
+    /** @return HasMany<PersonOffice, $this> Current offices (not yet ended). */
+    public function offices(): HasMany
+    {
+        return $this->hasMany(PersonOffice::class)->whereNull('ended_on');
+    }
+
+    /** @return HasMany<PersonOffice, $this> Offices that have ended. */
+    public function formerOffices(): HasMany
+    {
+        return $this->hasMany(PersonOffice::class)->whereNotNull('ended_on');
+    }
+
+    /** @return HasMany<PersonOffice, $this> All offices, current and former. */
+    public function allOffices(): HasMany
+    {
+        return $this->hasMany(PersonOffice::class);
+    }
+
+    /** @return BelongsTo<Person, $this> */
+    public function pastoralCareElder(): BelongsTo
+    {
+        return $this->belongsTo(Person::class, 'pastoral_care_elder_id');
     }
 
     /** @return Attribute<string, never> */
@@ -50,6 +100,22 @@ class Person extends Model
                 $value,
                 $attributes,
             ) => "{$attributes['first_name']} {$attributes['last_name']}",
+        );
+    }
+
+    /**
+     * @param  Builder<Person>  $query
+     */
+    public function scopeSearchedBy(Builder $query, ?string $term): void
+    {
+        if (! $term) {
+            return;
+        }
+
+        $query->whereAny(
+            ['first_name', 'last_name', 'email', 'phone'],
+            'like',
+            "%{$term}%",
         );
     }
 }

--- a/app/Models/PersonOffice.php
+++ b/app/Models/PersonOffice.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\Office;
+use Database\Factories\PersonOfficeFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+#[Fillable([
+    'person_id',
+    'kind',
+    'started_on',
+    'ended_on',
+    'end_reason',
+])]
+class PersonOffice extends Model
+{
+    /** @use HasFactory<PersonOfficeFactory> */
+    use HasFactory;
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'kind' => Office::class,
+            'started_on' => 'date',
+            'ended_on' => 'date',
+        ];
+    }
+
+    /** @return BelongsTo<Person, $this> */
+    public function person(): BelongsTo
+    {
+        return $this->belongsTo(Person::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -68,7 +68,8 @@ class User extends Authenticatable implements CanComment
         return DB::table('user_access_roles')
             ->where('user_id', $this->id)
             ->pluck('role')
-            ->map(fn (string $value) => AccessRole::from($value));
+            ->map(fn (string $value) => AccessRole::tryFrom($value))
+            ->filter();
     }
 
     public function hasAccessRole(AccessRole $role): bool

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -3,8 +3,9 @@
 namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
+use App\Enums\AccessRole;
 use App\Enums\DigestFrequency;
-use App\Enums\MembershipStatus;
+use App\Enums\GroupMembershipStatus;
 use App\Models\Traits\HasGravatar;
 use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
@@ -16,6 +17,8 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use NotificationChannels\WebPush\HasPushSubscriptions;
 use Spatie\Comments\Models\Concerns\InteractsWithComments;
@@ -59,6 +62,40 @@ class User extends Authenticatable implements CanComment
             ->implode('');
     }
 
+    /** @return Collection<int, AccessRole> */
+    public function accessRoles(): Collection
+    {
+        return DB::table('user_access_roles')
+            ->where('user_id', $this->id)
+            ->pluck('role')
+            ->map(fn (string $value) => AccessRole::from($value));
+    }
+
+    public function hasAccessRole(AccessRole $role): bool
+    {
+        return DB::table('user_access_roles')
+            ->where('user_id', $this->id)
+            ->where('role', $role->value)
+            ->exists();
+    }
+
+    public function grantAccessRole(AccessRole $role): void
+    {
+        DB::table('user_access_roles')->insertOrIgnore([
+            'user_id' => $this->id,
+            'role' => $role->value,
+            'created_at' => now(),
+        ]);
+    }
+
+    public function revokeAccessRole(AccessRole $role): void
+    {
+        DB::table('user_access_roles')
+            ->where('user_id', $this->id)
+            ->where('role', $role->value)
+            ->delete();
+    }
+
     /** @return BelongsTo<Person, $this> */
     public function person(): BelongsTo
     {
@@ -71,7 +108,7 @@ class User extends Authenticatable implements CanComment
         return $this->belongsToMany(Group::class)
             ->withPivot('role', 'status')
             ->withTimestamps()
-            ->wherePivot('status', MembershipStatus::ACTIVE);
+            ->wherePivot('status', GroupMembershipStatus::ACTIVE);
     }
 
     /** @return HasMany<NotificationPreference, $this> */

--- a/app/Policies/GroupPolicy.php
+++ b/app/Policies/GroupPolicy.php
@@ -2,8 +2,8 @@
 
 namespace App\Policies;
 
+use App\Enums\GroupMembershipStatus;
 use App\Enums\GroupVisibility;
-use App\Enums\MembershipStatus;
 use App\Models\Group;
 use App\Models\User;
 
@@ -34,7 +34,7 @@ class GroupPolicy
 
         return ! $group->allUsers()
             ->where('user_id', $user->id)
-            ->where('status', '!=', MembershipStatus::REJECTED)
+            ->where('status', '!=', GroupMembershipStatus::REJECTED)
             ->exists();
     }
 

--- a/database/factories/GroupFactory.php
+++ b/database/factories/GroupFactory.php
@@ -2,10 +2,10 @@
 
 namespace Database\Factories;
 
+use App\Enums\GroupMembershipStatus;
 use App\Enums\GroupMessaging;
 use App\Enums\GroupRole;
 use App\Enums\GroupVisibility;
-use App\Enums\MembershipStatus;
 use App\Models\Conversation;
 use App\Models\Group;
 use App\Models\User;
@@ -39,7 +39,7 @@ class GroupFactory extends Factory
         return $this->state(['visibility' => GroupVisibility::PRIVATE]);
     }
 
-    public function withMembers(int $count = 3, MembershipStatus $status = MembershipStatus::ACTIVE, GroupRole $role = GroupRole::MEMBER): self
+    public function withMembers(int $count = 3, GroupMembershipStatus $status = GroupMembershipStatus::ACTIVE, GroupRole $role = GroupRole::MEMBER): self
     {
         return $this->afterCreating(function (Group $group) use ($count, $status, $role): void {
             User::factory()->count($count)->create()->each(function (User $user) use ($group, $status, $role): void {

--- a/database/factories/PersonFactory.php
+++ b/database/factories/PersonFactory.php
@@ -3,6 +3,7 @@
 namespace Database\Factories;
 
 use App\Enums\Gender;
+use App\Enums\MembershipStatus;
 use App\Models\Person;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
@@ -12,18 +13,48 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 class PersonFactory extends Factory
 {
     /**
-     * Define the model's default state.
-     *
      * @return array<string, mixed>
      */
     public function definition(): array
     {
         return [
-            'first_name' => fake()->name(),
-            'last_name' => fake()->name(),
+            'first_name' => fake()->firstName(),
+            'last_name' => fake()->lastName(),
             'email' => fake()->unique()->safeEmail(),
+            'phone' => fake()->optional(0.7)->phoneNumber(),
+            'address_line1' => fake()->optional(0.6)->streetAddress(),
+            'address_city' => fake()->optional(0.6)->city(),
+            'address_state' => fake()->optional(0.6)->stateAbbr(),
+            'address_zip' => fake()->optional(0.6)->postcode(),
             'birth_date' => fake()->date(),
             'gender' => fake()->randomElement(Gender::cases()),
+            'membership_status' => fake()->randomElement([
+                MembershipStatus::VISITOR,
+                MembershipStatus::ADHERENT,
+                MembershipStatus::CATECHUMEN,
+                MembershipStatus::MEMBER,
+            ]),
+            'membership_since' => fake()->optional(0.7)->date(),
         ];
+    }
+
+    public function visitor(): self
+    {
+        return $this->state(['membership_status' => MembershipStatus::VISITOR]);
+    }
+
+    public function adherent(): self
+    {
+        return $this->state(['membership_status' => MembershipStatus::ADHERENT]);
+    }
+
+    public function catechumen(): self
+    {
+        return $this->state(['membership_status' => MembershipStatus::CATECHUMEN]);
+    }
+
+    public function member(): self
+    {
+        return $this->state(['membership_status' => MembershipStatus::MEMBER]);
     }
 }

--- a/database/factories/PersonOfficeFactory.php
+++ b/database/factories/PersonOfficeFactory.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\Office;
+use App\Models\Person;
+use App\Models\PersonOffice;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<PersonOffice>
+ */
+class PersonOfficeFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'person_id' => Person::factory(),
+            'kind' => fake()->randomElement(Office::cases()),
+            'started_on' => fake()->dateTimeBetween('-5 years', '-1 month'),
+            'ended_on' => null,
+            'end_reason' => null,
+        ];
+    }
+
+    public function ended(?string $reason = null): self
+    {
+        return $this->state(fn (array $attributes): array => [
+            'ended_on' => fake()->dateTimeBetween($attributes['started_on'], 'now'),
+            'end_reason' => $reason ?? fake()->sentence(),
+        ]);
+    }
+
+    public function elder(): self
+    {
+        return $this->state(['kind' => Office::ELDER]);
+    }
+
+    public function deacon(): self
+    {
+        return $this->state(['kind' => Office::DEACON]);
+    }
+
+    public function staff(): self
+    {
+        return $this->state(['kind' => Office::STAFF]);
+    }
+}

--- a/database/migrations/2026_05_25_185514_add_access_roles_to_users_table.php
+++ b/database/migrations/2026_05_25_185514_add_access_roles_to_users_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('user_access_roles', function (Blueprint $table): void {
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('role');
+            $table->timestamp('created_at')->nullable();
+
+            $table->unique(['user_id', 'role']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('user_access_roles');
+    }
+};

--- a/database/migrations/2026_05_25_185514_add_contact_and_membership_to_people_table.php
+++ b/database/migrations/2026_05_25_185514_add_contact_and_membership_to_people_table.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('people', function (Blueprint $table): void {
+            $table->string('phone')->nullable()->after('email');
+            $table->string('address_line1')->nullable()->after('phone');
+            $table->string('address_city')->nullable()->after('address_line1');
+            $table->string('address_state', 2)->nullable()->after('address_city');
+            $table->string('address_zip', 16)->nullable()->after('address_state');
+
+            $table->string('membership_status')->default('visitor')->after('gender');
+            $table->date('membership_since')->nullable()->after('membership_status');
+            $table->string('termination_reason')->nullable()->after('membership_since');
+
+            $table->foreignId('pastoral_care_elder_id')
+                ->nullable()
+                ->after('termination_reason')
+                ->constrained('people')
+                ->nullOnDelete();
+
+            $table->timestamp('last_active_at')->nullable()->after('pastoral_care_elder_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('people', function (Blueprint $table): void {
+            $table->dropForeign(['pastoral_care_elder_id']);
+            $table->dropColumn([
+                'phone',
+                'address_line1',
+                'address_city',
+                'address_state',
+                'address_zip',
+                'membership_status',
+                'membership_since',
+                'termination_reason',
+                'pastoral_care_elder_id',
+                'last_active_at',
+            ]);
+        });
+    }
+};

--- a/database/migrations/2026_05_25_185514_create_person_offices_table.php
+++ b/database/migrations/2026_05_25_185514_create_person_offices_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('person_offices', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('person_id')->constrained('people')->cascadeOnDelete();
+            $table->string('kind');
+            $table->date('started_on');
+            $table->date('ended_on')->nullable();
+            $table->string('end_reason')->nullable();
+            $table->timestamps();
+
+            $table->index(['person_id', 'ended_on']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('person_offices');
+    }
+};

--- a/database/seeders/GroupSeeder.php
+++ b/database/seeders/GroupSeeder.php
@@ -2,8 +2,8 @@
 
 namespace Database\Seeders;
 
+use App\Enums\GroupMembershipStatus;
 use App\Enums\GroupRole;
-use App\Enums\MembershipStatus;
 use App\Models\Group;
 use App\Models\User;
 use Illuminate\Database\Seeder;
@@ -26,13 +26,13 @@ class GroupSeeder extends Seeder
 
             $group->allUsers()->attach($members->first()->id, [
                 'role' => GroupRole::LEADER,
-                'status' => MembershipStatus::ACTIVE,
+                'status' => GroupMembershipStatus::ACTIVE,
             ]);
 
             $members->skip(1)->each(function (User $user) use ($group) {
                 $group->allUsers()->attach($user->id, [
                     'role' => fake()->randomElement(GroupRole::cases()),
-                    'status' => fake()->randomElement(MembershipStatus::cases()),
+                    'status' => fake()->randomElement(GroupMembershipStatus::cases()),
                 ]);
             });
         });

--- a/resources/js/echo.js
+++ b/resources/js/echo.js
@@ -3,21 +3,25 @@ import Pusher from 'pusher-js';
 
 window.Pusher = Pusher;
 
-window.Echo = new Echo({
-    broadcaster: 'reverb',
-    key: import.meta.env.VITE_REVERB_APP_KEY,
-    wsHost: import.meta.env.VITE_REVERB_HOST,
-    wsPort: import.meta.env.VITE_REVERB_PORT ?? 80,
-    wssPort: import.meta.env.VITE_REVERB_PORT ?? 443,
-    forceTLS: (import.meta.env.VITE_REVERB_SCHEME ?? 'https') === 'https',
-    enabledTransports: ['ws', 'wss'],
-});
+const reverbKey = import.meta.env.VITE_REVERB_APP_KEY;
 
-const userId = document.querySelector('meta[name="user-id"]')?.getAttribute('content');
+if (reverbKey) {
+    window.Echo = new Echo({
+        broadcaster: 'reverb',
+        key: reverbKey,
+        wsHost: import.meta.env.VITE_REVERB_HOST,
+        wsPort: import.meta.env.VITE_REVERB_PORT ?? 80,
+        wssPort: import.meta.env.VITE_REVERB_PORT ?? 443,
+        forceTLS: (import.meta.env.VITE_REVERB_SCHEME ?? 'https') === 'https',
+        enabledTransports: ['ws', 'wss'],
+    });
 
-if (userId) {
-    window.Echo.private(`App.Models.User.${userId}`)
-        .notification((notification) => {
-            window.dispatchEvent(new CustomEvent('stave:notification', { detail: notification }));
-        });
+    const userId = document.querySelector('meta[name="user-id"]')?.getAttribute('content');
+
+    if (userId) {
+        window.Echo.private(`App.Models.User.${userId}`)
+            .notification((notification) => {
+                window.dispatchEvent(new CustomEvent('stave:notification', { detail: notification }));
+            });
+    }
 }

--- a/resources/views/components/membership-badge.blade.php
+++ b/resources/views/components/membership-badge.blade.php
@@ -1,0 +1,19 @@
+@props([
+    'status',
+    'reason' => null,
+    'size' => 'sm',
+])
+
+@php
+    $title = $status->label() . ($reason ? ' — ' . $reason->label() : '');
+@endphp
+
+<flux:badge
+    :color="$status->color()"
+    :icon="$status->icon()"
+    :size="$size"
+    :title="$title"
+    {{ $attributes }}
+>
+    {{ $status->label() }}
+</flux:badge>

--- a/resources/views/components/office-chip.blade.php
+++ b/resources/views/components/office-chip.blade.php
@@ -1,0 +1,14 @@
+@props([
+    'kind',
+    'size' => 'sm',
+])
+
+<flux:badge
+    :color="$kind->color()"
+    :icon="$kind->icon()"
+    :size="$size"
+    :title="$kind->label() . ' — ' . $kind->description()"
+    {{ $attributes }}
+>
+    {{ $kind->label() }}
+</flux:badge>

--- a/resources/views/components/person-avatar.blade.php
+++ b/resources/views/components/person-avatar.blade.php
@@ -1,0 +1,15 @@
+@props([
+    'person',
+    'size' => 'sm',
+    'circle' => false,
+])
+
+<flux:avatar
+    :name="$person->full_name"
+    :src="$person->gravatar"
+    :size="$size"
+    :circle="$circle"
+    color="auto"
+    :color:seed="$person->id"
+    {{ $attributes }}
+/>

--- a/resources/views/components/role-pill.blade.php
+++ b/resources/views/components/role-pill.blade.php
@@ -1,0 +1,15 @@
+@props([
+    'role',
+    'short' => false,
+    'size' => 'sm',
+])
+
+<flux:badge
+    :color="$role->color()"
+    :icon="$role->icon()"
+    :size="$size"
+    :title="$role->description()"
+    {{ $attributes }}
+>
+    {{ $short ? $role->shortLabel() : $role->label() }}
+</flux:badge>

--- a/resources/views/livewire/people/add-modal.blade.php
+++ b/resources/views/livewire/people/add-modal.blade.php
@@ -1,0 +1,71 @@
+<?php
+
+use App\Livewire\Forms\PersonForm;
+use Flux\Flux;
+use Livewire\Component;
+
+new class extends Component
+{
+    public PersonForm $form;
+
+    public function save(bool $thenOpen = false): void
+    {
+        $person = $this->form->store();
+
+        $this->form->reset();
+        Flux::modal('add-person')->close();
+        Flux::toast(variant: 'success', text: "Added {$person->full_name}.");
+
+        $this->dispatch('person-added', personId: $person->id);
+
+        if ($thenOpen) {
+            $this->dispatch('open-person-drawer', personId: $person->id)->to('people.drawer');
+        }
+    }
+}; ?>
+
+<div>
+    <flux:modal name="add-person" class="w-[28rem]">
+        <form wire:submit="save" class="space-y-6">
+            <div class="flex items-start gap-3">
+                <div class="grid size-10 place-items-center rounded-lg bg-emerald-50 dark:bg-emerald-950 text-emerald-700 dark:text-emerald-300 ring-1 ring-emerald-100 dark:ring-emerald-900 shrink-0">
+                    <flux:icon name="user-plus" class="size-5" />
+                </div>
+                <div class="flex-1">
+                    <flux:heading size="lg">Add a person</flux:heading>
+                    <flux:subheading>Start with the basics. You can fill in phone, address, and access in the profile.</flux:subheading>
+                </div>
+            </div>
+
+            <div class="grid grid-cols-2 gap-3">
+                <flux:field>
+                    <flux:label>First name</flux:label>
+                    <flux:input wire:model="form.first_name" autofocus placeholder="Jane" />
+                    <flux:error name="form.first_name" />
+                </flux:field>
+                <flux:field>
+                    <flux:label>Last name</flux:label>
+                    <flux:input wire:model="form.last_name" placeholder="Doe" />
+                    <flux:error name="form.last_name" />
+                </flux:field>
+            </div>
+
+            <flux:field>
+                <flux:label>Email</flux:label>
+                <flux:input wire:model="form.email" type="email" icon="envelope" placeholder="jane.doe@example.com" />
+                <flux:error name="form.email" />
+            </flux:field>
+
+            <div class="flex items-center justify-between gap-2 pt-1">
+                <flux:button variant="ghost" wire:click="save(true)" type="button">Save &amp; open profile →</flux:button>
+
+                <div class="flex gap-2">
+                    <flux:modal.close>
+                        <flux:button variant="ghost" type="button">Cancel</flux:button>
+                    </flux:modal.close>
+                    <flux:button type="submit" variant="primary">Add Person</flux:button>
+                </div>
+            </div>
+        </form>
+    </flux:modal>
+</div>

--- a/resources/views/livewire/people/card.blade.php
+++ b/resources/views/livewire/people/card.blade.php
@@ -1,0 +1,61 @@
+<?php
+
+use App\Models\Person;
+use Livewire\Component;
+
+new class extends Component
+{
+    public Person $person;
+
+    public string $density = 'spacious';
+
+    public function open(): void
+    {
+        $this->dispatch('open-person-drawer', personId: $this->person->id)->to('people.drawer');
+    }
+}; ?>
+
+<button
+    type="button"
+    wire:click="open"
+    @class([
+        'group flex flex-col gap-2.5 text-left bg-white dark:bg-zinc-900 rounded-lg ring-1 ring-zinc-200 dark:ring-zinc-700 hover:ring-zinc-300 dark:hover:ring-zinc-600 hover:shadow-sm transition cursor-pointer',
+        'p-4' => $density === 'spacious',
+        'p-3' => $density === 'compact',
+    ])
+>
+    <div class="flex items-center gap-3">
+        <x-person-avatar :person="$person" :size="$density === 'compact' ? 'sm' : 'md'" />
+        <div class="flex-1 min-w-0">
+            <div class="font-medium text-zinc-900 dark:text-white truncate">{{ $person->full_name }}</div>
+            @if ($person->email)
+                <div class="text-xs text-zinc-500 truncate">{{ $person->email }}</div>
+            @endif
+        </div>
+    </div>
+
+    <div class="flex flex-wrap items-center gap-1.5 min-h-[1.5rem]">
+        <x-membership-badge :status="$person->membership_status" :reason="$person->termination_reason" />
+        @foreach ($person->offices as $office)
+            <flux:badge
+                size="sm"
+                :color="$office->kind->color()"
+                :icon="$office->kind->icon()"
+                :title="$office->kind->label()"
+            />
+        @endforeach
+    </div>
+
+    @if ($person->phone || $person->address_city)
+        <div class="mt-auto pt-2 border-t border-zinc-100 dark:border-zinc-800 grid grid-cols-[auto_1fr] gap-x-2 gap-y-1 text-xs text-zinc-500">
+            @if ($person->phone)
+                <flux:icon name="phone" variant="micro" class="size-3.5" />
+                <div class="text-zinc-700 dark:text-zinc-300 tabular-nums">{{ $person->phone }}</div>
+            @endif
+            @if ($person->address_city)
+                <flux:icon name="map-pin" variant="micro" class="size-3.5" />
+                <div>{{ $person->address_city }}@if ($person->address_state), {{ $person->address_state }}@endif</div>
+            @endif
+        </div>
+    @endif
+</button>

--- a/resources/views/livewire/people/drawer.blade.php
+++ b/resources/views/livewire/people/drawer.blade.php
@@ -99,6 +99,10 @@ new class extends Component
 
     public function addOffice(): void
     {
+        if (! $this->person) {
+            return;
+        }
+
         $this->validate([
             'newOffice' => ['required', Rule::enum(Office::class)],
             'newOfficeStartedOn' => ['required', 'date'],
@@ -120,6 +124,10 @@ new class extends Component
 
     public function endOffice(int $officeId, ?string $reason = null): void
     {
+        if (! $this->person) {
+            return;
+        }
+
         $office = PersonOffice::where('person_id', $this->person->id)->findOrFail($officeId);
         $office->update([
             'ended_on' => now()->toDateString(),
@@ -138,7 +146,10 @@ new class extends Component
         }
 
         $user = $this->person->user;
-        $accessRole = AccessRole::from($role);
+        $accessRole = AccessRole::tryFrom($role);
+        if (! $accessRole) {
+            return;
+        }
 
         $user->hasAccessRole($accessRole)
             ? $user->revokeAccessRole($accessRole)

--- a/resources/views/livewire/people/drawer.blade.php
+++ b/resources/views/livewire/people/drawer.blade.php
@@ -1,0 +1,380 @@
+<?php
+
+use App\Enums\AccessRole;
+use App\Enums\Gender;
+use App\Enums\MembershipStatus;
+use App\Enums\Office;
+use App\Enums\TerminationReason;
+use App\Livewire\Forms\PersonForm;
+use App\Models\Person;
+use App\Models\PersonOffice;
+use Flux\Flux;
+use Illuminate\Validation\Rule;
+use Livewire\Attributes\Computed;
+use Livewire\Attributes\On;
+use Livewire\Component;
+
+new class extends Component
+{
+    public ?int $personId = null;
+
+    public PersonForm $form;
+
+    public ?string $newOffice = null;
+
+    public string $newOfficeStartedOn;
+
+    public function mount(): void
+    {
+        $this->newOfficeStartedOn = now()->toDateString();
+    }
+
+    #[Computed]
+    public function person(): ?Person
+    {
+        if (! $this->personId) {
+            return null;
+        }
+
+        return Person::with(['allOffices', 'user', 'pastoralCareElder'])->find($this->personId);
+    }
+
+    /** @return \Illuminate\Support\Collection<int, Person> */
+    #[Computed]
+    public function elderCandidates()
+    {
+        return Person::query()
+            ->whereHas('offices', fn ($q) => $q->where('kind', Office::ELDER))
+            ->when($this->person, fn ($q) => $q->where('id', '!=', $this->person->id))
+            ->orderBy('last_name')
+            ->get();
+    }
+
+    #[On('open-person-drawer')]
+    public function openPerson(int $personId): void
+    {
+        $this->personId = $personId;
+        $this->loadForm();
+        Flux::modal('person-drawer')->show();
+    }
+
+    private function loadForm(): void
+    {
+        $person = $this->person;
+
+        if ($person) {
+            $this->form->setPerson($person);
+        }
+    }
+
+    public function save(): void
+    {
+        if (! $this->person) {
+            return;
+        }
+
+        $this->form->update();
+
+        Flux::toast(variant: 'success', text: 'Saved.');
+        Flux::modal('person-drawer')->close();
+
+        $this->dispatch('person-saved', personId: $this->person->id);
+    }
+
+    public function delete(): void
+    {
+        if (! $this->person) {
+            return;
+        }
+
+        $id = $this->person->id;
+        $this->person->delete();
+
+        Flux::toast(variant: 'danger', text: 'Person deleted.');
+        Flux::modal('person-drawer')->close();
+
+        $this->personId = null;
+        $this->dispatch('person-deleted', personId: $id);
+    }
+
+    public function addOffice(): void
+    {
+        $this->validate([
+            'newOffice' => ['required', Rule::enum(Office::class)],
+            'newOfficeStartedOn' => ['required', 'date'],
+        ]);
+
+        PersonOffice::create([
+            'person_id' => $this->person->id,
+            'kind' => $this->newOffice,
+            'started_on' => $this->newOfficeStartedOn,
+        ]);
+
+        $this->newOffice = null;
+        $this->newOfficeStartedOn = now()->toDateString();
+
+        unset($this->person);
+
+        Flux::toast(variant: 'success', text: 'Office added.');
+    }
+
+    public function endOffice(int $officeId, ?string $reason = null): void
+    {
+        $office = PersonOffice::where('person_id', $this->person->id)->findOrFail($officeId);
+        $office->update([
+            'ended_on' => now()->toDateString(),
+            'end_reason' => $reason,
+        ]);
+
+        unset($this->person);
+
+        Flux::toast(variant: 'success', text: 'Office ended.');
+    }
+
+    public function toggleAccessRole(string $role): void
+    {
+        if (! $this->person?->user) {
+            return;
+        }
+
+        $user = $this->person->user;
+        $accessRole = AccessRole::from($role);
+
+        $user->hasAccessRole($accessRole)
+            ? $user->revokeAccessRole($accessRole)
+            : $user->grantAccessRole($accessRole);
+
+        unset($this->person);
+
+        Flux::toast(variant: 'success', text: 'Access updated.');
+    }
+}; ?>
+
+<div>
+    <flux:modal variant="flyout" name="person-drawer" class="!w-[36rem] max-w-[96vw]">
+        @if ($this->person)
+            @php($person = $this->person)
+
+            <div class="space-y-1">
+                <div class="flex items-start gap-3">
+                    <x-person-avatar :person="$person" size="lg" />
+                    <div class="flex-1 min-w-0">
+                        <flux:heading size="lg">{{ $person->full_name }}</flux:heading>
+                        @if ($person->email)
+                            <a href="mailto:{{ $person->email }}" class="text-sm text-emerald-700 dark:text-emerald-300 underline underline-offset-2 break-all">{{ $person->email }}</a>
+                        @endif
+                        <div class="mt-2 flex flex-wrap gap-1.5">
+                            <x-membership-badge :status="$person->membership_status" :reason="$person->termination_reason" />
+                            @foreach ($person->offices as $office)
+                                <x-office-chip :kind="$office->kind" />
+                            @endforeach
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <flux:separator class="my-5" />
+
+            <form wire:submit="save" class="space-y-6">
+                {{-- Contact --}}
+                <section>
+                    <flux:heading class="!text-xs uppercase tracking-wider text-zinc-500 mb-2">Contact</flux:heading>
+                    <div class="grid grid-cols-2 gap-3">
+                        <flux:field>
+                            <flux:label>First name</flux:label>
+                            <flux:input wire:model="form.first_name" />
+                            <flux:error name="form.first_name" />
+                        </flux:field>
+                        <flux:field>
+                            <flux:label>Last name</flux:label>
+                            <flux:input wire:model="form.last_name" />
+                            <flux:error name="form.last_name" />
+                        </flux:field>
+                        <flux:field>
+                            <flux:label>Email</flux:label>
+                            <flux:input wire:model="form.email" type="email" icon="envelope" />
+                            <flux:error name="form.email" />
+                        </flux:field>
+                        <flux:field>
+                            <flux:label>Phone</flux:label>
+                            <flux:input wire:model="form.phone" icon="phone" placeholder="(555) 123-4567" />
+                            <flux:error name="form.phone" />
+                        </flux:field>
+                    </div>
+                    <flux:field class="mt-3">
+                        <flux:label>Street address</flux:label>
+                        <flux:input wire:model="form.address_line1" icon="map-pin" />
+                    </flux:field>
+                    <div class="grid grid-cols-[2fr_1fr_1fr] gap-3 mt-3">
+                        <flux:field>
+                            <flux:label>City</flux:label>
+                            <flux:input wire:model="form.address_city" />
+                        </flux:field>
+                        <flux:field>
+                            <flux:label>State</flux:label>
+                            <flux:input wire:model="form.address_state" maxlength="2" />
+                        </flux:field>
+                        <flux:field>
+                            <flux:label>ZIP</flux:label>
+                            <flux:input wire:model="form.address_zip" />
+                        </flux:field>
+                    </div>
+                </section>
+
+                {{-- Membership --}}
+                <section>
+                    <flux:heading class="!text-xs uppercase tracking-wider text-zinc-500 mb-2">Membership</flux:heading>
+                    <flux:select wire:model.live="form.membership_status" variant="listbox">
+                        @foreach (MembershipStatus::cases() as $status)
+                            <flux:select.option :value="$status->value">{{ $status->label() }}</flux:select.option>
+                        @endforeach
+                    </flux:select>
+                    <p class="mt-1 text-xs text-zinc-500">{{ MembershipStatus::from($form->membership_status)->description() }}</p>
+
+                    @if ($form->membership_status === MembershipStatus::TERMINATED->value)
+                        <flux:field class="mt-3">
+                            <flux:label>Termination reason <span class="text-zinc-400">(optional)</span></flux:label>
+                            <flux:select wire:model="form.termination_reason" variant="listbox" placeholder="Select a reason…">
+                                @foreach (TerminationReason::cases() as $reason)
+                                    <flux:select.option :value="$reason->value">{{ $reason->label() }}</flux:select.option>
+                                @endforeach
+                            </flux:select>
+                        </flux:field>
+                    @else
+                        <flux:field class="mt-3">
+                            <flux:label>Member since</flux:label>
+                            <flux:input wire:model="form.membership_since" type="date" />
+                        </flux:field>
+                    @endif
+                </section>
+
+                {{-- Office --}}
+                <section>
+                    <flux:heading class="!text-xs uppercase tracking-wider text-zinc-500 mb-2">Office</flux:heading>
+
+                    @if ($person->offices->isEmpty())
+                        <p class="text-sm text-zinc-500">No current office.</p>
+                    @else
+                        <ul class="space-y-1.5 mb-3">
+                            @foreach ($person->offices as $office)
+                                <li class="flex items-center justify-between gap-3 rounded-md ring-1 ring-zinc-200 dark:ring-zinc-700 px-3 py-2">
+                                    <div class="flex items-center gap-2">
+                                        <x-office-chip :kind="$office->kind" />
+                                        <span class="text-xs text-zinc-500">since {{ $office->started_on->format('M Y') }}</span>
+                                    </div>
+                                    <flux:button size="sm" variant="ghost" wire:click="endOffice({{ $office->id }})" wire:confirm="End this office?">End</flux:button>
+                                </li>
+                            @endforeach
+                        </ul>
+                    @endif
+
+                    <div class="flex items-end gap-2">
+                        <flux:field class="flex-1">
+                            <flux:label>Add office</flux:label>
+                            <flux:select wire:model="newOffice" variant="listbox" placeholder="Select…">
+                                @foreach (Office::cases() as $kind)
+                                    <flux:select.option :value="$kind->value">{{ $kind->label() }}</flux:select.option>
+                                @endforeach
+                            </flux:select>
+                        </flux:field>
+                        <flux:field>
+                            <flux:label>Started</flux:label>
+                            <flux:input wire:model="newOfficeStartedOn" type="date" />
+                        </flux:field>
+                        <flux:button type="button" variant="ghost" icon="plus" wire:click="addOffice">Add</flux:button>
+                    </div>
+
+                    @if ($person->formerOffices->isNotEmpty())
+                        <div class="mt-3">
+                            <flux:subheading class="!text-xs">Former</flux:subheading>
+                            <ul class="space-y-1 mt-1">
+                                @foreach ($person->formerOffices as $office)
+                                    <li class="flex items-center gap-2 text-xs text-zinc-500">
+                                        <x-office-chip :kind="$office->kind" size="sm" />
+                                        <span>{{ $office->started_on->format('Y') }} – {{ $office->ended_on->format('Y') }}</span>
+                                        @if ($office->end_reason)
+                                            <span class="text-zinc-400">· {{ $office->end_reason }}</span>
+                                        @endif
+                                    </li>
+                                @endforeach
+                            </ul>
+                        </div>
+                    @endif
+                </section>
+
+                {{-- Pastoral Care --}}
+                <section>
+                    <flux:heading class="!text-xs uppercase tracking-wider text-zinc-500 mb-2">Pastoral care</flux:heading>
+                    <flux:select wire:model="form.pastoral_care_elder_id" variant="listbox" placeholder="Unassigned">
+                        <flux:select.option :value="null">Unassigned</flux:select.option>
+                        @foreach ($this->elderCandidates as $elder)
+                            <flux:select.option :value="$elder->id">{{ $elder->full_name }}</flux:select.option>
+                        @endforeach
+                    </flux:select>
+                </section>
+
+                {{-- Access --}}
+                @if ($person->user)
+                    <section>
+                        <flux:heading class="!text-xs uppercase tracking-wider text-zinc-500 mb-2">Access</flux:heading>
+                        <div class="flex flex-wrap gap-1.5">
+                            @foreach (AccessRole::cases() as $role)
+                                @php($active = $person->user->hasAccessRole($role))
+                                <button type="button" wire:click="toggleAccessRole('{{ $role->value }}')" class="appearance-none">
+                                    <flux:badge
+                                        :color="$active ? $role->color() : 'zinc'"
+                                        :icon="$role->icon()"
+                                        size="sm"
+                                        :title="$role->description()"
+                                        :class="$active ? '' : 'opacity-50'"
+                                    >
+                                        {{ $role->label() }}
+                                    </flux:badge>
+                                </button>
+                            @endforeach
+                        </div>
+                        <p class="mt-1 text-xs text-zinc-500">Click to toggle. (Display-only for now — no enforcement yet.)</p>
+                    </section>
+                @endif
+
+                {{-- Groups --}}
+                @if ($person->user && $person->user->groups->isNotEmpty())
+                    <section>
+                        <flux:heading class="!text-xs uppercase tracking-wider text-zinc-500 mb-2">Groups</flux:heading>
+                        <div class="flex flex-wrap gap-1.5">
+                            @foreach ($person->user->groups as $group)
+                                <flux:badge size="sm" color="zinc" icon="user-group">{{ $group->name }}</flux:badge>
+                            @endforeach
+                        </div>
+                    </section>
+                @endif
+
+                {{-- Activity --}}
+                <section>
+                    <flux:heading class="!text-xs uppercase tracking-wider text-zinc-500 mb-2">Activity</flux:heading>
+                    <dl class="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-sm">
+                        <dt class="text-zinc-500">Last active</dt>
+                        <dd>{{ $person->last_active_at?->diffForHumans() ?? '—' }}</dd>
+                        <dt class="text-zinc-500">Added</dt>
+                        <dd>{{ $person->created_at->toFormattedDayDateString() }}</dd>
+                        <dt class="text-zinc-500">Gender</dt>
+                        <dd>{{ $person->gender?->label() ?? '—' }}</dd>
+                    </dl>
+                </section>
+
+                {{-- Footer --}}
+                <div class="flex items-center justify-between pt-4 border-t border-zinc-200 dark:border-zinc-700">
+                    <flux:button type="button" variant="ghost" icon="trash" class="!text-rose-600" wire:click="delete" wire:confirm="Permanently delete this person?">
+                        Delete person
+                    </flux:button>
+                    <div class="flex gap-2">
+                        <flux:modal.close>
+                            <flux:button variant="ghost" type="button">Cancel</flux:button>
+                        </flux:modal.close>
+                        <flux:button type="submit" variant="primary" icon="check">Save changes</flux:button>
+                    </div>
+                </div>
+            </form>
+        @endif
+    </flux:modal>
+</div>

--- a/resources/views/livewire/people/partials/empty-state.blade.php
+++ b/resources/views/livewire/people/partials/empty-state.blade.php
@@ -1,0 +1,14 @@
+<div class="rounded-xl border border-dashed border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-6 py-14 text-center">
+    <div class="mx-auto mb-3 grid size-14 place-items-center rounded-xl bg-emerald-50 dark:bg-emerald-950 text-emerald-700 dark:text-emerald-300 ring-1 ring-emerald-100 dark:ring-emerald-900">
+        <flux:icon name="users" class="size-6" />
+    </div>
+    <flux:heading size="lg">No people yet</flux:heading>
+    <flux:subheading class="mx-auto mt-1 max-w-sm">
+        Add the members of your congregation to start assigning them to services, groups, and the prayer schedule.
+    </flux:subheading>
+    <div class="mt-4 inline-flex gap-2">
+        <flux:modal.trigger name="add-person">
+            <flux:button variant="primary" icon="user-plus">Add your first person</flux:button>
+        </flux:modal.trigger>
+    </div>
+</div>

--- a/resources/views/livewire/people/partials/filter-chips.blade.php
+++ b/resources/views/livewire/people/partials/filter-chips.blade.php
@@ -1,0 +1,39 @@
+@props([
+    'counts',
+    'current' => null,
+])
+
+@php
+    $items = [
+        ['key' => 'all',        'label' => 'All',         'icon' => 'users'],
+        ['key' => 'member',     'label' => 'Members',     'icon' => 'home-modern'],
+        ['key' => 'catechumen', 'label' => 'Catechumens', 'icon' => 'book-open'],
+        ['key' => 'adherent',   'label' => 'Adherents',   'icon' => 'user-group'],
+        ['key' => 'visitor',    'label' => 'Visitors',    'icon' => 'face-smile'],
+    ];
+@endphp
+
+<div class="inline-flex flex-wrap gap-1 p-1 rounded-lg bg-zinc-50 dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700">
+    @foreach ($items as $it)
+        @php
+            $active = ($it['key'] === 'all' && $current === null) || $current === $it['key'];
+        @endphp
+        <button
+            type="button"
+            wire:click="setFilter('{{ $it['key'] }}')"
+            @class([
+                'inline-flex items-center gap-1.5 px-2.5 h-7 rounded-md text-xs font-medium transition',
+                'bg-white dark:bg-zinc-700 text-zinc-900 dark:text-white shadow-sm ring-1 ring-zinc-200 dark:ring-zinc-600' => $active,
+                'text-zinc-600 dark:text-zinc-300 hover:bg-white/60 dark:hover:bg-zinc-700/60' => ! $active,
+            ])
+        >
+            <flux:icon :name="$it['icon']" variant="micro" class="size-3.5" />
+            {{ $it['label'] }}
+            <span @class([
+                'ml-0.5 text-[11px] tabular-nums',
+                'text-zinc-500 dark:text-zinc-300' => $active,
+                'text-zinc-400 dark:text-zinc-500' => ! $active,
+            ])>{{ $counts[$it['key']] ?? 0 }}</span>
+        </button>
+    @endforeach
+</div>

--- a/resources/views/livewire/people/partials/no-match.blade.php
+++ b/resources/views/livewire/people/partials/no-match.blade.php
@@ -1,0 +1,9 @@
+<div class="rounded-xl border border-dashed border-zinc-300 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-900 px-6 py-12 text-center">
+    <div class="mx-auto mb-3 grid size-12 place-items-center rounded-lg bg-white dark:bg-zinc-800 text-zinc-500 ring-1 ring-zinc-200 dark:ring-zinc-700">
+        <flux:icon name="magnifying-glass" class="size-5" />
+    </div>
+    <flux:heading>No people match those filters</flux:heading>
+    <flux:subheading class="mt-1">
+        Try clearing the search or switching to <button type="button" wire:click="setFilter('all')" class="font-semibold underline">All</button>.
+    </flux:subheading>
+</div>

--- a/resources/views/livewire/people/row.blade.php
+++ b/resources/views/livewire/people/row.blade.php
@@ -3,63 +3,57 @@
 use App\Models\Person;
 use Livewire\Component;
 
-new class extends Component {
+new class extends Component
+{
     public Person $person;
 
-    public function delete()
+    public string $density = 'spacious';
+
+    public function open(): void
     {
-        $this->modal("delete-person")->show();
+        $this->dispatch('open-person-drawer', personId: $this->person->id)->to('people.drawer');
     }
-};
-?>
+}; ?>
 
-<flux:table.row>
+<flux:table.row class="cursor-pointer" wire:click="open">
     <flux:table.cell>
-        <flux:link variant="subtle" href="{{ route('people.show', ['person' => $person]) }}">
-            <div class="flex w-max items-center gap-2">
-                <flux:avatar name="{{ $person->name }}" src="{{ $person->gravatar }}" />
-                <div class="flex flex-col">
-                    <span>{{ $person->fullName }}</span>
-                    <span>{{ $person->email }}</span>
-                </div>
+        <div class="flex items-center gap-3">
+            <x-person-avatar :person="$person" :size="$density === 'compact' ? 'xs' : 'sm'" />
+            <div class="min-w-0">
+                <div class="font-medium text-zinc-900 dark:text-white truncate">{{ $person->full_name }}</div>
+                @if ($person->email)
+                    <div class="text-xs text-zinc-500 truncate">{{ $person->email }}</div>
+                @endif
             </div>
-        </flux:link>
+        </div>
     </flux:table.cell>
+
     <flux:table.cell>
-        <flux:badge size="sm" inset="top bottom" :color="$person->gender?->color()">{{ $person->gender?->label() }}</flux:badge>
+        <x-membership-badge :status="$person->membership_status" :reason="$person->termination_reason" />
     </flux:table.cell>
-    <flux:table.cell class="whitespace-nowrap">{{ $person->created_at->toFormattedDayDateString() }}</flux:table.cell>
+
+    <flux:table.cell>
+        @if ($person->offices->isEmpty())
+            <span class="text-zinc-400 text-xs">—</span>
+        @else
+            <div class="inline-flex gap-1">
+                @foreach ($person->offices as $office)
+                    <flux:badge
+                        size="sm"
+                        :color="$office->kind->color()"
+                        :icon="$office->kind->icon()"
+                        :title="$office->kind->label() . ' · since ' . $office->started_on->format('M Y')"
+                    />
+                @endforeach
+            </div>
+        @endif
+    </flux:table.cell>
+
+    <flux:table.cell class="text-zinc-500 text-sm whitespace-nowrap">
+        {{ $person->created_at->toFormattedDayDateString() }}
+    </flux:table.cell>
+
     <flux:table.cell align="end">
-        <flux:dropdown align="end" offset="-15">
-            <flux:button variant="ghost" size="sm" icon="ellipsis-horizontal" inset="bottom" />
-
-            <flux:menu class="min-w-32">
-                <flux:menu.item href="{{ route('people.edit', ['person' => $person]) }}" icon="pencil-square">Edit</flux:menu.item>
-                <flux:menu.item wire:click="delete" icon="trash" variant="danger">Delete</flux:menu.item>
-            </flux:menu>
-        </flux:dropdown>
-
-        <flux:modal name="delete-person" class="min-w-[22rem]">
-            <form wire:submit="$parent.delete({{ $person->id }})" class="space-y-6">
-                <div>
-                    <flux:heading size="lg">Delete person?</flux:heading>
-
-                    <flux:subheading>
-                        <p>This will permanently delete the person.</p>
-                        <p>It cannot be undone.</p>
-                    </flux:subheading>
-                </div>
-
-                <div class="flex gap-2">
-                    <flux:spacer />
-
-                    <flux:modal.close>
-                        <flux:button variant="ghost">Cancel</flux:button>
-                    </flux:modal.close>
-
-                    <flux:button type="submit" variant="danger">Delete person</flux:button>
-                </div>
-            </form>
-        </flux:modal>
+        <flux:icon name="chevron-right" class="size-4 text-zinc-400" />
     </flux:table.cell>
 </flux:table.row>

--- a/resources/views/livewire/people/row.blade.php
+++ b/resources/views/livewire/people/row.blade.php
@@ -15,7 +15,14 @@ new class extends Component
     }
 }; ?>
 
-<flux:table.row class="cursor-pointer" wire:click="open">
+<flux:table.row
+    class="cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/50"
+    wire:click="open"
+    tabindex="0"
+    role="button"
+    wire:keydown.enter="open"
+    wire:keydown.space.prevent="open"
+>
     <flux:table.cell>
         <div class="flex items-center gap-3">
             <x-person-avatar :person="$person" :size="$density === 'compact' ? 'xs' : 'sm'" />

--- a/resources/views/pages/groups/index.blade.php
+++ b/resources/views/pages/groups/index.blade.php
@@ -3,7 +3,7 @@
 use App\Enums\GroupMessaging;
 use App\Enums\GroupRole;
 use App\Enums\GroupVisibility;
-use App\Enums\MembershipStatus;
+use App\Enums\GroupMembershipStatus;
 use App\Models\Group;
 use Flux\Flux;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
@@ -72,7 +72,7 @@ new class extends Component {
             ->where('visibility', GroupVisibility::PUBLIC)
             ->whereDoesntHave('allUsers', fn ($q) => $q
                 ->where('users.id', Auth::id())
-                ->whereIn('status', [MembershipStatus::ACTIVE->value, MembershipStatus::PENDING->value])
+                ->whereIn('status', [GroupMembershipStatus::ACTIVE->value, GroupMembershipStatus::PENDING->value])
             )
             ->withCount('members')
             ->when($this->search !== '', fn ($q) =>
@@ -95,7 +95,7 @@ new class extends Component {
             ->where('visibility', GroupVisibility::PUBLIC)
             ->whereDoesntHave('allUsers', fn ($q) => $q
                 ->where('users.id', Auth::id())
-                ->whereIn('status', [MembershipStatus::ACTIVE->value, MembershipStatus::PENDING->value])
+                ->whereIn('status', [GroupMembershipStatus::ACTIVE->value, GroupMembershipStatus::PENDING->value])
             );
 
         $byMessaging = (clone $base)
@@ -120,12 +120,12 @@ new class extends Component {
 
         if ($existing) {
             $group->allUsers()->updateExistingPivot(Auth::id(), [
-                'status' => MembershipStatus::PENDING,
+                'status' => GroupMembershipStatus::PENDING,
             ]);
         } else {
             $group->allUsers()->attach(Auth::id(), [
                 'role' => GroupRole::MEMBER,
-                'status' => MembershipStatus::PENDING,
+                'status' => GroupMembershipStatus::PENDING,
             ]);
         }
 

--- a/resources/views/pages/groups/show.blade.php
+++ b/resources/views/pages/groups/show.blade.php
@@ -3,7 +3,7 @@
 use App\Enums\GroupMessaging;
 use App\Enums\GroupRole;
 use App\Enums\GroupVisibility;
-use App\Enums\MembershipStatus;
+use App\Enums\GroupMembershipStatus;
 use App\Models\Conversation;
 use App\Models\Group;
 use App\Models\GroupUser;
@@ -64,7 +64,7 @@ new class extends Component {
     #[Computed]
     public function isMember(): bool
     {
-        return $this->membership?->status === MembershipStatus::ACTIVE;
+        return $this->membership?->status === GroupMembershipStatus::ACTIVE;
     }
 
     #[Computed]
@@ -163,7 +163,7 @@ new class extends Component {
         }
 
         $existingUserIds = $this->group->allUsers()
-            ->whereIn('group_user.status', [MembershipStatus::ACTIVE, MembershipStatus::PENDING])
+            ->whereIn('group_user.status', [GroupMembershipStatus::ACTIVE, GroupMembershipStatus::PENDING])
             ->pluck('users.id');
 
         return User::query()
@@ -235,12 +235,12 @@ new class extends Component {
 
         if ($existing) {
             $this->group->allUsers()->updateExistingPivot(Auth::id(), [
-                'status' => MembershipStatus::PENDING,
+                'status' => GroupMembershipStatus::PENDING,
             ]);
         } else {
             $this->group->allUsers()->attach(Auth::id(), [
                 'role' => GroupRole::MEMBER,
-                'status' => MembershipStatus::PENDING,
+                'status' => GroupMembershipStatus::PENDING,
             ]);
         }
 
@@ -255,7 +255,7 @@ new class extends Component {
         /** @var ?GroupUser $membership */
         $membership = $this->group->allUsers()->where('user_id', Auth::id())->first()?->pivot;
 
-        if ($membership?->status !== MembershipStatus::PENDING) {
+        if ($membership?->status !== GroupMembershipStatus::PENDING) {
             return;
         }
 
@@ -308,7 +308,7 @@ new class extends Component {
             }
 
             $this->group->allUsers()->updateExistingPivot($user->id, [
-                'status' => MembershipStatus::ACTIVE,
+                'status' => GroupMembershipStatus::ACTIVE,
             ]);
 
             return $user;
@@ -339,7 +339,7 @@ new class extends Component {
             }
 
             $this->group->allUsers()->updateExistingPivot($user->id, [
-                'status' => MembershipStatus::REJECTED,
+                'status' => GroupMembershipStatus::REJECTED,
             ]);
 
             return $user;
@@ -377,12 +377,12 @@ new class extends Component {
             foreach ($users as $user) {
                 if (in_array($user->id, $existingIds, true)) {
                     $this->group->allUsers()->updateExistingPivot($user->id, [
-                        'status' => MembershipStatus::ACTIVE,
+                        'status' => GroupMembershipStatus::ACTIVE,
                     ]);
                 } else {
                     $this->group->allUsers()->attach($user->id, [
                         'role' => GroupRole::MEMBER,
-                        'status' => MembershipStatus::ACTIVE,
+                        'status' => GroupMembershipStatus::ACTIVE,
                     ]);
                 }
             }
@@ -577,15 +577,15 @@ new class extends Component {
 
             @if ($this->membership === null && $group->visibility === GroupVisibility::PUBLIC)
                 <flux:button wire:click="join" variant="primary" icon="user-plus">Request to Join</flux:button>
-            @elseif ($this->membership?->status === MembershipStatus::PENDING)
+            @elseif ($this->membership?->status === GroupMembershipStatus::PENDING)
                 <div class="flex items-center gap-2">
                     <flux:badge color="amber">Request Pending</flux:badge>
                     <flux:button wire:click="cancelRequest" variant="ghost" size="sm">Cancel</flux:button>
                 </div>
-            @elseif ($this->membership?->status === MembershipStatus::ACTIVE && ! $this->isLeader)
+            @elseif ($this->membership?->status === GroupMembershipStatus::ACTIVE && ! $this->isLeader)
                 <flux:button wire:click="leave" variant="danger" icon="arrow-right-start-on-rectangle"
                     wire:confirm="Are you sure you want to leave this group?">Leave Group</flux:button>
-            @elseif ($this->membership?->status === MembershipStatus::REJECTED)
+            @elseif ($this->membership?->status === GroupMembershipStatus::REJECTED)
                 <flux:button wire:click="join" variant="primary" icon="user-plus">Request to Join</flux:button>
             @endif
         </div>

--- a/resources/views/pages/people/index.blade.php
+++ b/resources/views/pages/people/index.blade.php
@@ -1,79 +1,183 @@
 <?php
 
+use App\Enums\MembershipStatus;
 use App\Models\Person;
-use Flux\Flux;
+use Livewire\Attributes\Computed;
+use Livewire\Attributes\Session;
 use Livewire\Component;
 use Livewire\WithPagination;
-use Livewire\Attributes\Computed;
 
-new class extends Component {
+new class extends Component
+{
     use WithPagination;
 
-    public $sortBy = "last_name";
-    public $sortDirection = "asc";
-    public $search = "";
+    public string $search = '';
 
-    public function sort($column)
+    public ?string $filter = null;
+
+    #[Session('people.layout')]
+    public string $layout = 'table';
+
+    #[Session('people.density')]
+    public string $density = 'spacious';
+
+    public ?int $openPersonId = null;
+
+    public function openPerson(int $id): void
     {
-        if ($this->sortBy === $column) {
-            $this->sortDirection =
-                $this->sortDirection === "asc" ? "desc" : "asc";
-        } else {
-            $this->sortBy = $column;
-            $this->sortDirection = "asc";
-        }
+        $this->openPersonId = $id;
+        $this->dispatch('open-person-drawer', personId: $id);
+    }
+
+    public function setFilter(?string $filter): void
+    {
+        $this->filter = $filter === 'all' ? null : $filter;
+        $this->resetPage();
+    }
+
+    public function setLayout(string $layout): void
+    {
+        $this->layout = in_array($layout, ['table', 'cards'], true) ? $layout : 'table';
+    }
+
+    public function setDensity(string $density): void
+    {
+        $this->density = in_array($density, ['spacious', 'compact'], true) ? $density : 'spacious';
+    }
+
+    /** @return array<string, int> */
+    #[Computed]
+    public function counts(): array
+    {
+        $base = Person::query()->searchedBy($this->search);
+
+        $byStatus = (clone $base)
+            ->selectRaw('membership_status, count(*) as total')
+            ->groupBy('membership_status')
+            ->pluck('total', 'membership_status')
+            ->all();
+
+        return [
+            'all' => (clone $base)->count(),
+            'member' => (int) ($byStatus[MembershipStatus::MEMBER->value] ?? 0),
+            'catechumen' => (int) ($byStatus[MembershipStatus::CATECHUMEN->value] ?? 0),
+            'adherent' => (int) ($byStatus[MembershipStatus::ADHERENT->value] ?? 0),
+            'visitor' => (int) ($byStatus[MembershipStatus::VISITOR->value] ?? 0),
+        ];
     }
 
     #[Computed]
     public function people()
     {
         return Person::query()
-            ->when($this->search, function ($query): void {
-                $query->whereAny(
-                    ["first_name", "last_name", "email"],
-                    "like",
-                    "%{$this->search}%",
-                );
-            })
-            ->tap(
-                fn($query) => $this->sortBy
-                    ? $query->orderBy($this->sortBy, $this->sortDirection)
-                    : $query,
-            )
-            ->paginate(12);
+            ->with(['offices', 'user'])
+            ->searchedBy($this->search)
+            ->when($this->filter, fn ($q) => $q->where('membership_status', $this->filter))
+            ->orderBy('last_name')
+            ->orderBy('first_name')
+            ->paginate($this->layout === 'cards' ? 24 : 12);
     }
 
-    public function delete($id)
+    public function updatedSearch(): void
     {
-        Person::findOrFail($id)->delete();
-        Flux::modal("delete-person")->close();
-        Flux::toast(variant: "danger", text: "Person deleted.");
+        $this->resetPage();
     }
-};
-?>
+}; ?>
 
 <section class="w-full">
-    <flux:heading size="xl" level="1">People</flux:heading>
-    <flux:subheading size="lg" class="mb-6">Manage your members and visitors.</flux:subheading>
-
-    <div class="flex space-x-4 items-center">
-        <flux:input wire:model.live="search" size="sm" placeholder="Search..." icon="magnifying-glass" class="max-w-96" clearable/>
-        <flux:spacer/>
-        <flux:button :href="route('people.create')" size="sm" variant="primary" icon="plus">Add Person</flux:button>
+    <div class="flex items-end justify-between gap-4 mb-4">
+        <div>
+            <flux:heading size="xl" level="1">People</flux:heading>
+            <flux:subheading size="lg">Manage your members and visitors.</flux:subheading>
+        </div>
+        <flux:modal.trigger name="add-person">
+            <flux:button size="sm" variant="primary" icon="plus">Add Person</flux:button>
+        </flux:modal.trigger>
     </div>
 
-    <flux:table :paginate="$this->people" class="mt-2">
-        <flux:table.columns>
-            <flux:table.column sortable :sorted="$sortBy === 'last_name'" :direction="$sortDirection" wire:click="sort('last_name')">Person</flux:table.column>
-            <flux:table.column sortable :sorted="$sortBy === 'gender'" :direction="$sortDirection" wire:click="sort('gender')">Gender</flux:table.column>
-            <flux:table.column sortable :sorted="$sortBy === 'created_at'" :direction="$sortDirection" wire:click="sort('created_at')">Added</flux:table.column>
-            <flux:table.column></flux:table.column>
-        </flux:table.columns>
+    <div class="flex flex-wrap items-center justify-between gap-3 mb-4">
+        @include('livewire.people.partials.filter-chips', ['counts' => $this->counts, 'current' => $filter])
 
-        <flux:table.rows>
+        <div class="flex items-center gap-2">
+            <flux:input
+                wire:model.live.debounce.250ms="search"
+                size="sm"
+                placeholder="Search by name, email, phone…"
+                icon="magnifying-glass"
+                class="w-72"
+                clearable
+            />
+
+            <flux:button.group size="sm">
+                <flux:button
+                    icon="bars-3"
+                    :variant="$layout === 'table' ? 'filled' : 'outline'"
+                    wire:click="setLayout('table')"
+                    title="Table view"
+                />
+                <flux:button
+                    icon="squares-2x2"
+                    :variant="$layout === 'cards' ? 'filled' : 'outline'"
+                    wire:click="setLayout('cards')"
+                    title="Card view"
+                />
+            </flux:button.group>
+
+            <flux:button.group size="sm">
+                <flux:button
+                    icon="arrows-up-down"
+                    :variant="$density === 'spacious' ? 'filled' : 'outline'"
+                    wire:click="setDensity('spacious')"
+                    title="Spacious"
+                />
+                <flux:button
+                    icon="bars-2"
+                    :variant="$density === 'compact' ? 'filled' : 'outline'"
+                    wire:click="setDensity('compact')"
+                    title="Compact"
+                />
+            </flux:button.group>
+        </div>
+    </div>
+
+    @if ($this->people->isEmpty())
+        @if ($search || $filter)
+            @include('livewire.people.partials.no-match')
+        @else
+            @include('livewire.people.partials.empty-state')
+        @endif
+    @elseif ($layout === 'cards')
+        <div @class([
+            'grid gap-3' => true,
+            'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4' => $density === 'spacious',
+            'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5' => $density === 'compact',
+        ])>
             @foreach ($this->people as $person)
-                <livewire:people.row :$person :key="$person->id" />
+                <livewire:people.card :$person :density="$density" :key="'card-'.$person->id" />
             @endforeach
-        </flux:table.rows>
-    </flux:table>
+        </div>
+
+        <div class="mt-4">
+            {{ $this->people->links() }}
+        </div>
+    @else
+        <flux:table :paginate="$this->people">
+            <flux:table.columns>
+                <flux:table.column>Person</flux:table.column>
+                <flux:table.column>Membership</flux:table.column>
+                <flux:table.column>Office</flux:table.column>
+                <flux:table.column>Added</flux:table.column>
+                <flux:table.column></flux:table.column>
+            </flux:table.columns>
+
+            <flux:table.rows>
+                @foreach ($this->people as $person)
+                    <livewire:people.row :$person :density="$density" :key="'row-'.$person->id" />
+                @endforeach
+            </flux:table.rows>
+        </flux:table>
+    @endif
+
+    <livewire:people.drawer :person-id="$openPersonId" />
+    <livewire:people.add-modal />
 </section>

--- a/resources/views/pages/people/index.blade.php
+++ b/resources/views/pages/people/index.blade.php
@@ -38,6 +38,7 @@ new class extends Component
     public function setLayout(string $layout): void
     {
         $this->layout = in_array($layout, ['table', 'cards'], true) ? $layout : 'table';
+        $this->resetPage();
     }
 
     public function setDensity(string $density): void

--- a/routes/web.php
+++ b/routes/web.php
@@ -81,14 +81,7 @@ Route::middleware(['auth'])->group(function (): void {
                 });
         });
 
-    Route::name('people.')
-        ->prefix('people')
-        ->group(function (): void {
-            Route::livewire('/', 'pages::people.index')->name('index');
-            Route::livewire('/create', 'pages::people.create')->name('create');
-            Route::livewire('/{person}', 'pages::people.show')->name('show');
-            Route::livewire('/{person}/edit', 'pages::people.edit')->name('edit');
-        });
+    Route::livewire('/people', 'pages::people.index')->name('people.index');
 });
 
 require __DIR__.'/auth.php';

--- a/tests/Browser/GroupConversationSmokeTest.php
+++ b/tests/Browser/GroupConversationSmokeTest.php
@@ -1,9 +1,9 @@
 <?php
 
+use App\Enums\GroupMembershipStatus;
 use App\Enums\GroupMessaging;
 use App\Enums\GroupRole;
 use App\Enums\GroupVisibility;
-use App\Enums\MembershipStatus;
 use App\Models\Conversation;
 use App\Models\Group;
 use App\Models\User;
@@ -19,7 +19,7 @@ it('renders an empty group conversation without smoke', function (): void {
         'messaging' => GroupMessaging::ALL_MEMBERS,
         'name' => 'Elders',
     ]);
-    $group->allUsers()->attach($user, ['role' => GroupRole::LEADER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($user, ['role' => GroupRole::LEADER, 'status' => GroupMembershipStatus::ACTIVE]);
 
     $conversation = Conversation::factory()->create([
         'group_id' => $group->id,
@@ -46,8 +46,8 @@ it('renders a populated group conversation with pinned, prayer, and scripture re
         'messaging' => GroupMessaging::ALL_MEMBERS,
         'name' => 'Elders',
     ]);
-    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => MembershipStatus::ACTIVE]);
-    $group->allUsers()->attach($member, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => GroupMembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($member, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::ACTIVE]);
 
     $conversation = Conversation::factory()->create([
         'group_id' => $group->id,

--- a/tests/Browser/People/PeoplePageTest.php
+++ b/tests/Browser/People/PeoplePageTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use App\Models\Person;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+/** @group browser */
+it('renders the empty state when there are no people', function (): void {
+    $user = User::factory()->create();
+    $user->person->delete();
+    Person::query()->delete();
+
+    $this->actingAs($user);
+
+    visit(route('people.index'))
+        ->assertSee('No people yet')
+        ->assertSee('Add your first person')
+        ->assertNoSmoke();
+});
+
+/** @group browser */
+it('filters by membership status', function (): void {
+    $user = User::factory()->create();
+    $user->person->delete();
+    Person::query()->delete();
+
+    Person::factory()->member()->count(3)->create();
+    Person::factory()->visitor()->count(2)->create();
+
+    $this->actingAs($user);
+
+    visit(route('people.index'))
+        ->assertSee('Members')
+        ->assertSee('Visitors')
+        ->assertNoSmoke();
+});

--- a/tests/Browser/People/PeoplePageTest.php
+++ b/tests/Browser/People/PeoplePageTest.php
@@ -26,13 +26,14 @@ it('filters by membership status', function (): void {
     $user->person->delete();
     Person::query()->delete();
 
-    Person::factory()->member()->count(3)->create();
-    Person::factory()->visitor()->count(2)->create();
+    Person::factory()->member()->create(['first_name' => 'Member', 'last_name' => 'One']);
+    Person::factory()->visitor()->create(['first_name' => 'Visitor', 'last_name' => 'One']);
 
     $this->actingAs($user);
 
     visit(route('people.index'))
-        ->assertSee('Members')
-        ->assertSee('Visitors')
+        ->click('Members')
+        ->assertSee('Member One')
+        ->assertDontSee('Visitor One')
         ->assertNoSmoke();
 });

--- a/tests/Feature/CommentEditTest.php
+++ b/tests/Feature/CommentEditTest.php
@@ -1,9 +1,9 @@
 <?php
 
+use App\Enums\GroupMembershipStatus;
 use App\Enums\GroupMessaging;
 use App\Enums\GroupRole;
 use App\Enums\GroupVisibility;
-use App\Enums\MembershipStatus;
 use App\Models\Conversation;
 use App\Models\ConversationFile;
 use App\Models\Group;
@@ -25,9 +25,9 @@ function makeEditScenario(): array
         'visibility' => GroupVisibility::PUBLIC,
         'messaging' => GroupMessaging::ALL_MEMBERS,
     ]);
-    $group->allUsers()->attach($author, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
-    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => MembershipStatus::ACTIVE]);
-    $group->allUsers()->attach($member, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($author, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => GroupMembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($member, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::ACTIVE]);
 
     $conversation = Conversation::factory()->create([
         'group_id' => $group->id,

--- a/tests/Feature/CommentPinPrayerInteractionTest.php
+++ b/tests/Feature/CommentPinPrayerInteractionTest.php
@@ -1,9 +1,9 @@
 <?php
 
+use App\Enums\GroupMembershipStatus;
 use App\Enums\GroupMessaging;
 use App\Enums\GroupRole;
 use App\Enums\GroupVisibility;
-use App\Enums\MembershipStatus;
 use App\Models\Conversation;
 use App\Models\ConversationFile;
 use App\Models\Group;
@@ -22,7 +22,7 @@ function buildInteractionScenario(): array
         'visibility' => GroupVisibility::PUBLIC,
         'messaging' => GroupMessaging::ALL_MEMBERS,
     ]);
-    $group->allUsers()->attach($author, ['role' => GroupRole::LEADER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($author, ['role' => GroupRole::LEADER, 'status' => GroupMembershipStatus::ACTIVE]);
 
     $conversation = Conversation::factory()->create([
         'group_id' => $group->id,
@@ -63,7 +63,7 @@ test('pinning re-opens the pinned strip even if the user previously dismissed it
 test('a non-author non-leader member cannot pin a comment', function (): void {
     [$group, $conversation, $author] = buildInteractionScenario();
     $other = User::factory()->create();
-    $group->allUsers()->attach($other, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($other, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::ACTIVE]);
 
     $comment = $conversation->postComment('not yours', $author);
 
@@ -93,7 +93,7 @@ test('an authorized user can unpin a pinned comment', function (): void {
 test('a non-author non-leader member cannot unpin a comment', function (): void {
     [$group, $conversation, $author] = buildInteractionScenario();
     $other = User::factory()->create();
-    $group->allUsers()->attach($other, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($other, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::ACTIVE]);
 
     $comment = $conversation->postComment('not yours', $author);
     $comment->fresh()->pin($author);
@@ -111,7 +111,7 @@ test('a non-author non-leader member cannot unpin a comment', function (): void 
 test('any active group member can mark a comment as prayer', function (): void {
     [$group, $conversation, $author] = buildInteractionScenario();
     $member = User::factory()->create();
-    $group->allUsers()->attach($member, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($member, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::ACTIVE]);
 
     $comment = $conversation->postComment('pray for this', $author);
 
@@ -171,7 +171,7 @@ test('the unpin toggle is rendered for a pinned comment', function (): void {
 test('the pin toggle is hidden for a member who cannot pin', function (): void {
     [$group, $conversation, $author] = buildInteractionScenario();
     $other = User::factory()->create();
-    $group->allUsers()->attach($other, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($other, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::ACTIVE]);
     $conversation->postComment('hi', $author);
 
     Livewire::actingAs($other)
@@ -183,7 +183,7 @@ test('the pin toggle is hidden for a member who cannot pin', function (): void {
 test('the prayer toggle button is rendered for active group members', function (): void {
     [$group, $conversation, $author] = buildInteractionScenario();
     $member = User::factory()->create();
-    $group->allUsers()->attach($member, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($member, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::ACTIVE]);
     $conversation->postComment('hi', $author);
 
     Livewire::actingAs($member)
@@ -219,7 +219,7 @@ test('an author can delete their own comment via deleteComment', function (): vo
 test('a group leader can delete any comment', function (): void {
     [$group, $conversation, $author] = buildInteractionScenario();
     $member = User::factory()->create();
-    $group->allUsers()->attach($member, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($member, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::ACTIVE]);
 
     $comment = $conversation->postComment('member message', $member);
 
@@ -234,7 +234,7 @@ test('a group leader can delete any comment', function (): void {
 test('a non-author non-leader member cannot delete a comment', function (): void {
     [$group, $conversation, $author] = buildInteractionScenario();
     $other = User::factory()->create();
-    $group->allUsers()->attach($other, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($other, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::ACTIVE]);
 
     $comment = $conversation->postComment('not yours', $author);
 
@@ -310,7 +310,7 @@ test('the delete toggle is rendered for the comment author', function (): void {
 test('the delete toggle is hidden for a member who cannot delete', function (): void {
     [$group, $conversation, $author] = buildInteractionScenario();
     $other = User::factory()->create();
-    $group->allUsers()->attach($other, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($other, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::ACTIVE]);
     $conversation->postComment('not yours', $author);
 
     Livewire::actingAs($other)

--- a/tests/Feature/CommentPinPrayerTest.php
+++ b/tests/Feature/CommentPinPrayerTest.php
@@ -1,9 +1,9 @@
 <?php
 
+use App\Enums\GroupMembershipStatus;
 use App\Enums\GroupMessaging;
 use App\Enums\GroupRole;
 use App\Enums\GroupVisibility;
-use App\Enums\MembershipStatus;
 use App\Models\Comment;
 use App\Models\Conversation;
 use App\Models\Group;
@@ -20,7 +20,7 @@ function makeGroupConversation(GroupRole $authorRole = GroupRole::MEMBER): array
     ]);
 
     $author = User::factory()->create();
-    $group->allUsers()->attach($author, ['role' => $authorRole, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($author, ['role' => $authorRole, 'status' => GroupMembershipStatus::ACTIVE]);
 
     $conversation = Conversation::factory()->create(['group_id' => $group->id, 'user_id' => $author->id]);
     $comment = $conversation->postComment('Hello group', $author);
@@ -101,7 +101,7 @@ test('group leader can pin any comment in the conversation', function (): void {
     [$group, $conversation, $comment] = makeGroupConversation();
 
     $leader = User::factory()->create();
-    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => GroupMembershipStatus::ACTIVE]);
 
     expect($leader->can('pin', $comment))->toBeTrue()
         ->and($leader->can('unpin', $comment))->toBeTrue();
@@ -111,7 +111,7 @@ test('a non-leader member who did not author the comment cannot pin it', functio
     [$group, $conversation, $comment] = makeGroupConversation();
 
     $otherMember = User::factory()->create();
-    $group->allUsers()->attach($otherMember, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($otherMember, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::ACTIVE]);
 
     expect($otherMember->can('pin', $comment))->toBeFalse()
         ->and($otherMember->can('unpin', $comment))->toBeFalse();
@@ -132,7 +132,7 @@ test('any active group member can mark prayer on any comment', function (): void
     [$group, $conversation, $comment] = makeGroupConversation();
 
     $otherMember = User::factory()->create();
-    $group->allUsers()->attach($otherMember, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($otherMember, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::ACTIVE]);
 
     expect($otherMember->can('markPrayer', $comment))->toBeTrue();
 });
@@ -149,7 +149,7 @@ test('a pending member cannot mark prayer', function (): void {
     [$group, $conversation, $comment] = makeGroupConversation();
 
     $pending = User::factory()->create();
-    $group->allUsers()->attach($pending, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::PENDING]);
+    $group->allUsers()->attach($pending, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::PENDING]);
 
     expect($pending->can('markPrayer', $comment))->toBeFalse();
 });
@@ -166,7 +166,7 @@ test('group leader can delete any comment in the conversation', function (): voi
     [$group, $conversation, $comment] = makeGroupConversation();
 
     $leader = User::factory()->create();
-    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => GroupMembershipStatus::ACTIVE]);
 
     expect($leader->can('delete', $comment))->toBeTrue();
 });
@@ -175,7 +175,7 @@ test('a non-leader member who did not author the comment cannot delete it', func
     [$group, $conversation, $comment] = makeGroupConversation();
 
     $otherMember = User::factory()->create();
-    $group->allUsers()->attach($otherMember, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($otherMember, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::ACTIVE]);
 
     expect($otherMember->can('delete', $comment))->toBeFalse();
 });

--- a/tests/Feature/ConversationAttachmentsTest.php
+++ b/tests/Feature/ConversationAttachmentsTest.php
@@ -1,9 +1,9 @@
 <?php
 
+use App\Enums\GroupMembershipStatus;
 use App\Enums\GroupMessaging;
 use App\Enums\GroupRole;
 use App\Enums\GroupVisibility;
-use App\Enums\MembershipStatus;
 use App\Models\Conversation;
 use App\Models\ConversationFile;
 use App\Models\Group;
@@ -29,9 +29,9 @@ function makeConversation(GroupMessaging $messaging = GroupMessaging::ALL_MEMBER
         'messaging' => $messaging,
     ]);
 
-    $group->allUsers()->attach($author, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
-    $group->allUsers()->attach($member, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
-    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($author, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($member, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => GroupMembershipStatus::ACTIVE]);
 
     $conversation = Conversation::factory()->create([
         'group_id' => $group->id,

--- a/tests/Feature/ConversationComposerTest.php
+++ b/tests/Feature/ConversationComposerTest.php
@@ -1,9 +1,9 @@
 <?php
 
+use App\Enums\GroupMembershipStatus;
 use App\Enums\GroupMessaging;
 use App\Enums\GroupRole;
 use App\Enums\GroupVisibility;
-use App\Enums\MembershipStatus;
 use App\Models\Conversation;
 use App\Models\Group;
 use App\Models\User;
@@ -20,7 +20,7 @@ function buildComposerScenario(): array
         'visibility' => GroupVisibility::PUBLIC,
         'messaging' => GroupMessaging::ALL_MEMBERS,
     ]);
-    $group->allUsers()->attach($member, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($member, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::ACTIVE]);
 
     $conversation = Conversation::factory()->create([
         'group_id' => $group->id,
@@ -140,8 +140,8 @@ test('the composer is hidden for users who cannot comment', function (): void {
         'visibility' => GroupVisibility::PUBLIC,
         'messaging' => GroupMessaging::ONLY_LEADERS,
     ]);
-    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => MembershipStatus::ACTIVE]);
-    $group->allUsers()->attach($reader, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => GroupMembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($reader, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::ACTIVE]);
 
     $conversation = Conversation::factory()->create(['group_id' => $group->id, 'user_id' => $leader->id]);
 

--- a/tests/Feature/ConversationMessageRowTest.php
+++ b/tests/Feature/ConversationMessageRowTest.php
@@ -1,9 +1,9 @@
 <?php
 
+use App\Enums\GroupMembershipStatus;
 use App\Enums\GroupMessaging;
 use App\Enums\GroupRole;
 use App\Enums\GroupVisibility;
-use App\Enums\MembershipStatus;
 use App\Models\Conversation;
 use App\Models\Group;
 use App\Models\User;
@@ -20,7 +20,7 @@ function buildRowScenario(): array
         'messaging' => GroupMessaging::ALL_MEMBERS,
         'name' => 'Elders',
     ]);
-    $group->allUsers()->attach($viewer, ['role' => GroupRole::LEADER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($viewer, ['role' => GroupRole::LEADER, 'status' => GroupMembershipStatus::ACTIVE]);
 
     $conversation = Conversation::factory()->create([
         'group_id' => $group->id,
@@ -87,7 +87,7 @@ test('own messages render with the accent left border and a "(you)" suffix', fun
 test('other peoples messages do not get the mine attribute', function (): void {
     [$group, $conversation, $viewer] = buildRowScenario();
     $other = User::factory()->create(['name' => 'Other Owen']);
-    $group->allUsers()->attach($other, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($other, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::ACTIVE]);
     $conversation->postComment('theirs', $other);
 
     $html = Livewire::actingAs($viewer)
@@ -156,7 +156,7 @@ test('a reaction chip the viewer added carries the mine flag', function (): void
 test('a reaction chip the viewer did not add does not carry the mine flag', function (): void {
     [$group, $conversation, $viewer] = buildRowScenario();
     $other = User::factory()->create();
-    $group->allUsers()->attach($other, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($other, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::ACTIVE]);
 
     $comment = $conversation->postComment('react to me', $other);
     $comment->fresh()->react('👍', $other);
@@ -186,7 +186,7 @@ test('clicking a reaction the viewer already gave removes it', function (): void
 test('hovering a reaction chip shows the reactors names in a tooltip', function (): void {
     [$group, $conversation, $viewer] = buildRowScenario();
     $other = User::factory()->create(['name' => 'Sarah Reactor']);
-    $group->allUsers()->attach($other, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($other, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::ACTIVE]);
 
     $comment = $conversation->postComment('react to me', $other);
     $comment->fresh()->react('👍', $other);
@@ -233,8 +233,8 @@ test('the hover toolbar does not render for read-only viewers (leaders-only grou
         'visibility' => GroupVisibility::PUBLIC,
         'messaging' => GroupMessaging::ONLY_LEADERS,
     ]);
-    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => MembershipStatus::ACTIVE]);
-    $group->allUsers()->attach($member, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => GroupMembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($member, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::ACTIVE]);
 
     $conversation = Conversation::factory()->create([
         'group_id' => $group->id,

--- a/tests/Feature/ConversationMobileEnhancementsTest.php
+++ b/tests/Feature/ConversationMobileEnhancementsTest.php
@@ -1,9 +1,9 @@
 <?php
 
+use App\Enums\GroupMembershipStatus;
 use App\Enums\GroupMessaging;
 use App\Enums\GroupRole;
 use App\Enums\GroupVisibility;
-use App\Enums\MembershipStatus;
 use App\Models\Conversation;
 use App\Models\Group;
 use App\Models\User;
@@ -20,7 +20,7 @@ function buildMobileScenario(): array
         'messaging' => GroupMessaging::ALL_MEMBERS,
         'name' => 'Elders',
     ]);
-    $group->allUsers()->attach($viewer, ['role' => GroupRole::LEADER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($viewer, ['role' => GroupRole::LEADER, 'status' => GroupMembershipStatus::ACTIVE]);
 
     $conversation = Conversation::factory()->create([
         'group_id' => $group->id,
@@ -169,8 +169,8 @@ test('the mobile composer pill is hidden for users who cannot comment', function
         'visibility' => GroupVisibility::PUBLIC,
         'messaging' => GroupMessaging::ONLY_LEADERS,
     ]);
-    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => MembershipStatus::ACTIVE]);
-    $group->allUsers()->attach($reader, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => GroupMembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($reader, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::ACTIVE]);
 
     $conversation = Conversation::factory()->create(['group_id' => $group->id, 'user_id' => $leader->id]);
 

--- a/tests/Feature/GroupConversationDeleteFromListTest.php
+++ b/tests/Feature/GroupConversationDeleteFromListTest.php
@@ -1,9 +1,9 @@
 <?php
 
+use App\Enums\GroupMembershipStatus;
 use App\Enums\GroupMessaging;
 use App\Enums\GroupRole;
 use App\Enums\GroupVisibility;
-use App\Enums\MembershipStatus;
 use App\Models\Conversation;
 use App\Models\Group;
 use App\Models\User;
@@ -24,7 +24,7 @@ function attachDel(Group $group, User $user, GroupRole $role = GroupRole::MEMBER
 {
     $group->allUsers()->attach($user, [
         'role' => $role,
-        'status' => MembershipStatus::ACTIVE,
+        'status' => GroupMembershipStatus::ACTIVE,
     ]);
 }
 

--- a/tests/Feature/GroupConversationLayoutTest.php
+++ b/tests/Feature/GroupConversationLayoutTest.php
@@ -1,9 +1,9 @@
 <?php
 
+use App\Enums\GroupMembershipStatus;
 use App\Enums\GroupMessaging;
 use App\Enums\GroupRole;
 use App\Enums\GroupVisibility;
-use App\Enums\MembershipStatus;
 use App\Models\Conversation;
 use App\Models\Group;
 use App\Models\User;
@@ -21,11 +21,11 @@ function buildLayoutScenario(int $extraMembers = 0): array
         'messaging' => GroupMessaging::ALL_MEMBERS,
         'name' => 'Elders',
     ]);
-    $group->allUsers()->attach($viewer, ['role' => GroupRole::LEADER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($viewer, ['role' => GroupRole::LEADER, 'status' => GroupMembershipStatus::ACTIVE]);
 
     for ($i = 0; $i < $extraMembers; $i++) {
         $member = User::factory()->create(['name' => "Member {$i}"]);
-        $group->allUsers()->attach($member, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+        $group->allUsers()->attach($member, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::ACTIVE]);
     }
 
     $conversation = Conversation::factory()->create([
@@ -185,8 +185,8 @@ test('empty state encourages read-only viewers differently than commenters', fun
         'visibility' => GroupVisibility::PUBLIC,
         'messaging' => GroupMessaging::ONLY_LEADERS,
     ]);
-    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => MembershipStatus::ACTIVE]);
-    $group->allUsers()->attach($reader, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => GroupMembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($reader, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::ACTIVE]);
 
     $conversation = Conversation::factory()->create(['group_id' => $group->id, 'user_id' => $leader->id]);
 

--- a/tests/Feature/GroupConversationMentionsTest.php
+++ b/tests/Feature/GroupConversationMentionsTest.php
@@ -1,10 +1,10 @@
 <?php
 
 use App\Actions\Comments\ResolveGroupMentionsAutocompleteAction;
+use App\Enums\GroupMembershipStatus;
 use App\Enums\GroupMessaging;
 use App\Enums\GroupRole;
 use App\Enums\GroupVisibility;
-use App\Enums\MembershipStatus;
 use App\Models\Conversation;
 use App\Models\Group;
 use App\Models\User;
@@ -24,14 +24,14 @@ function buildMentionScenario(): array
     ]);
 
     $caller = User::factory()->create();
-    $group->allUsers()->attach($caller, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($caller, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::ACTIVE]);
 
     $conversation = Conversation::factory()->create(['group_id' => $group->id, 'user_id' => $caller->id]);
 
     return [$group, $conversation, $caller];
 }
 
-function attachMentionMember(Group $group, User $user, MembershipStatus $status = MembershipStatus::ACTIVE): void
+function attachMentionMember(Group $group, User $user, GroupMembershipStatus $status = GroupMembershipStatus::ACTIVE): void
 {
     $group->allUsers()->attach($user, ['role' => GroupRole::MEMBER, 'status' => $status]);
 }
@@ -82,7 +82,7 @@ test('mentionCandidates excludes inactive (pending) group members', function ():
     [$group, $conversation, $caller] = buildMentionScenario();
 
     $pending = User::factory()->create(['name' => 'Patty Pending']);
-    attachMentionMember($group, $pending, MembershipStatus::PENDING);
+    attachMentionMember($group, $pending, GroupMembershipStatus::PENDING);
 
     Livewire::actingAs($caller)
         ->test('pages::groups.conversations.show', ['group' => $group, 'conversation' => $conversation])

--- a/tests/Feature/GroupConversationPinTest.php
+++ b/tests/Feature/GroupConversationPinTest.php
@@ -1,9 +1,9 @@
 <?php
 
+use App\Enums\GroupMembershipStatus;
 use App\Enums\GroupMessaging;
 use App\Enums\GroupRole;
 use App\Enums\GroupVisibility;
-use App\Enums\MembershipStatus;
 use App\Models\Conversation;
 use App\Models\Group;
 use App\Models\User;
@@ -24,7 +24,7 @@ function attachPin(Group $group, User $user, GroupRole $role = GroupRole::MEMBER
 {
     $group->allUsers()->attach($user, [
         'role' => $role,
-        'status' => MembershipStatus::ACTIVE,
+        'status' => GroupMembershipStatus::ACTIVE,
     ]);
 }
 

--- a/tests/Feature/GroupConversationsTest.php
+++ b/tests/Feature/GroupConversationsTest.php
@@ -1,9 +1,9 @@
 <?php
 
+use App\Enums\GroupMembershipStatus;
 use App\Enums\GroupMessaging;
 use App\Enums\GroupRole;
 use App\Enums\GroupVisibility;
-use App\Enums\MembershipStatus;
 use App\Models\Conversation;
 use App\Models\Group;
 use App\Models\User;
@@ -19,7 +19,7 @@ function attachMember(Group $group, User $user, GroupRole $role = GroupRole::MEM
 {
     $group->allUsers()->attach($user, [
         'role' => $role,
-        'status' => MembershipStatus::ACTIVE,
+        'status' => GroupMembershipStatus::ACTIVE,
     ]);
 }
 

--- a/tests/Feature/GroupJoinTest.php
+++ b/tests/Feature/GroupJoinTest.php
@@ -1,9 +1,9 @@
 <?php
 
+use App\Enums\GroupMembershipStatus;
 use App\Enums\GroupMessaging;
 use App\Enums\GroupRole;
 use App\Enums\GroupVisibility;
-use App\Enums\MembershipStatus;
 use App\Models\Group;
 use App\Models\User;
 use App\Notifications\GroupJoinRequestNotification;
@@ -47,7 +47,7 @@ test('non-members cannot view a private group show page', function (): void {
 test('active members can view a private group show page', function (): void {
     $user = User::factory()->create();
     $group = Group::factory()->create(['visibility' => GroupVisibility::PRIVATE]);
-    $group->allUsers()->attach($user, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($user, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::ACTIVE]);
 
     $this->actingAs($user)
         ->get("/groups/{$group->id}")
@@ -62,7 +62,7 @@ test('user can request to join a public group', function (): void {
     $leader = User::factory()->create();
     $user = User::factory()->create();
     $group = Group::factory()->create(['visibility' => GroupVisibility::PUBLIC]);
-    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => GroupMembershipStatus::ACTIVE]);
 
     $this->actingAs($user);
 
@@ -74,7 +74,7 @@ test('user can request to join a public group', function (): void {
         'group_id' => $group->id,
         'user_id' => $user->id,
         'role' => GroupRole::MEMBER->value,
-        'status' => MembershipStatus::PENDING->value,
+        'status' => GroupMembershipStatus::PENDING->value,
     ]);
 
     Notification::assertSentTo($leader, GroupJoinRequestNotification::class);
@@ -93,7 +93,7 @@ test('user cannot join a private group', function (): void {
 test('user cannot join if already pending', function (): void {
     $user = User::factory()->create();
     $group = Group::factory()->create(['visibility' => GroupVisibility::PUBLIC]);
-    $group->allUsers()->attach($user, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::PENDING]);
+    $group->allUsers()->attach($user, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::PENDING]);
 
     $this->actingAs($user);
 
@@ -105,7 +105,7 @@ test('user cannot join if already pending', function (): void {
 test('user cannot join if already active member', function (): void {
     $user = User::factory()->create();
     $group = Group::factory()->create(['visibility' => GroupVisibility::PUBLIC]);
-    $group->allUsers()->attach($user, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($user, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::ACTIVE]);
 
     $this->actingAs($user);
 
@@ -120,8 +120,8 @@ test('rejected user can re-request to join', function (): void {
     $leader = User::factory()->create();
     $user = User::factory()->create();
     $group = Group::factory()->create(['visibility' => GroupVisibility::PUBLIC]);
-    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => MembershipStatus::ACTIVE]);
-    $group->allUsers()->attach($user, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::REJECTED]);
+    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => GroupMembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($user, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::REJECTED]);
 
     $this->actingAs($user);
 
@@ -132,14 +132,14 @@ test('rejected user can re-request to join', function (): void {
     $this->assertDatabaseHas('group_user', [
         'group_id' => $group->id,
         'user_id' => $user->id,
-        'status' => MembershipStatus::PENDING->value,
+        'status' => GroupMembershipStatus::PENDING->value,
     ]);
 });
 
 test('user can cancel a pending join request', function (): void {
     $user = User::factory()->create();
     $group = Group::factory()->create(['visibility' => GroupVisibility::PUBLIC]);
-    $group->allUsers()->attach($user, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::PENDING]);
+    $group->allUsers()->attach($user, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::PENDING]);
 
     $this->actingAs($user);
 
@@ -160,8 +160,8 @@ test('leader can approve a pending request', function (): void {
     $leader = User::factory()->create();
     $user = User::factory()->create();
     $group = Group::factory()->create(['visibility' => GroupVisibility::PUBLIC]);
-    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => MembershipStatus::ACTIVE]);
-    $group->allUsers()->attach($user, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::PENDING]);
+    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => GroupMembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($user, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::PENDING]);
 
     $this->actingAs($leader);
 
@@ -172,7 +172,7 @@ test('leader can approve a pending request', function (): void {
     $this->assertDatabaseHas('group_user', [
         'group_id' => $group->id,
         'user_id' => $user->id,
-        'status' => MembershipStatus::ACTIVE->value,
+        'status' => GroupMembershipStatus::ACTIVE->value,
     ]);
 
     Notification::assertSentTo($user, GroupMembershipResponseNotification::class, function ($notification) {
@@ -186,8 +186,8 @@ test('leader can reject a pending request', function (): void {
     $leader = User::factory()->create();
     $user = User::factory()->create();
     $group = Group::factory()->create(['visibility' => GroupVisibility::PUBLIC]);
-    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => MembershipStatus::ACTIVE]);
-    $group->allUsers()->attach($user, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::PENDING]);
+    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => GroupMembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($user, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::PENDING]);
 
     $this->actingAs($leader);
 
@@ -198,7 +198,7 @@ test('leader can reject a pending request', function (): void {
     $this->assertDatabaseHas('group_user', [
         'group_id' => $group->id,
         'user_id' => $user->id,
-        'status' => MembershipStatus::REJECTED->value,
+        'status' => GroupMembershipStatus::REJECTED->value,
     ]);
 
     Notification::assertSentTo($user, GroupMembershipResponseNotification::class, function ($notification) {
@@ -210,8 +210,8 @@ test('non-leader cannot approve a pending request', function (): void {
     $member = User::factory()->create();
     $user = User::factory()->create();
     $group = Group::factory()->create(['visibility' => GroupVisibility::PUBLIC]);
-    $group->allUsers()->attach($member, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
-    $group->allUsers()->attach($user, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::PENDING]);
+    $group->allUsers()->attach($member, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($user, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::PENDING]);
 
     $this->actingAs($member);
 
@@ -228,7 +228,7 @@ test('leader can directly add a member', function (): void {
     $leader = User::factory()->create();
     $user = User::factory()->create();
     $group = Group::factory()->create(['visibility' => GroupVisibility::PUBLIC]);
-    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => GroupMembershipStatus::ACTIVE]);
 
     $this->actingAs($leader);
 
@@ -240,7 +240,7 @@ test('leader can directly add a member', function (): void {
         'group_id' => $group->id,
         'user_id' => $user->id,
         'role' => GroupRole::MEMBER->value,
-        'status' => MembershipStatus::ACTIVE->value,
+        'status' => GroupMembershipStatus::ACTIVE->value,
     ]);
 
     Notification::assertSentTo($user, GroupMemberAddedNotification::class);
@@ -250,7 +250,7 @@ test('non-leader cannot add a member', function (): void {
     $member = User::factory()->create();
     $user = User::factory()->create();
     $group = Group::factory()->create(['visibility' => GroupVisibility::PUBLIC]);
-    $group->allUsers()->attach($member, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($member, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::ACTIVE]);
 
     $this->actingAs($member);
 
@@ -265,8 +265,8 @@ test('active member can leave a group', function (): void {
     $user = User::factory()->create();
     $leader = User::factory()->create();
     $group = Group::factory()->create(['visibility' => GroupVisibility::PUBLIC]);
-    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => MembershipStatus::ACTIVE]);
-    $group->allUsers()->attach($user, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => GroupMembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($user, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::ACTIVE]);
 
     $this->actingAs($user);
 
@@ -283,7 +283,7 @@ test('active member can leave a group', function (): void {
 test('sole leader cannot leave the group', function (): void {
     $leader = User::factory()->create();
     $group = Group::factory()->create(['visibility' => GroupVisibility::PUBLIC]);
-    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => GroupMembershipStatus::ACTIVE]);
 
     $this->actingAs($leader);
 
@@ -298,8 +298,8 @@ test('leader can remove a member', function (): void {
     $leader = User::factory()->create();
     $user = User::factory()->create();
     $group = Group::factory()->create(['visibility' => GroupVisibility::PUBLIC]);
-    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => MembershipStatus::ACTIVE]);
-    $group->allUsers()->attach($user, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => GroupMembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($user, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::ACTIVE]);
 
     $this->actingAs($leader);
 
@@ -316,7 +316,7 @@ test('leader can remove a member', function (): void {
 test('cannot remove the sole leader', function (): void {
     $leader = User::factory()->create();
     $group = Group::factory()->create(['visibility' => GroupVisibility::PUBLIC]);
-    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => GroupMembershipStatus::ACTIVE]);
 
     $this->actingAs($leader);
 
@@ -335,8 +335,8 @@ test('members tab is visible to leaders', function (): void {
     $leader = User::factory()->create();
     $member = User::factory()->create();
     $group = Group::factory()->create(['visibility' => GroupVisibility::PUBLIC]);
-    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => MembershipStatus::ACTIVE]);
-    $group->allUsers()->attach($member, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => GroupMembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($member, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::ACTIVE]);
 
     $this->actingAs($leader);
 
@@ -351,9 +351,9 @@ test('members tab is visible to regular members', function (): void {
     $user = User::factory()->create();
     $pending = User::factory()->create(['name' => 'Pending Person']);
     $group = Group::factory()->create(['visibility' => GroupVisibility::PUBLIC]);
-    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => MembershipStatus::ACTIVE]);
-    $group->allUsers()->attach($user, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
-    $group->allUsers()->attach($pending, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::PENDING]);
+    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => GroupMembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($user, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($pending, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::PENDING]);
 
     $this->actingAs($user);
 
@@ -369,7 +369,7 @@ test('members tab is not visible to non-members', function (): void {
     $leader = User::factory()->create(['name' => 'Group Leader']);
     $user = User::factory()->create();
     $group = Group::factory()->create(['visibility' => GroupVisibility::PUBLIC]);
-    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => GroupMembershipStatus::ACTIVE]);
 
     $this->actingAs($user);
 
@@ -397,7 +397,7 @@ test('conversations tab is visible to members when messaging is enabled', functi
         'visibility' => GroupVisibility::PUBLIC,
         'messaging' => GroupMessaging::ALL_MEMBERS,
     ]);
-    $group->allUsers()->attach($user, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($user, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::ACTIVE]);
 
     $this->actingAs($user);
 
@@ -432,7 +432,7 @@ test('group description is sanitized of malicious HTML', function (): void {
 test('leader sees edit button on show page', function (): void {
     $leader = User::factory()->create();
     $group = Group::factory()->create(['visibility' => GroupVisibility::PUBLIC]);
-    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => GroupMembershipStatus::ACTIVE]);
 
     $this->actingAs($leader);
 
@@ -444,8 +444,8 @@ test('leader sees pending requests on members tab', function (): void {
     $leader = User::factory()->create();
     $pending = User::factory()->create(['name' => 'Pending Person']);
     $group = Group::factory()->create(['visibility' => GroupVisibility::PUBLIC]);
-    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => MembershipStatus::ACTIVE]);
-    $group->allUsers()->attach($pending, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::PENDING]);
+    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => GroupMembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($pending, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::PENDING]);
 
     $this->actingAs($leader);
 
@@ -460,10 +460,10 @@ test('leader sees pending requests on members tab', function (): void {
 test('my groups section shows active groups', function (): void {
     $user = User::factory()->create();
     $group = Group::factory()->create(['name' => 'My Active Group', 'visibility' => GroupVisibility::PUBLIC]);
-    $group->allUsers()->attach($user, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($user, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::ACTIVE]);
 
     $pendingGroup = Group::factory()->create(['name' => 'Pending Group', 'visibility' => GroupVisibility::PRIVATE]);
-    $pendingGroup->allUsers()->attach($user, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::PENDING]);
+    $pendingGroup->allUsers()->attach($user, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::PENDING]);
 
     $this->actingAs($user);
 

--- a/tests/Feature/GroupMemberRoleChangeTest.php
+++ b/tests/Feature/GroupMemberRoleChangeTest.php
@@ -1,9 +1,9 @@
 <?php
 
+use App\Enums\GroupMembershipStatus;
 use App\Enums\GroupMessaging;
 use App\Enums\GroupRole;
 use App\Enums\GroupVisibility;
-use App\Enums\MembershipStatus;
 use App\Models\Group;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -23,7 +23,7 @@ function attachRole(Group $group, User $user, GroupRole $role = GroupRole::MEMBE
 {
     $group->allUsers()->attach($user, [
         'role' => $role,
-        'status' => MembershipStatus::ACTIVE,
+        'status' => GroupMembershipStatus::ACTIVE,
     ]);
 }
 

--- a/tests/Feature/GroupTest.php
+++ b/tests/Feature/GroupTest.php
@@ -1,9 +1,9 @@
 <?php
 
+use App\Enums\GroupMembershipStatus;
 use App\Enums\GroupMessaging;
 use App\Enums\GroupRole;
 use App\Enums\GroupVisibility;
-use App\Enums\MembershipStatus;
 use App\Models\Group;
 use App\Models\User;
 use Illuminate\Database\UniqueConstraintViolationException;
@@ -136,7 +136,7 @@ test('groups index search filters by name', function (): void {
 test('leaders can delete a group from the index page', function (): void {
     $user = User::factory()->create();
     $group = Group::factory()->create(['name' => 'Old Group', 'visibility' => GroupVisibility::PUBLIC]);
-    $group->allUsers()->attach($user, ['role' => GroupRole::LEADER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($user, ['role' => GroupRole::LEADER, 'status' => GroupMembershipStatus::ACTIVE]);
 
     $this->actingAs($user);
 
@@ -190,7 +190,7 @@ test('group creator is automatically assigned as leader', function (): void {
         'group_id' => $group->id,
         'user_id' => $user->id,
         'role' => GroupRole::LEADER->value,
-        'status' => MembershipStatus::ACTIVE->value,
+        'status' => GroupMembershipStatus::ACTIVE->value,
     ]);
 });
 
@@ -199,8 +199,8 @@ test('members relationship returns only active users', function (): void {
     $active = User::factory()->create();
     $pending = User::factory()->create();
 
-    $group->allUsers()->attach($active, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
-    $group->allUsers()->attach($pending, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::PENDING]);
+    $group->allUsers()->attach($active, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($pending, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::PENDING]);
 
     expect($group->members)->toHaveCount(1);
     expect($group->members->first()->id)->toBe($active->id);
@@ -212,9 +212,9 @@ test('leaders relationship returns only active leaders', function (): void {
     $member = User::factory()->create();
     $pendingLeader = User::factory()->create();
 
-    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => MembershipStatus::ACTIVE]);
-    $group->allUsers()->attach($member, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
-    $group->allUsers()->attach($pendingLeader, ['role' => GroupRole::LEADER, 'status' => MembershipStatus::PENDING]);
+    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => GroupMembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($member, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($pendingLeader, ['role' => GroupRole::LEADER, 'status' => GroupMembershipStatus::PENDING]);
 
     expect($group->leaders)->toHaveCount(1);
     expect($group->leaders->first()->id)->toBe($leader->id);
@@ -225,8 +225,8 @@ test('pending requests returns only pending users', function (): void {
     $pending = User::factory()->create();
     $active = User::factory()->create();
 
-    $group->allUsers()->attach($pending, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::PENDING]);
-    $group->allUsers()->attach($active, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($pending, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::PENDING]);
+    $group->allUsers()->attach($active, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::ACTIVE]);
 
     expect($group->pendingRequests)->toHaveCount(1);
     expect($group->pendingRequests->first()->id)->toBe($pending->id);
@@ -236,9 +236,9 @@ test('all users returns every membership regardless of status', function (): voi
     $group = Group::factory()->create();
     $users = User::factory()->count(3)->create();
 
-    $group->allUsers()->attach($users[0], ['role' => GroupRole::LEADER, 'status' => MembershipStatus::ACTIVE]);
-    $group->allUsers()->attach($users[1], ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::PENDING]);
-    $group->allUsers()->attach($users[2], ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::REJECTED]);
+    $group->allUsers()->attach($users[0], ['role' => GroupRole::LEADER, 'status' => GroupMembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($users[1], ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::PENDING]);
+    $group->allUsers()->attach($users[2], ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::REJECTED]);
 
     expect($group->allUsers)->toHaveCount(3);
 });
@@ -248,8 +248,8 @@ test('user groups relationship returns only active memberships', function (): vo
     $activeGroup = Group::factory()->create();
     $pendingGroup = Group::factory()->create();
 
-    $activeGroup->allUsers()->attach($user, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
-    $pendingGroup->allUsers()->attach($user, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::PENDING]);
+    $activeGroup->allUsers()->attach($user, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::ACTIVE]);
+    $pendingGroup->allUsers()->attach($user, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::PENDING]);
 
     expect($user->groups)->toHaveCount(1);
     expect($user->groups->first()->id)->toBe($activeGroup->id);
@@ -259,9 +259,9 @@ test('duplicate group membership is prevented', function (): void {
     $group = Group::factory()->create();
     $user = User::factory()->create();
 
-    $group->allUsers()->attach($user, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($user, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::ACTIVE]);
 
-    expect(fn () => $group->allUsers()->attach($user, ['role' => GroupRole::LEADER, 'status' => MembershipStatus::ACTIVE]))
+    expect(fn () => $group->allUsers()->attach($user, ['role' => GroupRole::LEADER, 'status' => GroupMembershipStatus::ACTIVE]))
         ->toThrow(UniqueConstraintViolationException::class);
 });
 
@@ -269,7 +269,7 @@ test('deleting a group removes its memberships', function (): void {
     $group = Group::factory()->create();
     $user = User::factory()->create();
 
-    $group->allUsers()->attach($user, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($user, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::ACTIVE]);
 
     $group->delete();
 
@@ -287,7 +287,7 @@ test('guests are redirected from the groups edit page', function (): void {
 test('leaders can view the groups edit page', function (): void {
     $user = User::factory()->create();
     $group = Group::factory()->create();
-    $group->allUsers()->attach($user, ['role' => GroupRole::LEADER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($user, ['role' => GroupRole::LEADER, 'status' => GroupMembershipStatus::ACTIVE]);
 
     $this->actingAs($user)
         ->get(route('groups.edit', $group))
@@ -298,7 +298,7 @@ test('leaders can view the groups edit page', function (): void {
 test('non-leaders cannot view the groups edit page', function (): void {
     $user = User::factory()->create();
     $group = Group::factory()->create();
-    $group->allUsers()->attach($user, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($user, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::ACTIVE]);
 
     $this->actingAs($user)
         ->get(route('groups.edit', $group))
@@ -308,7 +308,7 @@ test('non-leaders cannot view the groups edit page', function (): void {
 test('leaders can update a group', function (): void {
     $user = User::factory()->create();
     $group = Group::factory()->create(['name' => 'Old Name', 'visibility' => GroupVisibility::PUBLIC]);
-    $group->allUsers()->attach($user, ['role' => GroupRole::LEADER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($user, ['role' => GroupRole::LEADER, 'status' => GroupMembershipStatus::ACTIVE]);
 
     $this->actingAs($user);
 
@@ -334,7 +334,7 @@ test('leaders can update a group with a new image', function (): void {
 
     $user = User::factory()->create();
     $group = Group::factory()->create();
-    $group->allUsers()->attach($user, ['role' => GroupRole::LEADER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($user, ['role' => GroupRole::LEADER, 'status' => GroupMembershipStatus::ACTIVE]);
 
     $this->actingAs($user);
 
@@ -358,7 +358,7 @@ test('leaders can remove an existing group image', function (): void {
 
     $user = User::factory()->create();
     $group = Group::factory()->create(['image' => 'groups/old-image.jpg']);
-    $group->allUsers()->attach($user, ['role' => GroupRole::LEADER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($user, ['role' => GroupRole::LEADER, 'status' => GroupMembershipStatus::ACTIVE]);
 
     $this->actingAs($user);
 
@@ -377,7 +377,7 @@ test('leaders can remove an existing group image', function (): void {
 test('leaders can delete a group from the edit page', function (): void {
     $user = User::factory()->create();
     $group = Group::factory()->create();
-    $group->allUsers()->attach($user, ['role' => GroupRole::LEADER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($user, ['role' => GroupRole::LEADER, 'status' => GroupMembershipStatus::ACTIVE]);
 
     $this->actingAs($user);
 
@@ -396,7 +396,7 @@ test('leaders can add multiple members in one batch', function (): void {
         'visibility' => GroupVisibility::PUBLIC,
         'messaging' => GroupMessaging::ALL_MEMBERS,
     ]);
-    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => GroupMembershipStatus::ACTIVE]);
 
     Livewire::actingAs($leader)
         ->test('pages::groups.show', ['group' => $group])
@@ -419,8 +419,8 @@ test('regular members cannot add members via addMembers', function (): void {
         'visibility' => GroupVisibility::PUBLIC,
         'messaging' => GroupMessaging::ALL_MEMBERS,
     ]);
-    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => MembershipStatus::ACTIVE]);
-    $group->allUsers()->attach($member, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => GroupMembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($member, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::ACTIVE]);
 
     Livewire::actingAs($member)
         ->test('pages::groups.show', ['group' => $group])
@@ -437,7 +437,7 @@ test('addMembers picks up users via the popover pickUser flow', function (): voi
         'visibility' => GroupVisibility::PUBLIC,
         'messaging' => GroupMessaging::ALL_MEMBERS,
     ]);
-    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($leader, ['role' => GroupRole::LEADER, 'status' => GroupMembershipStatus::ACTIVE]);
 
     Livewire::actingAs($leader)
         ->test('pages::groups.show', ['group' => $group])
@@ -456,8 +456,8 @@ test('my groups card shows latest message preview when a comment exists', functi
     $user = User::factory()->create();
     $author = User::factory()->create(['name' => 'Alice Author']);
     $group = Group::factory()->create(['name' => 'Worship Team', 'visibility' => GroupVisibility::PUBLIC]);
-    $group->allUsers()->attach($user, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
-    $group->allUsers()->attach($author, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($user, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($author, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::ACTIVE]);
 
     $conversation = $group->conversations()->create([
         'user_id' => $author->id,
@@ -475,7 +475,7 @@ test('my groups card shows latest message preview when a comment exists', functi
 test('my groups card shows "No messages yet" when group has no comments', function (): void {
     $user = User::factory()->create();
     $group = Group::factory()->create(['name' => 'Quiet Group', 'visibility' => GroupVisibility::PUBLIC]);
-    $group->allUsers()->attach($user, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($user, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::ACTIVE]);
 
     Livewire::actingAs($user)
         ->test('pages::groups.index')
@@ -487,10 +487,10 @@ test('my groups card shows "No messages yet" when group has no comments', functi
 test('my groups card renders a flux avatar group with a +N overflow for groups with more than four members', function (): void {
     $user = User::factory()->create();
     $group = Group::factory()->create(['name' => 'Big Crew', 'visibility' => GroupVisibility::PUBLIC]);
-    $group->allUsers()->attach($user, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+    $group->allUsers()->attach($user, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::ACTIVE]);
 
     foreach (User::factory()->count(6)->create() as $member) {
-        $group->allUsers()->attach($member, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+        $group->allUsers()->attach($member, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::ACTIVE]);
     }
 
     $component = Livewire::actingAs($user)
@@ -559,7 +559,7 @@ test('discover filter chips restrict by messaging and combine with search', func
 test('discover excludes groups the current user is already a member of', function (): void {
     $user = User::factory()->create();
     $joined = Group::factory()->create(['name' => 'My Group', 'visibility' => GroupVisibility::PUBLIC]);
-    $joined->allUsers()->attach($user, ['role' => GroupRole::MEMBER, 'status' => MembershipStatus::ACTIVE]);
+    $joined->allUsers()->attach($user, ['role' => GroupRole::MEMBER, 'status' => GroupMembershipStatus::ACTIVE]);
     Group::factory()->create(['name' => 'Other Group', 'visibility' => GroupVisibility::PUBLIC]);
 
     $this->actingAs($user);
@@ -583,7 +583,7 @@ test('discover join action sends a join request and removes the group from disco
     $this->assertDatabaseHas('group_user', [
         'group_id' => $group->id,
         'user_id' => $user->id,
-        'status' => MembershipStatus::PENDING->value,
+        'status' => GroupMembershipStatus::PENDING->value,
     ]);
 
     expect($component->get('discover')->pluck('name')->all())->toBe([]);

--- a/tests/Feature/MuteConversationTest.php
+++ b/tests/Feature/MuteConversationTest.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
+use App\Enums\GroupMembershipStatus;
 use App\Enums\GroupMessaging;
-use App\Enums\MembershipStatus;
 use App\Models\Conversation;
 use App\Models\Group;
 use App\Models\MutedCommentable;
@@ -21,7 +21,7 @@ function activateGroupMember(Group $group, User $user): void
 {
     $group->allUsers()->attach($user, [
         'role' => 'member',
-        'status' => MembershipStatus::ACTIVE,
+        'status' => GroupMembershipStatus::ACTIVE,
     ]);
 }
 

--- a/tests/Feature/Notifications/DispatchCommentNotificationsListenerTest.php
+++ b/tests/Feature/Notifications/DispatchCommentNotificationsListenerTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use App\Enums\MembershipStatus;
+use App\Enums\GroupMembershipStatus;
 use App\Models\Conversation;
 use App\Models\Group;
 use App\Models\LiturgyElement;
@@ -20,7 +20,7 @@ function attachActiveMember(Group $group, User $user): void
 {
     $group->allUsers()->attach($user, [
         'role' => 'member',
-        'status' => MembershipStatus::ACTIVE,
+        'status' => GroupMembershipStatus::ACTIVE,
     ]);
 }
 

--- a/tests/Feature/People/AddPersonModalTest.php
+++ b/tests/Feature/People/AddPersonModalTest.php
@@ -1,0 +1,59 @@
+<?php
+
+use App\Models\Person;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function (): void {
+    $this->actingAs(User::factory()->create());
+});
+
+test('saves a new person with name and email', function (): void {
+    Livewire::test('people.add-modal')
+        ->set('form.first_name', 'Jane')
+        ->set('form.last_name', 'Doe')
+        ->set('form.email', 'jane.doe@example.com')
+        ->call('save')
+        ->assertHasNoErrors()
+        ->assertDispatched('person-added');
+
+    expect(Person::where('email', 'jane.doe@example.com')->first())
+        ->not->toBeNull()
+        ->first_name->toBe('Jane')
+        ->last_name->toBe('Doe');
+});
+
+test('requires first and last name', function (): void {
+    Livewire::test('people.add-modal')
+        ->set('form.first_name', '')
+        ->set('form.last_name', '')
+        ->set('form.email', 'jane@example.com')
+        ->call('save')
+        ->assertHasErrors(['form.first_name', 'form.last_name']);
+});
+
+test('save & open profile dispatches drawer open event', function (): void {
+    Livewire::test('people.add-modal')
+        ->set('form.first_name', 'Sam')
+        ->set('form.last_name', 'Park')
+        ->set('form.email', 'sam@example.com')
+        ->call('save', true)
+        ->assertHasNoErrors()
+        ->assertDispatched('open-person-drawer');
+});
+
+test('does not create a User account', function (): void {
+    $userCountBefore = User::count();
+
+    Livewire::test('people.add-modal')
+        ->set('form.first_name', 'Jane')
+        ->set('form.last_name', 'Doe')
+        ->set('form.email', 'jane.doe@example.com')
+        ->call('save')
+        ->assertHasNoErrors();
+
+    expect(User::count())->toBe($userCountBefore);
+});

--- a/tests/Feature/People/DrawerTest.php
+++ b/tests/Feature/People/DrawerTest.php
@@ -1,0 +1,149 @@
+<?php
+
+use App\Enums\AccessRole;
+use App\Enums\MembershipStatus;
+use App\Enums\Office;
+use App\Enums\TerminationReason;
+use App\Models\Person;
+use App\Models\PersonOffice;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function (): void {
+    $this->actingAs(User::factory()->create());
+});
+
+test('opens drawer for a person', function (): void {
+    $person = Person::factory()->member()->create(['first_name' => 'Joshua', 'last_name' => 'Pangborn']);
+
+    Livewire::test('people.drawer')
+        ->call('openPerson', $person->id)
+        ->assertSet('personId', $person->id)
+        ->assertSet('form.first_name', 'Joshua')
+        ->assertSet('form.last_name', 'Pangborn');
+});
+
+test('saves contact changes', function (): void {
+    $person = Person::factory()->visitor()->create(['phone' => null]);
+
+    Livewire::test('people.drawer')
+        ->call('openPerson', $person->id)
+        ->set('form.phone', '(206) 555-0142')
+        ->set('form.address_city', 'Seattle')
+        ->call('save')
+        ->assertHasNoErrors()
+        ->assertDispatched('person-saved');
+
+    $person->refresh();
+    expect($person->phone)->toBe('(206) 555-0142');
+    expect($person->address_city)->toBe('Seattle');
+});
+
+test('changes membership status', function (): void {
+    $person = Person::factory()->visitor()->create();
+
+    Livewire::test('people.drawer')
+        ->call('openPerson', $person->id)
+        ->set('form.membership_status', MembershipStatus::MEMBER->value)
+        ->call('save')
+        ->assertHasNoErrors();
+
+    expect($person->refresh()->membership_status)->toBe(MembershipStatus::MEMBER);
+});
+
+test('terminating records reason and clears it when status reverted', function (): void {
+    $person = Person::factory()->member()->create();
+
+    Livewire::test('people.drawer')
+        ->call('openPerson', $person->id)
+        ->set('form.membership_status', MembershipStatus::TERMINATED->value)
+        ->set('form.termination_reason', TerminationReason::TRANSFERRED->value)
+        ->call('save')
+        ->assertHasNoErrors();
+
+    $person->refresh();
+    expect($person->membership_status)->toBe(MembershipStatus::TERMINATED);
+    expect($person->termination_reason)->toBe(TerminationReason::TRANSFERRED);
+
+    Livewire::test('people.drawer')
+        ->call('openPerson', $person->id)
+        ->set('form.membership_status', MembershipStatus::ADHERENT->value)
+        ->call('save');
+
+    $person->refresh();
+    expect($person->membership_status)->toBe(MembershipStatus::ADHERENT);
+    expect($person->termination_reason)->toBeNull();
+});
+
+test('adds a new office', function (): void {
+    $person = Person::factory()->member()->create();
+
+    Livewire::test('people.drawer')
+        ->call('openPerson', $person->id)
+        ->set('newOffice', Office::ELDER->value)
+        ->set('newOfficeStartedOn', '2024-01-15')
+        ->call('addOffice')
+        ->assertHasNoErrors();
+
+    expect($person->offices()->count())->toBe(1);
+    expect($person->offices()->first()->kind)->toBe(Office::ELDER);
+});
+
+test('ends a current office', function (): void {
+    $person = Person::factory()->member()->create();
+    $office = PersonOffice::factory()->elder()->create(['person_id' => $person->id]);
+
+    Livewire::test('people.drawer')
+        ->call('openPerson', $person->id)
+        ->call('endOffice', $office->id);
+
+    $office->refresh();
+    expect($office->ended_on)->not->toBeNull();
+    expect($person->offices()->count())->toBe(0);
+    expect($person->formerOffices()->count())->toBe(1);
+});
+
+test('toggles an access role on the linked user', function (): void {
+    $person = Person::factory()->member()->create();
+    User::factory()->create(['person_id' => $person->id]);
+
+    Livewire::test('people.drawer')
+        ->call('openPerson', $person->id)
+        ->call('toggleAccessRole', AccessRole::ADMIN->value);
+
+    expect($person->fresh()->user->hasAccessRole(AccessRole::ADMIN))->toBeTrue();
+
+    Livewire::test('people.drawer')
+        ->call('openPerson', $person->id)
+        ->call('toggleAccessRole', AccessRole::ADMIN->value);
+
+    expect($person->fresh()->user->hasAccessRole(AccessRole::ADMIN))->toBeFalse();
+});
+
+test('assigns a pastoral care elder', function (): void {
+    $elder = Person::factory()->member()->create();
+    PersonOffice::factory()->elder()->create(['person_id' => $elder->id]);
+
+    $person = Person::factory()->visitor()->create();
+
+    Livewire::test('people.drawer')
+        ->call('openPerson', $person->id)
+        ->set('form.pastoral_care_elder_id', $elder->id)
+        ->call('save');
+
+    expect($person->refresh()->pastoral_care_elder_id)->toBe($elder->id);
+});
+
+test('deletes a person', function (): void {
+    $person = Person::factory()->visitor()->create();
+
+    Livewire::test('people.drawer')
+        ->call('openPerson', $person->id)
+        ->call('delete')
+        ->assertDispatched('person-deleted');
+
+    expect(Person::find($person->id))->toBeNull();
+});

--- a/tests/Feature/People/IndexTest.php
+++ b/tests/Feature/People/IndexTest.php
@@ -80,6 +80,10 @@ test('layout and density persist via session', function (): void {
         ->assertSet('layout', 'cards')
         ->call('setDensity', 'compact')
         ->assertSet('density', 'compact');
+
+    Livewire::test('pages::people.index')
+        ->assertSet('layout', 'cards')
+        ->assertSet('density', 'compact');
 });
 
 test('openPerson dispatches drawer event', function (): void {

--- a/tests/Feature/People/IndexTest.php
+++ b/tests/Feature/People/IndexTest.php
@@ -1,0 +1,92 @@
+<?php
+
+use App\Models\Person;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function (): void {
+    $this->actingAs(User::factory()->create());
+    Person::query()->delete();
+});
+
+test('renders the people index', function (): void {
+    Person::factory()->count(3)->create();
+
+    $this->get('/people')->assertOk();
+});
+
+test('shows empty state when no people exist', function (): void {
+    $this->get('/people')->assertOk()->assertSee('No people yet');
+});
+
+test('counts each membership status', function (): void {
+    Person::factory()->member()->count(3)->create();
+    Person::factory()->catechumen()->count(2)->create();
+    Person::factory()->adherent()->count(1)->create();
+    Person::factory()->visitor()->count(4)->create();
+
+    Livewire::test('pages::people.index')
+        ->assertSet('filter', null)
+        ->tap(function ($t): void {
+            $counts = $t->instance()->counts;
+            expect($counts)->toMatchArray([
+                'all' => 10,
+                'member' => 3,
+                'catechumen' => 2,
+                'adherent' => 1,
+                'visitor' => 4,
+            ]);
+        });
+});
+
+test('filters by membership status', function (): void {
+    Person::factory()->member()->count(2)->create();
+    Person::factory()->visitor()->count(3)->create();
+
+    Livewire::test('pages::people.index')
+        ->call('setFilter', 'member')
+        ->assertSet('filter', 'member')
+        ->tap(function ($t): void {
+            expect($t->instance()->people->total())->toBe(2);
+        });
+});
+
+test('setFilter(all) clears the filter', function (): void {
+    Person::factory()->visitor()->create();
+
+    Livewire::test('pages::people.index')
+        ->call('setFilter', 'member')
+        ->call('setFilter', 'all')
+        ->assertSet('filter', null);
+});
+
+test('searches by name', function (): void {
+    Person::factory()->create(['first_name' => 'Joshua', 'last_name' => 'Pangborn']);
+    Person::factory()->create(['first_name' => 'Andrew', 'last_name' => 'Burnette']);
+
+    Livewire::test('pages::people.index')
+        ->set('search', 'Pangborn')
+        ->tap(function ($t): void {
+            expect($t->instance()->people->total())->toBe(1);
+        });
+});
+
+test('layout and density persist via session', function (): void {
+    Livewire::test('pages::people.index')
+        ->call('setLayout', 'cards')
+        ->assertSet('layout', 'cards')
+        ->call('setDensity', 'compact')
+        ->assertSet('density', 'compact');
+});
+
+test('openPerson dispatches drawer event', function (): void {
+    $person = Person::factory()->create();
+
+    Livewire::test('pages::people.index')
+        ->call('openPerson', $person->id)
+        ->assertSet('openPersonId', $person->id)
+        ->assertDispatched('open-person-drawer');
+});

--- a/tests/Feature/People/PersonModelTest.php
+++ b/tests/Feature/People/PersonModelTest.php
@@ -1,0 +1,51 @@
+<?php
+
+use App\Enums\MembershipStatus;
+use App\Enums\Office;
+use App\Enums\TerminationReason;
+use App\Models\Person;
+use App\Models\PersonOffice;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+test('casts membership_status and termination_reason', function (): void {
+    $person = Person::factory()->create([
+        'membership_status' => MembershipStatus::TERMINATED->value,
+        'termination_reason' => TerminationReason::TRANSFERRED->value,
+    ]);
+
+    expect($person->refresh()->membership_status)->toBe(MembershipStatus::TERMINATED);
+    expect($person->termination_reason)->toBe(TerminationReason::TRANSFERRED);
+});
+
+test('offices relationship returns only current offices', function (): void {
+    $person = Person::factory()->create();
+    PersonOffice::factory()->elder()->create(['person_id' => $person->id]);
+    PersonOffice::factory()->deacon()->ended('stepped down')->create(['person_id' => $person->id]);
+
+    $person->refresh()->load(['offices', 'formerOffices', 'allOffices']);
+
+    expect($person->offices)->toHaveCount(1);
+    expect($person->offices->first()->kind)->toBe(Office::ELDER);
+    expect($person->formerOffices)->toHaveCount(1);
+    expect($person->formerOffices->first()->kind)->toBe(Office::DEACON);
+    expect($person->allOffices)->toHaveCount(2);
+});
+
+test('pastoralCareElder relationship', function (): void {
+    $elder = Person::factory()->create();
+    $person = Person::factory()->create(['pastoral_care_elder_id' => $elder->id]);
+
+    expect($person->refresh()->pastoralCareElder->id)->toBe($elder->id);
+});
+
+test('searchedBy scope matches first/last/email/phone', function (): void {
+    Person::factory()->create(['first_name' => 'Joshua', 'last_name' => 'Pangborn', 'email' => 'josh@example.com', 'phone' => '555-0142']);
+    Person::factory()->create(['first_name' => 'Andrew', 'last_name' => 'Burnette', 'email' => 'andrew@example.com', 'phone' => '555-0317']);
+
+    expect(Person::query()->searchedBy('Pangborn')->count())->toBe(1);
+    expect(Person::query()->searchedBy('josh@')->count())->toBe(1);
+    expect(Person::query()->searchedBy('555-0317')->count())->toBe(1);
+    expect(Person::query()->searchedBy(null)->count())->toBe(2);
+});


### PR DESCRIPTION
## Summary

- Replaces the basic people table with a full people management section: contact info, church membership status lifecycle (visitor → adherent → catechumen → member → terminated), ordained offices (elder/deacon/staff), pastoral care elder assignment, and per-user access roles stored in a dedicated `user_access_roles` table.
- Adds filter chips by membership status, card/table layout toggle, density control, an add-person modal, and a flyout drawer for viewing and editing person details — collapsing the old multi-page CRUD routes into a single index.
- Renames `MembershipStatus` → `GroupMembershipStatus` to disambiguate from the new congregation-level membership enum, and guards Echo initialization behind a Reverb key check.

## Test plan

- [x] 25 new People tests (index, drawer, add modal, model) all pass
- [x] All existing Group tests updated for the enum rename and pass
- [x] Browser smoke tests for empty state and filter chips
- [ ] Manually verify the drawer opens, edits save, and office add/end works
- [ ] Run migrations on a fresh database

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added People management section with searchable, filterable person directory
  * Added editable person profiles with contact information, membership status, and office/role history
  * Added access role management for controlling user permissions
  * Added pastoral care elder assignment capabilities
  * Enhanced person records with termination tracking

* **Refactor**
  * Improved membership status handling with dedicated enums for groups and people

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jpangborn/stave/pull/126?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->