### PR TITLE
Fix bottom padding under service discussion composer

### DIFF
--- a/resources/views/pages/services/show.blade.php
+++ b/resources/views/pages/services/show.blade.php
@@ -76,7 +76,7 @@ new class extends Component {
 
 <section @class([
     'w-full',
-    'flex min-h-0 flex-col h-[calc(100dvh-6rem)] lg:h-[calc(100dvh-4rem)]' => $isDiscussion,
+    'flex min-h-0 flex-col -mb-6 lg:-mb-8 h-[calc(100dvh-4.5rem)] lg:h-[calc(100dvh-2rem)]' => $isDiscussion,
 ]) data-service-show>
     <header class="flex shrink-0 flex-col gap-4 sm:flex-row sm:items-stretch">
         <x-service.date-block :date="$form->date" />


### PR DESCRIPTION
The service discussion tab left a strip of empty space below the message composer, caused by `flux:main`'s `p-6 lg:p-8` padding — the discussion section's height was sized to fit *inside* that padding, so the bottom padding rendered as a visible gap. This mirrors the group conversation page's flux:main break-out technique, scoped to the bottom edge only: `-mb-6 lg:-mb-8` consumes the bottom padding and the section height grows by the same amount, anchoring the composer flush to the bottom of the viewport. The page header, stats strip, and side padding are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the vertical layout spacing for the service discussion tab to improve display consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->