### PR TITLE
Fix Post Conversation button stuck disabled on group conversation create

### DIFF
--- a/resources/views/pages/groups/conversations/create.blade.php
+++ b/resources/views/pages/groups/conversations/create.blade.php
@@ -265,7 +265,7 @@ new class extends Component {
                 type="submit"
                 variant="primary"
                 icon="paper-airplane"
-                :disabled="trim($title) === ''"
+                x-bind:disabled="!$wire.title.trim()"
                 data-test="post-button"
             >
                 {{ $allowReplies ? 'Post conversation' : 'Post · replies off' }}


### PR DESCRIPTION
## Summary
- The Post Conversation submit button on `groups/{group}/conversations/create` was permanently disabled even after typing a title, because `:disabled` was evaluated server-side from `$title` while the title input used deferred `wire:model` (no `.live`/`.blur`), so the server's `$title` stayed empty until an action fired.
- Swapped the server expression for an Alpine `x-bind:disabled="!\$wire.title.trim()"`, which reads the live client-side value through Livewire's `\$wire` proxy and reacts instantly without extra network roundtrips.

## Test plan
- [ ] Visit a group's conversation create page; confirm the button starts disabled, enables on the first character typed into Title, and re-disables when the title is cleared.
- [ ] Submit with a title and message and confirm the conversation is created and redirects.
- [x] `php artisan test --compact --filter=Conversation` — 160/160 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the submit button's disabled state handling to use client-side binding for improved responsiveness when managing conversation titles.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jpangborn/stave/pull/138?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->