### PR TITLE
Fix duplicate notifications from double-registered event listeners

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,16 +3,11 @@
 namespace App\Providers;
 
 use App\Channels\DigestChannel;
-use App\Listeners\DispatchCommentNotifications;
-use App\Listeners\TouchPushSubscriptionLastUsed;
-use Illuminate\Notifications\Events\NotificationSent;
-use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\ServiceProvider;
 use Livewire\Blaze\Blaze;
 use NotificationChannels\WebPush\WebPushChannel;
-use Spatie\Comments\Events\CommentApprovedEvent;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -43,9 +38,6 @@ class AppServiceProvider extends ServiceProvider
         if (app()->isLocal()) {
             Blaze::debug();
         }
-
-        Event::listen(CommentApprovedEvent::class, DispatchCommentNotifications::class);
-        Event::listen(NotificationSent::class, TouchPushSubscriptionLastUsed::class);
 
         Notification::extend('webpush', fn ($app) => $app->make(WebPushChannel::class));
         Notification::extend('digest', fn ($app) => $app->make(DigestChannel::class));

--- a/tests/Feature/Notifications/DispatchCommentNotificationsListenerTest.php
+++ b/tests/Feature/Notifications/DispatchCommentNotificationsListenerTest.php
@@ -48,7 +48,7 @@ test('conversation reply fans out to participants and excludes the author', func
 
     $conversation->postComment('<p>Second message from author</p>', $author);
 
-    Notification::assertSentTo($other, ConversationReplyNotification::class);
+    Notification::assertSentToTimes($other, ConversationReplyNotification::class, 1);
     Notification::assertNotSentTo($author, ConversationReplyNotification::class);
     Notification::assertNotSentTo($bystander, ConversationReplyNotification::class);
 });
@@ -73,8 +73,8 @@ test('service discussion comment fans out to liturgy assignees and excludes comm
 
     $service->comment('<p>A note</p>', $author);
 
-    Notification::assertSentTo($assignee1, ServiceDiscussionCommentNotification::class);
-    Notification::assertSentTo($assignee2, ServiceDiscussionCommentNotification::class);
+    Notification::assertSentToTimes($assignee1, ServiceDiscussionCommentNotification::class, 1);
+    Notification::assertSentToTimes($assignee2, ServiceDiscussionCommentNotification::class, 1);
     Notification::assertNotSentTo($author, ServiceDiscussionCommentNotification::class);
 });
 
@@ -106,10 +106,10 @@ test('mentioned users get the mention notification and are deduped from the regu
         $author,
     );
 
-    Notification::assertSentTo($mentioned, CommentMentionNotification::class);
+    Notification::assertSentToTimes($mentioned, CommentMentionNotification::class, 1);
     Notification::assertNotSentTo($mentioned, ConversationReplyNotification::class);
 
-    Notification::assertSentTo($other, ConversationReplyNotification::class);
+    Notification::assertSentToTimes($other, ConversationReplyNotification::class, 1);
     Notification::assertNotSentTo($other, CommentMentionNotification::class);
 
     Notification::assertNotSentTo($author, CommentMentionNotification::class);
@@ -137,7 +137,7 @@ test('mentioned user who is not a participant still receives the mention notific
         $author,
     );
 
-    Notification::assertSentTo($mentioned, CommentMentionNotification::class);
+    Notification::assertSentToTimes($mentioned, CommentMentionNotification::class, 1);
 });
 
 test('service discussion comment that mentions an assignee dedupes the regular notification', function (): void {
@@ -156,6 +156,6 @@ test('service discussion comment that mentions an assignee dedupes the regular n
         $author,
     );
 
-    Notification::assertSentTo($assignee, CommentMentionNotification::class);
+    Notification::assertSentToTimes($assignee, CommentMentionNotification::class, 1);
     Notification::assertNotSentTo($assignee, ServiceDiscussionCommentNotification::class);
 });


### PR DESCRIPTION
## Problem

Comment notifications appeared duplicated in the sidebar bell panel. The panel renders rows straight from the `notifications` (database/Inbox) table, so these were real duplicate rows, not a display bug.

## Cause

`DispatchCommentNotifications` (and `TouchPushSubscriptionLastUsed`) were registered **twice** — once by Laravel's automatic event discovery (on by default, since the app uses the framework's base `EventServiceProvider`) and again via manual `Event::listen()` calls in `AppServiceProvider`. Each `CommentApprovedEvent` therefore dispatched the notification twice, inserting duplicate rows. Confirmed via `php artisan event:list`, which showed two registrations before the fix and one after.

## Fix

Removed the redundant manual `Event::listen()` calls (and now-unused imports) so auto-discovery registers each listener exactly once, and tightened the dispatch tests to assert exact send counts (`assertSentToTimes`) so any regression reintroducing double-dispatch fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced notification delivery verification to confirm accurate delivery counts across conversation replies, service discussion comments, and mention notifications.

* **Chores**
  * Streamlined internal event listener registration while maintaining notification channel functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->