### PR TITLE
Make muted_commentables migration idempotent

### DIFF
--- a/database/migrations/2026_05_19_174138_create_muted_commentables_table.php
+++ b/database/migrations/2026_05_19_174138_create_muted_commentables_table.php
@@ -8,14 +8,30 @@ return new class() extends Migration
 {
     public function up(): void
     {
-        Schema::create('muted_commentables', function (Blueprint $table) {
-            $table->id();
-            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
-            $table->morphs('commentable');
-            $table->timestamps();
+        if (! Schema::hasTable('muted_commentables')) {
+            Schema::create('muted_commentables', function (Blueprint $table) {
+                $table->id();
+                $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+                $table->morphs('commentable');
+                $table->timestamps();
 
-            $table->unique(['user_id', 'commentable_type', 'commentable_id']);
-        });
+                $table->unique(['user_id', 'commentable_type', 'commentable_id']);
+            });
+
+            return;
+        }
+
+        // Repair partial state from a prior aborted deploy: table exists but the
+        // unique index was never added (MySQL DDL isn't transactional, so a
+        // mid-migration crash can leave the table without its constraints).
+        if (! Schema::hasIndex('muted_commentables', 'muted_commentables_user_id_commentable_type_commentable_id_unique')) {
+            Schema::table('muted_commentables', function (Blueprint $table) {
+                $table->unique(
+                    ['user_id', 'commentable_type', 'commentable_id'],
+                    'muted_commentables_user_id_commentable_type_commentable_id_unique',
+                );
+            });
+        }
     }
 
     public function down(): void


### PR DESCRIPTION
## Summary

- Makes the `create_muted_commentables` migration safe to run against databases where the table already exists from a prior partial deploy.
- Guards table creation with `Schema::hasTable` and index creation with `Schema::hasIndex` to prevent duplicate-table and duplicate-index errors.
- Adds a repair path that applies the missing unique constraint if the table exists but the index does not.

## Test plan

- [x] Existing muted commentables test passes
- [ ] Run `php artisan migrate:fresh` to verify clean migration works
- [ ] Verify migration succeeds on a database where the table already exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)