### PR TITLE
Stage access role changes until save instead of toggling immediately

### DIFF
--- a/resources/views/livewire/people/drawer.blade.php
+++ b/resources/views/livewire/people/drawer.blade.php
@@ -9,6 +9,7 @@ use App\Models\Person;
 use App\Models\PersonOffice;
 use Flux\Flux;
 use Livewire\Attributes\Computed;
+use Livewire\Attributes\Locked;
 use Livewire\Attributes\On;
 use Livewire\Component;
 
@@ -19,6 +20,13 @@ new class extends Component
     public bool $showElderPicker = false;
 
     public PersonForm $form;
+
+    /** @var array<string, bool> */
+    public array $accessRoles = [];
+
+    /** @var array<string, bool> */
+    #[Locked]
+    public array $originalAccessRoles = [];
 
     #[Computed]
     public function person(): ?Person
@@ -53,6 +61,7 @@ new class extends Component
         $this->personId = $personId;
         $this->showElderPicker = false;
         $this->loadForm();
+        $this->loadAccessRoles();
         Flux::modal('person-drawer')->show();
     }
 
@@ -70,6 +79,22 @@ new class extends Component
         }
     }
 
+    private function loadAccessRoles(): void
+    {
+        $this->accessRoles = [];
+        $this->originalAccessRoles = [];
+
+        if (! $this->person?->user) {
+            return;
+        }
+
+        foreach (AccessRole::cases() as $role) {
+            $active = $this->person->user->hasAccessRole($role);
+            $this->accessRoles[$role->value] = $active;
+            $this->originalAccessRoles[$role->value] = $active;
+        }
+    }
+
     public function save(): void
     {
         if (! $this->person) {
@@ -78,10 +103,34 @@ new class extends Component
 
         $this->form->update();
 
+        $this->persistAccessRoles();
+
         Flux::toast(variant: 'success', text: 'Saved.');
         Flux::modal('person-drawer')->close();
 
         $this->dispatch('person-saved', personId: $this->person->id);
+    }
+
+    private function persistAccessRoles(): void
+    {
+        $user = $this->person?->user;
+
+        if (! $user) {
+            return;
+        }
+
+        foreach (AccessRole::cases() as $role) {
+            $desired = (bool) ($this->accessRoles[$role->value] ?? false);
+            $original = (bool) ($this->originalAccessRoles[$role->value] ?? false);
+
+            if ($desired === $original) {
+                continue;
+            }
+
+            $desired
+                ? $user->grantAccessRole($role)
+                : $user->revokeAccessRole($role);
+        }
     }
 
     public function delete(): void
@@ -146,26 +195,6 @@ new class extends Component
         Flux::toast(variant: 'success', text: 'Office ended.');
     }
 
-    public function toggleAccessRole(string $role): void
-    {
-        if (! $this->person?->user) {
-            return;
-        }
-
-        $user = $this->person->user;
-        $accessRole = AccessRole::tryFrom($role);
-        if (! $accessRole) {
-            return;
-        }
-
-        $user->hasAccessRole($accessRole)
-            ? $user->revokeAccessRole($accessRole)
-            : $user->grantAccessRole($accessRole);
-
-        unset($this->person);
-
-        Flux::toast(variant: 'success', text: 'Access updated.');
-    }
 }; ?>
 
 <div>
@@ -449,7 +478,6 @@ new class extends Component
                                 <div class="space-y-3">
                                     <flux:subheading class="!text-xs uppercase tracking-wider text-zinc-500">{{ $group }}</flux:subheading>
                                     @foreach ($roles as $role)
-                                        @php($active = $person->user->hasAccessRole($role))
                                         <div class="flex items-center gap-3">
                                             <div class="flex size-9 shrink-0 items-center justify-center rounded-lg {{ $role->iconBgClass() }}">
                                                 <flux:icon :icon="$role->icon()" class="size-5 {{ $role->iconColorClass() }}" />
@@ -459,10 +487,7 @@ new class extends Component
                                                 <p class="text-xs text-zinc-500">{{ $role->description() }}</p>
                                             </div>
                                             <flux:spacer />
-                                            <flux:checkbox
-                                                :checked="$active"
-                                                wire:click="toggleAccessRole('{{ $role->value }}')"
-                                            />
+                                            <flux:checkbox wire:model="accessRoles.{{ $role->value }}" />
                                         </div>
                                     @endforeach
                                 </div>

--- a/tests/Feature/People/DrawerTest.php
+++ b/tests/Feature/People/DrawerTest.php
@@ -104,21 +104,50 @@ test('ends a current office', function (): void {
     expect($person->formerOffices()->count())->toBe(1);
 });
 
-test('toggles an access role on the linked user', function (): void {
+test('access role changes are staged and persisted on save', function (): void {
     $person = Person::factory()->member()->create();
     User::factory()->create(['person_id' => $person->id]);
 
-    Livewire::test('people.drawer')
+    $component = Livewire::test('people.drawer')
         ->call('openPerson', $person->id)
-        ->call('toggleAccessRole', AccessRole::ADMIN->value);
+        ->assertSet('accessRoles.'.AccessRole::ADMIN->value, false)
+        ->set('accessRoles.'.AccessRole::ADMIN->value, true);
+
+    expect($person->fresh()->user->hasAccessRole(AccessRole::ADMIN))->toBeFalse();
+
+    $component->call('save')
+        ->assertHasNoErrors()
+        ->assertDispatched('person-saved');
 
     expect($person->fresh()->user->hasAccessRole(AccessRole::ADMIN))->toBeTrue();
 
     Livewire::test('people.drawer')
         ->call('openPerson', $person->id)
-        ->call('toggleAccessRole', AccessRole::ADMIN->value);
+        ->assertSet('accessRoles.'.AccessRole::ADMIN->value, true)
+        ->set('accessRoles.'.AccessRole::ADMIN->value, false)
+        ->call('save');
 
     expect($person->fresh()->user->hasAccessRole(AccessRole::ADMIN))->toBeFalse();
+});
+
+test('access role state resets when opening a different person', function (): void {
+    $personA = Person::factory()->member()->create();
+    User::factory()->create(['person_id' => $personA->id]);
+
+    $personB = Person::factory()->member()->create();
+    $userB = User::factory()->create(['person_id' => $personB->id]);
+    $userB->grantAccessRole(AccessRole::ADMIN);
+
+    Livewire::test('people.drawer')
+        ->call('openPerson', $personA->id)
+        ->assertSet('accessRoles.'.AccessRole::ADMIN->value, false)
+        ->set('accessRoles.'.AccessRole::ADMIN->value, true)
+        ->call('openPerson', $personB->id)
+        ->assertSet('accessRoles.'.AccessRole::ADMIN->value, true)
+        ->call('openPerson', $personA->id)
+        ->assertSet('accessRoles.'.AccessRole::ADMIN->value, false);
+
+    expect($personA->fresh()->user->hasAccessRole(AccessRole::ADMIN))->toBeFalse();
 });
 
 test('assigns a pastoral care elder', function (): void {


### PR DESCRIPTION
## Summary
- Replaces the immediate `toggleAccessRole` wire:click handler with `wire:model` bindings on access role checkboxes, so changes are staged in component state and only persisted when the user clicks Save.
- Tracks original role state in a `#[Locked]` property to diff against, only writing grants/revokes for roles that actually changed.
- Adds tests verifying that changes are staged (not persisted before save) and that role state resets correctly when switching between people.

## Test plan
- [x] `access role changes are staged and persisted on save` — verifies grant and revoke round-trip through save
- [x] `access role state resets when opening a different person` — verifies unsaved changes are discarded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced access role management in the person drawer. Role changes are now staged within the interface and only persist when explicitly saved, replacing the previous immediate toggle behavior for better control.

* **Tests**
  * Expanded test coverage for access role assignment, including verification of state staging and save persistence.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jpangborn/stave/pull/137?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->