### PR TITLE
Copy section_color when creating service from template

### DIFF
--- a/app/Livewire/Actions/CreateServiceFromTemplate.php
+++ b/app/Livewire/Actions/CreateServiceFromTemplate.php
@@ -34,6 +34,7 @@ class CreateServiceFromTemplate
                         'order' => $element->order,
                         'name' => $element->name,
                         'description' => $element->description,
+                        'section_color' => $element->section_color,
                         'assignee_id' => $element->assignee_id,
                         'content_type' => $element->content_type,
                         'content_id' => $element->content_id,

--- a/tests/Feature/CreateServiceFromTemplateTest.php
+++ b/tests/Feature/CreateServiceFromTemplateTest.php
@@ -37,11 +37,34 @@ it('creates a service from a template with liturgy elements', function () {
             'type' => $templateElement->type,
             'reading_type' => $templateElement->reading_type,
             'order' => $templateElement->order,
+            'section_color' => $templateElement->section_color,
             'assignee_id' => $templateElement->assignee_id,
             'content_id' => $templateElement->content_id,
             'content_type' => $templateElement->content_type,
         ]);
     }
+});
+
+it('copies section_color from template to service elements', function () {
+    $template = Template::factory()->create();
+
+    LiturgyElement::factory()->create([
+        'liturgy_type' => Template::class,
+        'liturgy_id' => $template->id,
+        'type' => LiturgyElementType::SECTION,
+        'section_color' => 'sky',
+    ]);
+
+    app(CreateServiceFromTemplate::class)($template, Carbon::tomorrow());
+
+    $service = Service::first();
+
+    $this->assertDatabaseHas('liturgy_elements', [
+        'liturgy_type' => Service::class,
+        'liturgy_id' => $service->id,
+        'type' => LiturgyElementType::SECTION->value,
+        'section_color' => 'sky',
+    ]);
 });
 
 it('copies reading_type from template to service elements', function () {


### PR DESCRIPTION
## Summary
- `CreateServiceFromTemplate` enumerated which `LiturgyElement` attributes to copy and omitted `section_color`, so colors picked on a template were lost on the generated service. Added the field to the copy payload.
- Extended the feature test's equality assertion to include `section_color`, and added a dedicated test that sets an explicit color on a template SECTION element and verifies it lands on the copied service element.

## Test plan
- [x] `php artisan test --compact --filter=CreateServiceFromTemplate`
- [ ] Manual smoke: recolor a section in a template, create a service from it, confirm the new service's section keeps the same color

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Section colors are now preserved when creating services from templates.

* **Tests**
  * Tests added to verify section color preservation when copying template elements to newly created services.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jpangborn/stave/pull/134?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->