### PR TITLE
Redesign office section in People drawer as card-based layout

### DIFF
--- a/app/Enums/Office.php
+++ b/app/Enums/Office.php
@@ -26,6 +26,15 @@ enum Office: string
         };
     }
 
+    public function textColorClass(): string
+    {
+        return match ($this) {
+            self::ELDER => 'text-amber-500',
+            self::DEACON => 'text-indigo-500',
+            self::STAFF => 'text-zinc-500',
+        };
+    }
+
     public function icon(): string
     {
         return match ($this) {

--- a/app/Models/PersonOffice.php
+++ b/app/Models/PersonOffice.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
+/** @property Office $kind */
 #[Fillable([
     'person_id',
     'kind',

--- a/resources/views/livewire/people/drawer.blade.php
+++ b/resources/views/livewire/people/drawer.blade.php
@@ -83,6 +83,9 @@ new class extends Component
         Flux::modal('person-drawer')->close();
 
         $this->personId = null;
+        $this->form->person = null;
+        unset($this->person);
+
         $this->dispatch('person-deleted', personId: $id);
     }
 
@@ -97,7 +100,7 @@ new class extends Component
             return;
         }
 
-        if ($this->person->offices->contains(fn ($o) => $o->kind === $office)) {
+        if ($this->person->offices->contains(fn (PersonOffice $o) => $o->kind === $office)) {
             return;
         }
 

--- a/resources/views/livewire/people/drawer.blade.php
+++ b/resources/views/livewire/people/drawer.blade.php
@@ -8,7 +8,6 @@ use App\Livewire\Forms\PersonForm;
 use App\Models\Person;
 use App\Models\PersonOffice;
 use Flux\Flux;
-use Illuminate\Validation\Rule;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\On;
 use Livewire\Component;
@@ -18,15 +17,6 @@ new class extends Component
     public ?int $personId = null;
 
     public PersonForm $form;
-
-    public ?string $newOffice = null;
-
-    public string $newOfficeStartedOn;
-
-    public function mount(): void
-    {
-        $this->newOfficeStartedOn = now()->toDateString();
-    }
 
     #[Computed]
     public function person(): ?Person
@@ -96,29 +86,30 @@ new class extends Component
         $this->dispatch('person-deleted', personId: $id);
     }
 
-    public function addOffice(): void
+    public function addOffice(string $kind): void
     {
         if (! $this->person) {
             return;
         }
 
-        $this->validate([
-            'newOffice' => ['required', Rule::enum(Office::class)],
-            'newOfficeStartedOn' => ['required', 'date'],
-        ]);
+        $office = Office::tryFrom($kind);
+        if (! $office) {
+            return;
+        }
+
+        if ($this->person->offices->contains(fn ($o) => $o->kind === $office)) {
+            return;
+        }
 
         PersonOffice::create([
             'person_id' => $this->person->id,
-            'kind' => $this->newOffice,
-            'started_on' => $this->newOfficeStartedOn,
+            'kind' => $office,
+            'started_on' => now()->toDateString(),
         ]);
-
-        $this->newOffice = null;
-        $this->newOfficeStartedOn = now()->toDateString();
 
         unset($this->person);
 
-        Flux::toast(variant: 'success', text: 'Office added.');
+        Flux::toast(variant: 'success', text: $office->label().' assigned.');
     }
 
     public function endOffice(int $officeId, ?string $reason = null): void
@@ -256,37 +247,49 @@ new class extends Component
                 {{-- Office --}}
                 <section>
                     <flux:heading class="!text-xs uppercase tracking-wider text-zinc-500 mb-2">Office</flux:heading>
-
-                    @if ($person->offices->isEmpty())
-                        <p class="text-sm text-zinc-500">No current office.</p>
-                    @else
-                        <ul class="space-y-1.5 mb-3">
-                            @foreach ($person->offices as $office)
-                                <li class="flex items-center justify-between gap-3 rounded-md ring-1 ring-zinc-200 dark:ring-zinc-700 px-3 py-2">
-                                    <div class="flex items-center gap-2">
-                                        <x-office-chip :kind="$office->kind" />
-                                        <span class="text-xs text-zinc-500">since {{ $office->started_on->format('M Y') }}</span>
+                    <div class="space-y-2">
+                        @foreach (Office::cases() as $kind)
+                            @php($held = $person->offices->firstWhere('kind', $kind))
+                            <flux:card class="!p-3">
+                                <div class="flex items-center justify-between gap-3">
+                                    <div class="flex items-start gap-3 min-w-0">
+                                        <flux:icon :icon="$kind->icon()" variant="solid" class="size-5 shrink-0 mt-0.5 {{ $kind->textColorClass() }}" />
+                                        <div class="min-w-0">
+                                            <div class="flex items-center gap-2">
+                                                <flux:heading class="!text-sm">{{ $kind->label() }}</flux:heading>
+                                                @if ($held)
+                                                    <flux:badge size="sm" color="zinc">Held</flux:badge>
+                                                @endif
+                                            </div>
+                                            @if ($held)
+                                                <p class="text-xs text-zinc-500">Since {{ $held->started_on->format('M Y') }}</p>
+                                            @else
+                                                <p class="text-xs text-zinc-500">{{ $kind->description() }}</p>
+                                            @endif
+                                        </div>
                                     </div>
-                                    <flux:button size="sm" variant="ghost" wire:click="endOffice({{ $office->id }})" wire:confirm="End this office?">End</flux:button>
-                                </li>
-                            @endforeach
-                        </ul>
-                    @endif
-
-                    <div class="flex items-end gap-2">
-                        <flux:field class="flex-1">
-                            <flux:label>Add office</flux:label>
-                            <flux:select wire:model="newOffice" variant="listbox" placeholder="Select…">
-                                @foreach (Office::cases() as $kind)
-                                    <flux:select.option :value="$kind->value">{{ $kind->label() }}</flux:select.option>
-                                @endforeach
-                            </flux:select>
-                        </flux:field>
-                        <flux:field>
-                            <flux:label>Started</flux:label>
-                            <flux:input wire:model="newOfficeStartedOn" type="date" />
-                        </flux:field>
-                        <flux:button type="button" variant="ghost" icon="plus" wire:click="addOffice">Add</flux:button>
+                                    @if ($held)
+                                        <flux:button
+                                            size="sm"
+                                            variant="ghost"
+                                            wire:click="endOffice({{ $held->id }})"
+                                            wire:confirm="End {{ $kind->label() }} office?"
+                                        >
+                                            Step down
+                                        </flux:button>
+                                    @else
+                                        <flux:button
+                                            size="sm"
+                                            variant="ghost"
+                                            icon="plus"
+                                            wire:click="addOffice('{{ $kind->value }}')"
+                                        >
+                                            Assign
+                                        </flux:button>
+                                    @endif
+                                </div>
+                            </flux:card>
+                        @endforeach
                     </div>
 
                     @if ($person->formerOffices->isNotEmpty())

--- a/tests/Feature/People/DrawerTest.php
+++ b/tests/Feature/People/DrawerTest.php
@@ -83,9 +83,7 @@ test('adds a new office', function (): void {
 
     Livewire::test('people.drawer')
         ->call('openPerson', $person->id)
-        ->set('newOffice', Office::ELDER->value)
-        ->set('newOfficeStartedOn', '2024-01-15')
-        ->call('addOffice')
+        ->call('addOffice', Office::ELDER->value)
         ->assertHasNoErrors();
 
     expect($person->offices()->count())->toBe(1);


### PR DESCRIPTION
## Summary

- Replaces the office list + select/date add form with a card grid showing all office types (Elder, Deacon, Staff), each with an icon, description, and assign/step-down action.
- Simplifies `addOffice()` to accept the office kind directly, with built-in duplicate prevention, removing the need for `$newOffice`/`$newOfficeStartedOn` component state.
- Adds `Office::textColorClass()` to return full Tailwind class strings, avoiding dynamic class interpolation that Tailwind's scanner can't detect.

## Test plan

- [ ] Open a person's drawer and verify all three office cards render with correct icons and colors
- [ ] Assign an office and confirm the card updates to show "Held" badge with date
- [ ] Step down from an office and confirm it moves to "Former offices"
- [ ] Verify duplicate assignment is silently prevented

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Completely redesigned office assignment interface featuring an intuitive card-based layout for improved user experience
  * Direct action buttons for each office type—"Assign" for available positions and "Step down" for currently held offices
  * Enhanced visual clarity distinguishing between currently held and available office assignments
  * Improved confirmation feedback messages for all office assignment operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jpangborn/stave/pull/130?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->