### PR TITLE
Fix discussion panel to fill available viewport height

### DIFF
--- a/resources/views/components/service/stats-strip.blade.php
+++ b/resources/views/components/service/stats-strip.blade.php
@@ -9,7 +9,7 @@
     $missing = $service->missingContentCount();
 @endphp
 
-<div class="mt-4 flex flex-wrap items-center gap-x-6 gap-y-3 rounded-lg border border-zinc-200 bg-zinc-50 px-4 py-2.5 dark:border-zinc-700 dark:bg-zinc-900">
+<div class="mt-4 flex shrink-0 flex-wrap items-center gap-x-6 gap-y-3 rounded-lg border border-zinc-200 bg-zinc-50 px-4 py-2.5 dark:border-zinc-700 dark:bg-zinc-900">
     <x-service.stat label="Sections" :value="$sections" />
     <div class="hidden h-6 w-px bg-zinc-200 sm:block dark:bg-zinc-700"></div>
     <x-service.stat label="Elements" :value="$elements" />

--- a/resources/views/livewire/services/discussion.blade.php
+++ b/resources/views/livewire/services/discussion.blade.php
@@ -282,14 +282,11 @@ new class extends Component {
 };
 ?>
 
-<section data-test="service-discussion">
+<section data-test="service-discussion" class="flex min-h-0 flex-1 flex-col">
     @php($currentUser = Auth::user())
     @php($quickReactions = Config::allowedReactions())
 
-    <div
-        class="flex w-full overflow-hidden"
-        style="height: min(calc(100vh - 22rem), 48rem); min-height: 28rem;"
-    >
+    <div class="flex min-h-[28rem] w-full flex-1 overflow-hidden">
         {{-- Conversation column (messages + composer) --}}
         <div class="flex min-w-0 flex-1 flex-col overflow-hidden">
         {{-- Messages --}}

--- a/resources/views/pages/services/show.blade.php
+++ b/resources/views/pages/services/show.blade.php
@@ -72,8 +72,13 @@ new class extends Component {
         : $dayLabel.' · '.mb_strtoupper($form->date->format('F j, Y'));
 @endphp
 
-<section class="w-full" data-service-show>
-    <header class="flex flex-col gap-4 sm:flex-row sm:items-stretch">
+@php($isDiscussion = $tab === 'discussion')
+
+<section @class([
+    'w-full',
+    'flex min-h-0 flex-col h-[calc(100dvh-6rem)] lg:h-[calc(100dvh-4rem)]' => $isDiscussion,
+]) data-service-show>
+    <header class="flex shrink-0 flex-col gap-4 sm:flex-row sm:items-stretch">
         <x-service.date-block :date="$form->date" />
 
         <div class="min-w-0 flex-1">
@@ -125,7 +130,7 @@ new class extends Component {
 
     <x-service.stats-strip :service="$form->service" />
 
-    <flux:tab.group class="mt-6">
+    <flux:tab.group @class(['mt-6', 'flex min-h-0 flex-1 flex-col' => $isDiscussion])>
         <flux:tabs wire:model.live="tab" scrollable>
             <flux:tab name="service-order" icon="queue-list">Service Order</flux:tab>
             <flux:tab name="discussion" icon="chat-bubble-left-right">Discussion</flux:tab>
@@ -137,7 +142,7 @@ new class extends Component {
             <livewire:services.elements :service-id="$form->service->id" />
         </flux:tab.panel>
 
-        <flux:tab.panel name="discussion">
+        <flux:tab.panel name="discussion" @class(['flex min-h-0 flex-1 flex-col' => $isDiscussion])>
             <livewire:services.discussion :service-id="$form->service->id" />
         </flux:tab.panel>
 

--- a/tests/Browser/ServiceDiscussionSmokeTest.php
+++ b/tests/Browser/ServiceDiscussionSmokeTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use App\Enums\LiturgyElementType;
+use App\Models\Service;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+/** @group browser */
+it('renders the service discussion tab full height without smoke', function (): void {
+    $user = User::factory()->create(['name' => 'Smoke Tester']);
+
+    $service = Service::factory()->create(['title' => 'Sunday Morning Service']);
+
+    // An assigned element makes the user a discussion participant.
+    $service->liturgyElements()->create([
+        'type' => LiturgyElementType::SERMON,
+        'name' => 'Sermon',
+        'assignee_id' => $user->id,
+        'order' => 0,
+    ]);
+
+    $service->comment('<p>Are you preaching this week?</p>', $user);
+    $service->comment('<p>Yes — Romans 8:31.</p>', $user);
+
+    $this->actingAs($user);
+
+    $page = visit(route('services.show', ['service' => $service, 'tab' => 'discussion']));
+
+    $page->assertSee('Sunday Morning Service')
+        ->assertSee('Romans 8:31')
+        ->assertSee('In this discussion')
+        ->assertNoJavascriptErrors()
+        ->assertNoSmoke();
+});


### PR DESCRIPTION
## Summary

Replaces the fixed-height CSS calculation (`min(calc(100vh - 22rem), 48rem)`) on the discussion panel with a flexbox layout chain that fills the available viewport. The flex classes are conditionally applied only when the discussion tab is active, leaving other tabs unaffected. Adds `shrink-0` to the header and stats strip to prevent them from collapsing, and includes a browser smoke test for the discussion tab.

## Test plan

- [ ] Open a service and switch to the Discussion tab — it should fill the viewport without a scrollbar on the page body
- [ ] Switch to other tabs (Service Order, Bulletin, Podium Notes) — layout should be unchanged
- [ ] Resize the browser window — discussion panel should adapt fluidly
- [ ] Test on mobile viewport — panel should respect the `100dvh` dynamic height
- [ ] Run `php artisan test --filter=ServiceDiscussionSmokeTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)