### PR TITLE
Shorten muted_commentables unique index name for MySQL

### DIFF
--- a/database/migrations/2026_05_19_174138_create_muted_commentables_table.php
+++ b/database/migrations/2026_05_19_174138_create_muted_commentables_table.php
@@ -8,14 +8,20 @@ return new class() extends Migration
 {
     public function up(): void
     {
+        $indexName = 'muted_commentables_user_commentable_unique';
+        $legacyIndexName = 'muted_commentables_user_id_commentable_type_commentable_id_unique';
+
         if (! Schema::hasTable('muted_commentables')) {
-            Schema::create('muted_commentables', function (Blueprint $table) {
+            Schema::create('muted_commentables', function (Blueprint $table) use ($indexName) {
                 $table->id();
                 $table->foreignId('user_id')->constrained()->cascadeOnDelete();
                 $table->morphs('commentable');
                 $table->timestamps();
 
-                $table->unique(['user_id', 'commentable_type', 'commentable_id']);
+                $table->unique(
+                    ['user_id', 'commentable_type', 'commentable_id'],
+                    $indexName,
+                );
             });
 
             return;
@@ -24,11 +30,14 @@ return new class() extends Migration
         // Repair partial state from a prior aborted deploy: table exists but the
         // unique index was never added (MySQL DDL isn't transactional, so a
         // mid-migration crash can leave the table without its constraints).
-        if (! Schema::hasIndex('muted_commentables', 'muted_commentables_user_id_commentable_type_commentable_id_unique')) {
-            Schema::table('muted_commentables', function (Blueprint $table) {
+        if (
+            ! Schema::hasIndex('muted_commentables', $indexName)
+            && ! Schema::hasIndex('muted_commentables', $legacyIndexName)
+        ) {
+            Schema::table('muted_commentables', function (Blueprint $table) use ($indexName) {
                 $table->unique(
                     ['user_id', 'commentable_type', 'commentable_id'],
-                    'muted_commentables_user_id_commentable_type_commentable_id_unique',
+                    $indexName,
                 );
             });
         }


### PR DESCRIPTION
## Summary
- Fixes `SQLSTATE[42000]: 1059 Identifier name '..._unique' is too long` on production MySQL by using an explicit 42-char index name (`muted_commentables_user_commentable_unique`) instead of the 65-char auto-generated one.
- Repair branch now also accepts the legacy long index name so local SQLite environments that already migrated successfully don't churn.

## Test plan
- [x] `php artisan migrate:fresh` succeeds and the unique index is present with the short name.
- [x] Re-running `php artisan migrate` is a no-op.
- [x] `MuteConversationTest` and `MuteServiceDiscussionTest` pass (13 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)