### PR TITLE
Redesign pastoral care section with elder and congregant details

### DIFF
--- a/app/Models/Person.php
+++ b/app/Models/Person.php
@@ -92,6 +92,12 @@ class Person extends Model
         return $this->belongsTo(Person::class, 'pastoral_care_elder_id');
     }
 
+    /** @return HasMany<Person, $this> People who have this person assigned as their pastoral care elder. */
+    public function assignedCongregants(): HasMany
+    {
+        return $this->hasMany(Person::class, 'pastoral_care_elder_id');
+    }
+
     /** @return Attribute<string, never> */
     protected function fullName(): Attribute
     {

--- a/resources/views/livewire/people/drawer.blade.php
+++ b/resources/views/livewire/people/drawer.blade.php
@@ -16,6 +16,8 @@ new class extends Component
 {
     public ?int $personId = null;
 
+    public bool $showElderPicker = false;
+
     public PersonForm $form;
 
     #[Computed]
@@ -25,7 +27,13 @@ new class extends Component
             return null;
         }
 
-        return Person::with(['allOffices', 'user', 'pastoralCareElder'])->find($this->personId);
+        return Person::with(['allOffices', 'user', 'pastoralCareElder', 'assignedCongregants'])->find($this->personId);
+    }
+
+    #[Computed]
+    public function isElder(): bool
+    {
+        return (bool) $this->person?->allOffices->contains(fn (PersonOffice $o) => $o->kind === Office::ELDER && $o->ended_on === null);
     }
 
     /** @return \Illuminate\Support\Collection<int, Person> */
@@ -43,8 +51,14 @@ new class extends Component
     public function openPerson(int $personId): void
     {
         $this->personId = $personId;
+        $this->showElderPicker = false;
         $this->loadForm();
         Flux::modal('person-drawer')->show();
+    }
+
+    public function toggleElderPicker(): void
+    {
+        $this->showElderPicker = ! $this->showElderPicker;
     }
 
     private function loadForm(): void
@@ -327,12 +341,90 @@ new class extends Component
                 {{-- Pastoral Care --}}
                 <section>
                     <flux:heading class="!text-xs uppercase tracking-wider text-zinc-500 mb-2">Pastoral care</flux:heading>
-                    <flux:select wire:model="form.pastoral_care_elder_id" variant="listbox" placeholder="Unassigned">
-                        <flux:select.option :value="null">Unassigned</flux:select.option>
-                        @foreach ($this->elderCandidates as $elder)
-                            <flux:select.option :value="$elder->id">{{ $elder->full_name }}</flux:select.option>
-                        @endforeach
-                    </flux:select>
+                    <flux:card class="!p-3 bg-white space-y-6">
+                        {{-- Assigned elder --}}
+                        @php($elder = $person->pastoralCareElder)
+                        <div class="flex items-center gap-3">
+                            @if ($elder)
+                                <x-person-avatar :person="$elder" size="sm" />
+                            @else
+                                <div class="grid size-8 place-items-center rounded-full bg-zinc-100 dark:bg-zinc-800 text-zinc-400 shrink-0">
+                                    <flux:icon icon="user" class="size-4" />
+                                </div>
+                            @endif
+                            <div class="flex flex-col gap-1 min-w-0">
+                                <flux:heading class="!text-sm truncate">
+                                    {{ $elder?->full_name ?? 'No elder assigned' }}
+                                </flux:heading>
+                                @if ($elder && $elder->email)
+                                    <p class="text-xs text-zinc-500 truncate">{{ $elder->email }}</p>
+                                @else
+                                    <p class="text-xs text-zinc-500">Pastoral care provided by an elder</p>
+                                @endif
+                            </div>
+                            <flux:spacer />
+                            @if ($elder)
+                                <flux:button size="sm" variant="ghost" wire:click="toggleElderPicker">
+                                    Change
+                                </flux:button>
+                            @else
+                                <flux:button size="sm" variant="ghost" icon="plus" wire:click="toggleElderPicker">
+                                    Assign
+                                </flux:button>
+                            @endif
+                        </div>
+
+                        @if ($showElderPicker)
+                            <flux:select
+                                variant="listbox"
+                                searchable
+                                wire:model.live="form.pastoral_care_elder_id"
+                                placeholder="Search elders..."
+                                clearable
+                            >
+                                @foreach ($this->elderCandidates as $candidate)
+                                    <flux:select.option :value="$candidate->id">
+                                        {{ $candidate->full_name }}
+                                    </flux:select.option>
+                                @endforeach
+                            </flux:select>
+                        @endif
+
+                        {{-- Congregants (only when this person is an elder) --}}
+                        @if ($this->isElder)
+                            @php($congregants = $person->assignedCongregants)
+                            @php($count = $congregants->count())
+                            <div class="flex items-center gap-3">
+                                <div class="grid size-8 place-items-center rounded-full bg-emerald-50 dark:bg-emerald-950 text-emerald-600 dark:text-emerald-300 shrink-0">
+                                    <flux:icon icon="users" class="size-4" />
+                                </div>
+                                <div class="flex flex-col gap-1 min-w-0">
+                                    <flux:heading class="!text-sm">
+                                        @if ($count === 0)
+                                            No congregants assigned
+                                        @else
+                                            {{ $count }} {{ Str::plural('congregant', $count) }} assigned to {{ $person->first_name }}
+                                        @endif
+                                    </flux:heading>
+                                    @if ($count > 0)
+                                        <div class="flex -space-x-1.5">
+                                            @foreach ($congregants->take(5) as $congregant)
+                                                <x-person-avatar :person="$congregant" size="xs" circle class="ring-2 ring-white dark:ring-zinc-900" />
+                                            @endforeach
+                                        </div>
+                                    @else
+                                        <p class="text-xs text-zinc-500">Members under this elder's care will appear here</p>
+                                    @endif
+                                </div>
+                                <flux:spacer />
+                                @if ($count > 0)
+                                    <flux:modal.trigger name="pastoral-care-congregants">
+                                        <flux:button size="sm" variant="ghost">View all</flux:button>
+                                    </flux:modal.trigger>
+                                @endif
+                            </div>
+                        @endif
+                    </flux:card>
                 </section>
 
                 {{-- Access --}}
@@ -397,6 +489,28 @@ new class extends Component
                     </div>
                 </div>
             </form>
+
+            <flux:modal name="pastoral-care-congregants" class="w-md">
+                <div class="space-y-4">
+                    <div>
+                        <flux:heading size="lg">Congregants assigned to {{ $person->first_name }}</flux:heading>
+                        <flux:subheading>Pastoral care responsibilities</flux:subheading>
+                    </div>
+                    <ul class="divide-y divide-zinc-100 dark:divide-zinc-800">
+                        @foreach ($person->assignedCongregants as $congregant)
+                            <li class="flex items-center gap-3 py-2">
+                                <x-person-avatar :person="$congregant" size="sm" />
+                                <div class="flex-1 min-w-0">
+                                    <p class="text-sm font-medium">{{ $congregant->full_name }}</p>
+                                    @if ($congregant->email)
+                                        <p class="text-xs text-zinc-500 truncate">{{ $congregant->email }}</p>
+                                    @endif
+                                </div>
+                            </li>
+                        @endforeach
+                    </ul>
+                </div>
+            </flux:modal>
         @endif
     </flux:modal>
 </div>

--- a/resources/views/livewire/people/drawer.blade.php
+++ b/resources/views/livewire/people/drawer.blade.php
@@ -341,7 +341,7 @@ new class extends Component
                 {{-- Pastoral Care --}}
                 <section>
                     <flux:heading class="!text-xs uppercase tracking-wider text-zinc-500 mb-2">Pastoral care</flux:heading>
-                    <flux:card class="!p-3 bg-white space-y-6">
+                    <flux:card class="!p-3 bg-white dark:bg-zinc-800 space-y-6">
                         {{-- Assigned elder --}}
                         @php($elder = $person->pastoralCareElder)
                         <div class="flex items-center gap-3">
@@ -490,27 +490,29 @@ new class extends Component
                 </div>
             </form>
 
-            <flux:modal name="pastoral-care-congregants" class="w-md">
-                <div class="space-y-4">
-                    <div>
-                        <flux:heading size="lg">Congregants assigned to {{ $person->first_name }}</flux:heading>
-                        <flux:subheading>Pastoral care responsibilities</flux:subheading>
+            @if ($this->isElder)
+                <flux:modal name="pastoral-care-congregants" class="w-md">
+                    <div class="space-y-4">
+                        <div>
+                            <flux:heading size="lg">Congregants assigned to {{ $person->first_name }}</flux:heading>
+                            <flux:subheading>Pastoral care responsibilities</flux:subheading>
+                        </div>
+                        <ul class="divide-y divide-zinc-100 dark:divide-zinc-800">
+                            @foreach ($person->assignedCongregants as $congregant)
+                                <li class="flex items-center gap-3 py-2">
+                                    <x-person-avatar :person="$congregant" size="sm" />
+                                    <div class="flex-1 min-w-0">
+                                        <p class="text-sm font-medium">{{ $congregant->full_name }}</p>
+                                        @if ($congregant->email)
+                                            <p class="text-xs text-zinc-500 truncate">{{ $congregant->email }}</p>
+                                        @endif
+                                    </div>
+                                </li>
+                            @endforeach
+                        </ul>
                     </div>
-                    <ul class="divide-y divide-zinc-100 dark:divide-zinc-800">
-                        @foreach ($person->assignedCongregants as $congregant)
-                            <li class="flex items-center gap-3 py-2">
-                                <x-person-avatar :person="$congregant" size="sm" />
-                                <div class="flex-1 min-w-0">
-                                    <p class="text-sm font-medium">{{ $congregant->full_name }}</p>
-                                    @if ($congregant->email)
-                                        <p class="text-xs text-zinc-500 truncate">{{ $congregant->email }}</p>
-                                    @endif
-                                </div>
-                            </li>
-                        @endforeach
-                    </ul>
-                </div>
-            </flux:modal>
+                </flux:modal>
+            @endif
         @endif
     </flux:modal>
 </div>

--- a/tests/Feature/People/DrawerTest.php
+++ b/tests/Feature/People/DrawerTest.php
@@ -135,6 +135,59 @@ test('assigns a pastoral care elder', function (): void {
     expect($person->refresh()->pastoral_care_elder_id)->toBe($elder->id);
 });
 
+test('shows empty state when no pastoral care elder is assigned', function (): void {
+    $person = Person::factory()->visitor()->create(['pastoral_care_elder_id' => null]);
+
+    Livewire::test('people.drawer')
+        ->call('openPerson', $person->id)
+        ->assertSee('No elder assigned');
+});
+
+test('shows the assigned elder name', function (): void {
+    $elder = Person::factory()->member()->create(['first_name' => 'Joshua', 'last_name' => 'Pangborn']);
+    PersonOffice::factory()->elder()->create(['person_id' => $elder->id]);
+
+    $person = Person::factory()->visitor()->create(['pastoral_care_elder_id' => $elder->id]);
+
+    Livewire::test('people.drawer')
+        ->call('openPerson', $person->id)
+        ->assertSee('Joshua Pangborn')
+        ->assertDontSee('No elder assigned');
+});
+
+test('hides the congregants card for people without the elder office', function (): void {
+    $person = Person::factory()->member()->create();
+
+    Livewire::test('people.drawer')
+        ->call('openPerson', $person->id)
+        ->assertSet('isElder', false)
+        ->assertDontSee('congregants assigned to');
+});
+
+test('shows the congregants card with count for an elder', function (): void {
+    $elder = Person::factory()->member()->create(['first_name' => 'Joshua']);
+    PersonOffice::factory()->elder()->create(['person_id' => $elder->id]);
+
+    Person::factory()->count(3)->create(['pastoral_care_elder_id' => $elder->id]);
+
+    Livewire::test('people.drawer')
+        ->call('openPerson', $elder->id)
+        ->assertSet('isElder', true)
+        ->assertSee('3 congregants assigned to Joshua');
+});
+
+test('toggles the elder picker', function (): void {
+    $person = Person::factory()->visitor()->create();
+
+    Livewire::test('people.drawer')
+        ->call('openPerson', $person->id)
+        ->assertSet('showElderPicker', false)
+        ->call('toggleElderPicker')
+        ->assertSet('showElderPicker', true)
+        ->call('toggleElderPicker')
+        ->assertSet('showElderPicker', false);
+});
+
 test('deletes a person', function (): void {
     $person = Person::factory()->visitor()->create();
 

--- a/tests/Feature/People/PersonModelTest.php
+++ b/tests/Feature/People/PersonModelTest.php
@@ -40,6 +40,14 @@ test('pastoralCareElder relationship', function (): void {
     expect($person->refresh()->pastoralCareElder->id)->toBe($elder->id);
 });
 
+test('assignedCongregants returns people pointing back to this elder', function (): void {
+    $elder = Person::factory()->create();
+    Person::factory()->count(2)->create(['pastoral_care_elder_id' => $elder->id]);
+    Person::factory()->create(['pastoral_care_elder_id' => null]);
+
+    expect($elder->refresh()->assignedCongregants)->toHaveCount(2);
+});
+
 test('searchedBy scope matches first/last/email/phone', function (): void {
     Person::factory()->create(['first_name' => 'Joshua', 'last_name' => 'Pangborn', 'email' => 'josh@example.com', 'phone' => '555-0142']);
     Person::factory()->create(['first_name' => 'Andrew', 'last_name' => 'Burnette', 'email' => 'andrew@example.com', 'phone' => '555-0317']);


### PR DESCRIPTION
## Summary

- Replaces the plain elder select dropdown with a card-based layout showing the assigned elder's avatar, name, and email
- Adds a toggleable, searchable elder picker instead of an always-visible dropdown
- Shows a congregant summary with avatar stack and count for people who hold the Elder office, with a "View all" modal for details
- Adds `assignedCongregants` HasMany relationship on the Person model
- Includes tests for empty states, assigned elder display, congregant counts, elder picker toggle, and the new model relationship

## Test plan

- [x] Tests pass (`php artisan test --compact tests/Feature/People/DrawerTest.php` — 14 tests, all green)
- [ ] Verify the pastoral care card renders correctly for a person with no elder assigned
- [ ] Verify the pastoral care card shows the elder's avatar and name when assigned
- [ ] Verify the elder picker toggles open/closed and allows searching
- [ ] Verify the congregants section appears only for people with the Elder office
- [ ] Verify the "View all" modal lists all congregants

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned pastoral care assignment interface in the people drawer.
  * Added congregant summary and modal view for elders to see assigned congregants.
  * Improved elder selection with toggle-based picker control.

* **Tests**
  * Added test coverage for pastoral care drawer functionality and person relationships.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jpangborn/stave/pull/131?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->