### PR TITLE
Fix service discussion notification deep-link to Discussion tab

### DIFF
--- a/app/Notifications/CommentMentionNotification.php
+++ b/app/Notifications/CommentMentionNotification.php
@@ -93,7 +93,7 @@ class CommentMentionNotification extends Notification implements ShouldQueue
 
         return match (true) {
             $commentable instanceof Conversation => $commentable->commentUrl().'#comment-'.$this->comment->id,
-            $commentable instanceof Service => route('services.show', $commentable).'#discussion',
+            $commentable instanceof Service => route('services.show', [$commentable, 'tab' => 'discussion']),
             default => throw new RuntimeException('Unsupported commentable type for mention notification: '.$this->comment->commentable_type),
         };
     }

--- a/app/Notifications/ServiceDiscussionCommentNotification.php
+++ b/app/Notifications/ServiceDiscussionCommentNotification.php
@@ -80,7 +80,7 @@ class ServiceDiscussionCommentNotification extends Notification implements Shoul
         return [
             'title' => "Service discussion: {$this->service->title}",
             'body' => "{$this->author->name}: ".$this->commentPreview($this->comment->text),
-            'url' => route('services.show', $this->service).'#discussion',
+            'url' => route('services.show', [$this->service, 'tab' => 'discussion']),
         ];
     }
 }

--- a/tests/Feature/Notifications/CommentMentionNotificationTest.php
+++ b/tests/Feature/Notifications/CommentMentionNotificationTest.php
@@ -69,7 +69,7 @@ test('mention notification url for service comment points to discussion anchor',
 
     $message = (new CommentMentionNotification($comment, $author))->toBroadcast($recipient);
 
-    expect($message->data['url'])->toContain('#discussion');
+    expect($message->data['url'])->toContain('?tab=discussion');
 });
 
 test('mention notification mail subject is prefixed', function (): void {

--- a/tests/Feature/Notifications/ServiceDiscussionCommentNotificationTest.php
+++ b/tests/Feature/Notifications/ServiceDiscussionCommentNotificationTest.php
@@ -42,7 +42,7 @@ test('service-discussion broadcast payload includes service title and discussion
     expect($message->data['title'])->toContain('Easter Service');
     expect($message->data['body'])->toContain('Linus Torvalds');
     expect($message->data['body'])->toContain('introit');
-    expect($message->data['url'])->toContain('#discussion');
+    expect($message->data['url'])->toContain('?tab=discussion');
 });
 
 test('service-discussion webpush message is well-formed', function (): void {


### PR DESCRIPTION
## Summary

Service discussion comment and @-mention notifications appended a `#discussion` hash fragment, but the service show page selects its active tab from a `tab` query-string parameter (`#[Url] public $tab`), not a hash — so clicking these notifications landed users on the default Service Order tab instead of the Discussion tab. This switches the notification URLs to the route-parameter form so they emit `?tab=discussion`, which the show page reads correctly. The `Conversation` mention anchor (`#comment-{id}`) is a legitimate comment anchor and is left unchanged.

## Testing

- `php artisan test` on the two affected notification test files: 10 passed, 24 assertions (now asserting `?tab=discussion`).
- `vendor/bin/pint --dirty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)