### PR TITLE
Show initials fallback on People index avatars

### DIFF
--- a/resources/views/components/person-avatar.blade.php
+++ b/resources/views/components/person-avatar.blade.php
@@ -6,7 +6,7 @@
 
 <flux:avatar
     :name="$person->full_name"
-    :src="$person->gravatar"
+    :src="$person->gravatarUrl()"
     :size="$size"
     :circle="$circle"
     color="auto"


### PR DESCRIPTION
## Summary
- The `x-person-avatar` component passed `$person->gravatar` (always a URL) to `flux:avatar`, so people without a registered Gravatar never fell back to initials.
- Swapped the `:src` binding to `$person->gravatarUrl()`, which returns `null` when no Gravatar exists and lets `flux:avatar` render its initials placeholder — matching how the assignee chip and other avatars in the app already work.

## Test plan
- [ ] Visit `/people` and confirm people with a real Gravatar still show the image
- [ ] Confirm people without a Gravatar now show a colored initials squircle
- [ ] Open the People drawer for both cases and confirm the avatar matches the row
- [ ] `php artisan test --compact --filter=People` passes (31 tests, 84 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)