### PR TITLE
Add direct messaging between users

### DIFF
--- a/app/Listeners/DispatchCommentNotifications.php
+++ b/app/Listeners/DispatchCommentNotifications.php
@@ -11,11 +11,13 @@ use App\Models\Service;
 use App\Models\User;
 use App\Notifications\CommentMentionNotification;
 use App\Notifications\ConversationReplyNotification;
+use App\Notifications\DirectMessageNotification;
 use App\Notifications\ServiceDiscussionCommentNotification;
 use App\Recipients\ResolveConversationReplyRecipients;
 use App\Recipients\ResolveMentionRecipients;
 use App\Recipients\ResolveServiceDiscussionRecipients;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Notification;
 use Spatie\Comments\Events\CommentApprovedEvent;
 
@@ -47,6 +49,14 @@ class DispatchCommentNotifications implements ShouldQueue
             return;
         }
 
+        // Direct-message threads notify every other member (not just past
+        // commentators), so a first message reaches a brand-new recipient.
+        if ($commentable instanceof Conversation && $commentable->group->is_direct) {
+            $this->dispatchDirectMessage($commentable, $comment, $author);
+
+            return;
+        }
+
         $mentioned = ($this->resolveMentionRecipients)($comment);
 
         $primary = $commentable instanceof Conversation
@@ -71,6 +81,20 @@ class DispatchCommentNotifications implements ShouldQueue
                 : new ServiceDiscussionCommentNotification($commentable, $comment, $author);
 
             Notification::send($primary, $primaryNotification);
+        }
+    }
+
+    private function dispatchDirectMessage(Conversation $conversation, Comment $comment, User $author): void
+    {
+        /** @var Collection<int, User> $recipients */
+        $recipients = $conversation->group->members()
+            ->where('users.id', '!=', $author->id)
+            ->get();
+
+        $recipients = MutedCommentable::filterMuted($recipients, $conversation);
+
+        if ($recipients->isNotEmpty()) {
+            Notification::send($recipients, new DirectMessageNotification($conversation, $comment, $author));
         }
     }
 }

--- a/app/Models/Conversation.php
+++ b/app/Models/Conversation.php
@@ -4,12 +4,15 @@ namespace App\Models;
 
 use Database\Factories\ConversationFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
 use Spatie\Comments\Models\Concerns\HasComments;
 use Spatie\Comments\Models\Concerns\Interfaces\CanComment;
 
@@ -18,6 +21,8 @@ use Spatie\Comments\Models\Concerns\Interfaces\CanComment;
  * @property ?Carbon $pinned_at
  * @property ?int $pinned_by_user_id
  * @property bool $allow_replies
+ * @property ?string $title
+ * @property int $group_id
  */
 #[Fillable(['group_id', 'user_id', 'title', 'allow_replies'])]
 class Conversation extends Model
@@ -37,7 +42,7 @@ class Conversation extends Model
 
     public function allowsReplies(): bool
     {
-        return (bool) $this->allow_replies;
+        return $this->allow_replies;
     }
 
     /** @return BelongsTo<Group, $this> */
@@ -137,14 +142,149 @@ class Conversation extends Model
 
     public function commentableName(): string
     {
-        return $this->title;
+        return $this->title ?? 'Direct message';
     }
 
     public function commentUrl(): string
     {
+        if ($this->group->is_direct) {
+            return $this->directUrl();
+        }
+
         return route('groups.conversations.show', [
             'group' => $this->group_id,
             'conversation' => $this,
         ]);
+    }
+
+    public function directUrl(): string
+    {
+        return route('messages.show', ['conversation' => $this]);
+    }
+
+    public function isDirect(): bool
+    {
+        return $this->group->is_direct;
+    }
+
+    /**
+     * Per-(conversation, user) read-state used for unread badges.
+     *
+     * @return BelongsToMany<User, $this>
+     */
+    public function participants(): BelongsToMany
+    {
+        return $this->belongsToMany(User::class, 'conversation_user')
+            ->withPivot('last_read_at')
+            ->withTimestamps();
+    }
+
+    public function lastReadAtFor(User $user): ?Carbon
+    {
+        /** @var ?User $participant */
+        $participant = $this->participants()->where('users.id', $user->id)->first();
+
+        $value = $participant?->getRelationValue('pivot')?->last_read_at;
+
+        return $value !== null ? Carbon::parse($value) : null;
+    }
+
+    /**
+     * Count of messages the user has not yet seen (excludes the user's own).
+     */
+    public function unreadCountFor(User $user): int
+    {
+        $lastReadAt = $this->lastReadAtFor($user);
+
+        return $this->comments()
+            ->whereNot(fn ($query) => $query
+                ->where('commentator_id', $user->id)
+                ->where('commentator_type', $user->getMorphClass())
+            )
+            ->when($lastReadAt, fn ($query) => $query->where('created_at', '>', $lastReadAt))
+            ->count();
+    }
+
+    public function markReadFor(User $user): void
+    {
+        $this->participants()->syncWithoutDetaching([
+            $user->id => ['last_read_at' => now()],
+        ]);
+    }
+
+    /**
+     * Members of the underlying direct group other than the viewer.
+     *
+     * @return Collection<int, User>
+     */
+    public function otherMembersFor(User $viewer): Collection
+    {
+        return $this->group->members
+            ->reject(fn (User $member): bool => $member->id === $viewer->id)
+            ->values();
+    }
+
+    /**
+     * Viewer-relative title: the other person's full name for a 1:1, or the
+     * other members' first names joined for an ad-hoc multi-person thread.
+     */
+    public function displayTitleFor(User $viewer): string
+    {
+        if (filled($this->title)) {
+            return $this->title;
+        }
+
+        $others = $this->otherMembersFor($viewer);
+
+        $first = $others->first();
+
+        if ($others->count() <= 1) {
+            return $first instanceof User ? $first->name : 'Direct message';
+        }
+
+        return self::joinNames(
+            $others->map(fn (User $member): string => Str::of($member->name)->trim()->before(' ')->toString())->all()
+        );
+    }
+
+    /**
+     * Subline beneath the thread title.
+     */
+    public function sublineFor(User $viewer): string
+    {
+        $others = $this->otherMembersFor($viewer);
+
+        if ($others->count() <= 1) {
+            return 'Direct message';
+        }
+
+        $firstNames = $others
+            ->map(fn (User $member): string => Str::of($member->name)->trim()->before(' ')->toString())
+            ->implode(', ');
+
+        return $firstNames.' · '.($others->count() + 1).' people';
+    }
+
+    /**
+     * Join names as "A", "A & B", "A, B & C", "A, B, C & D".
+     *
+     * @param  array<int, string>  $names
+     */
+    private static function joinNames(array $names): string
+    {
+        $names = array_values(array_filter($names, fn (string $name): bool => $name !== ''));
+        $count = count($names);
+
+        if ($count === 0) {
+            return 'Direct message';
+        }
+
+        if ($count === 1) {
+            return $names[0];
+        }
+
+        $last = array_pop($names);
+
+        return implode(', ', $names).' & '.$last;
     }
 }

--- a/app/Models/Group.php
+++ b/app/Models/Group.php
@@ -15,6 +15,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
@@ -169,13 +170,25 @@ class Group extends Model
                 }
             }
 
-            $group = self::create([
-                'name' => null,
-                'visibility' => GroupVisibility::PRIVATE,
-                'messaging' => GroupMessaging::ALL_MEMBERS,
-                'is_direct' => true,
-                'direct_key' => $directKey,
-            ]);
+            try {
+                $group = self::create([
+                    'name' => null,
+                    'visibility' => GroupVisibility::PRIVATE,
+                    'messaging' => GroupMessaging::ALL_MEMBERS,
+                    'is_direct' => true,
+                    'direct_key' => $directKey,
+                ]);
+            } catch (QueryException $exception) {
+                if ($directKey !== null && in_array($exception->getCode(), ['23000', '23505'], true)) {
+                    $existing = self::query()->direct()->where('direct_key', $directKey)->first();
+
+                    if ($existing instanceof self) {
+                        return $existing;
+                    }
+                }
+
+                throw $exception;
+            }
 
             $group->allUsers()->attach(collect($allIds)->mapWithKeys(fn (int $id): array => [
                 $id => [

--- a/app/Models/Group.php
+++ b/app/Models/Group.php
@@ -8,12 +8,14 @@ use App\Enums\GroupRole;
 use App\Enums\GroupVisibility;
 use Database\Factories\GroupFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Mews\Purifier\Casts\CleanHtmlInput;
@@ -21,8 +23,10 @@ use Mews\Purifier\Casts\CleanHtmlInput;
 /**
  * @property GroupVisibility $visibility
  * @property GroupMessaging $messaging
+ * @property bool $is_direct
+ * @property ?string $direct_key
  */
-#[Fillable(['name', 'description', 'image', 'visibility', 'messaging'])]
+#[Fillable(['name', 'description', 'image', 'visibility', 'messaging', 'is_direct', 'direct_key'])]
 class Group extends Model
 {
     /** @use HasFactory<GroupFactory> */
@@ -44,7 +48,28 @@ class Group extends Model
             'visibility' => GroupVisibility::class,
             'messaging' => GroupMessaging::class,
             'description' => CleanHtmlInput::class.':rich_text',
+            'is_direct' => 'boolean',
         ];
+    }
+
+    /**
+     * Direct (1:1 or ad-hoc multi-person) message groups.
+     *
+     * @param  Builder<Group>  $query
+     */
+    public function scopeDirect(Builder $query): void
+    {
+        $query->where('is_direct', true);
+    }
+
+    /**
+     * Named groups (everything that is not a direct-message group).
+     *
+     * @param  Builder<Group>  $query
+     */
+    public function scopeNotDirect(Builder $query): void
+    {
+        $query->where('is_direct', false);
     }
 
     /** @return BelongsToMany<User, $this, GroupUser> */
@@ -90,6 +115,85 @@ class Group extends Model
         return $this->hasOne(Conversation::class)
             ->whereNotNull('last_comment_at')
             ->latestOfMany('last_comment_at');
+    }
+
+    /**
+     * The single conversation that a direct-message group owns.
+     *
+     * @return HasOne<Conversation, $this>
+     */
+    public function directConversation(): HasOne
+    {
+        return $this->hasOne(Conversation::class)->oldestOfMany();
+    }
+
+    /**
+     * Normalized key for a 1:1 direct group (sorted member id pair).
+     *
+     * @param  array<int, int>  $userIds
+     */
+    public static function directKeyFor(array $userIds): string
+    {
+        $userIds = array_values(array_unique(array_map('intval', $userIds)));
+        sort($userIds);
+
+        return implode('-', $userIds);
+    }
+
+    /**
+     * Resolve the direct-message group for the given participants, creating it
+     * (with its single conversation and read-state rows) if needed. 1:1 pairs are
+     * deduped via `direct_key`; multi-person ad-hoc groups are always created fresh.
+     *
+     * @param  array<int, int>  $otherUserIds
+     */
+    public static function findOrCreateDirect(User $creator, array $otherUserIds): self
+    {
+        $otherUserIds = array_values(array_filter(
+            array_unique(array_map('intval', $otherUserIds)),
+            fn (int $id): bool => $id !== $creator->id,
+        ));
+
+        $allIds = [$creator->id, ...$otherUserIds];
+        sort($allIds);
+
+        $isOneToOne = count($allIds) === 2;
+        $directKey = $isOneToOne ? self::directKeyFor($allIds) : null;
+
+        return DB::transaction(function () use ($creator, $allIds, $directKey): self {
+            if ($directKey !== null) {
+                $existing = self::query()->direct()->where('direct_key', $directKey)->first();
+
+                if ($existing instanceof self) {
+                    return $existing;
+                }
+            }
+
+            $group = self::create([
+                'name' => null,
+                'visibility' => GroupVisibility::PRIVATE,
+                'messaging' => GroupMessaging::ALL_MEMBERS,
+                'is_direct' => true,
+                'direct_key' => $directKey,
+            ]);
+
+            $group->allUsers()->attach(collect($allIds)->mapWithKeys(fn (int $id): array => [
+                $id => [
+                    'role' => $id === $creator->id ? GroupRole::LEADER : GroupRole::MEMBER,
+                    'status' => GroupMembershipStatus::ACTIVE,
+                ],
+            ])->all());
+
+            $conversation = $group->conversations()->create([
+                'user_id' => $creator->id,
+                'title' => null,
+                'allow_replies' => true,
+            ]);
+
+            $conversation->participants()->attach($allIds);
+
+            return $group;
+        });
     }
 
     public function hasActiveMember(User $user): bool

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -10,6 +10,7 @@ use App\Models\Traits\HasGravatar;
 use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -110,6 +111,46 @@ class User extends Authenticatable implements CanComment
             ->withPivot('role', 'status')
             ->withTimestamps()
             ->wherePivot('status', GroupMembershipStatus::ACTIVE);
+    }
+
+    /**
+     * Conversations belonging to the user's direct-message groups.
+     *
+     * @return Builder<Conversation>
+     */
+    public function directConversations(): Builder
+    {
+        return Conversation::query()
+            ->whereHas('group', fn (Builder $query): Builder => $query
+                ->where('is_direct', true)
+                ->whereHas('allUsers', fn (Builder $inner): Builder => $inner
+                    ->where('users.id', $this->id)
+                    ->where('status', GroupMembershipStatus::ACTIVE->value)
+                )
+            );
+    }
+
+    /**
+     * Total unread direct messages across all of the user's conversations.
+     */
+    public function unreadDirectCount(): int
+    {
+        return Comment::query()
+            ->where('comments.commentable_type', (new Conversation())->getMorphClass())
+            ->whereIn('comments.commentable_id', $this->directConversations()->select('conversations.id'))
+            ->whereNot(fn ($q) => $q
+                ->where('comments.commentator_id', $this->id)
+                ->where('comments.commentator_type', $this->getMorphClass())
+            )
+            ->leftJoin('conversation_user', fn ($join) => $join
+                ->on('conversation_user.conversation_id', '=', 'comments.commentable_id')
+                ->where('conversation_user.user_id', $this->id)
+            )
+            ->where(fn ($q) => $q
+                ->whereNull('conversation_user.last_read_at')
+                ->orWhereColumn('comments.created_at', '>', 'conversation_user.last_read_at')
+            )
+            ->count();
     }
 
     /** @return HasMany<NotificationPreference, $this> */

--- a/app/Notifications/DirectMessageNotification.php
+++ b/app/Notifications/DirectMessageNotification.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notifications;
+
+use App\Enums\NotificationEventType;
+use App\Models\Comment;
+use App\Models\Conversation;
+use App\Models\User;
+use App\Notifications\Concerns\HasCommentPreview;
+use App\Notifications\Concerns\RespectsNotificationPreferences;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\BroadcastMessage;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+use NotificationChannels\WebPush\WebPushMessage;
+
+class DirectMessageNotification extends Notification implements ShouldQueue
+{
+    use HasCommentPreview, Queueable, RespectsNotificationPreferences;
+
+    public function __construct(
+        public Conversation $conversation,
+        public Comment $comment,
+        public User $author,
+    ) {}
+
+    public function eventType(): NotificationEventType
+    {
+        return NotificationEventType::CONVERSATION_REPLY;
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        $payload = $this->payload();
+
+        return (new MailMessage())
+            ->subject($payload['title'])
+            ->line("{$this->author->name} sent you a message:")
+            ->line($this->commentPreview($this->comment->text, 400))
+            ->action('View Message', $payload['url']);
+    }
+
+    public function toBroadcast(object $notifiable): BroadcastMessage
+    {
+        return new BroadcastMessage([
+            ...$this->payload(),
+            'conversation_id' => $this->conversation->id,
+            'is_direct' => true,
+        ]);
+    }
+
+    public function toWebPush(object $notifiable, ?Notification $notification): WebPushMessage
+    {
+        $payload = $this->payload();
+
+        return (new WebPushMessage())
+            ->title($payload['title'])
+            ->body($payload['body'])
+            ->icon('/icons/icon-192.png')
+            ->badge('/icons/icon-192.png')
+            ->data(['url' => $payload['url']]);
+    }
+
+    /** @return array<string, mixed> */
+    public function toArray(object $notifiable): array
+    {
+        return [
+            ...$this->payload(),
+            'type' => $this->eventType()->value,
+            'conversation_id' => $this->conversation->id,
+            'group_id' => $this->conversation->group_id,
+            'comment_id' => $this->comment->id,
+            'author_id' => $this->author->id,
+            'author_name' => $this->author->name,
+            'is_direct' => true,
+        ];
+    }
+
+    /** @return array<string, string> */
+    private function payload(): array
+    {
+        return [
+            'title' => "New message from {$this->author->name}",
+            'body' => "{$this->author->name}: ".$this->commentPreview($this->comment->text),
+            'url' => $this->conversation->directUrl(),
+        ];
+    }
+}

--- a/database/factories/GroupFactory.php
+++ b/database/factories/GroupFactory.php
@@ -39,15 +39,27 @@ class GroupFactory extends Factory
         return $this->state(['visibility' => GroupVisibility::PRIVATE]);
     }
 
+    public function direct(): self
+    {
+        return $this->state([
+            'name' => null,
+            'visibility' => GroupVisibility::PRIVATE,
+            'messaging' => GroupMessaging::ALL_MEMBERS,
+            'is_direct' => true,
+        ]);
+    }
+
     public function withMembers(int $count = 3, GroupMembershipStatus $status = GroupMembershipStatus::ACTIVE, GroupRole $role = GroupRole::MEMBER): self
     {
         return $this->afterCreating(function (Group $group) use ($count, $status, $role): void {
-            User::factory()->count($count)->create()->each(function (User $user) use ($group, $status, $role): void {
+            $users = User::factory()->count($count)->create();
+
+            foreach ($users as $user) {
                 $group->allUsers()->attach($user, [
                     'role' => $role,
                     'status' => $status,
                 ]);
-            });
+            }
         });
     }
 

--- a/database/migrations/2026_06_16_022640_add_direct_columns_to_groups_table.php
+++ b/database/migrations/2026_06_16_022640_add_direct_columns_to_groups_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('groups', function (Blueprint $table): void {
+            $table->boolean('is_direct')->default(false)->index();
+            $table->string('direct_key')->nullable()->unique();
+            $table->string('name')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('groups', function (Blueprint $table): void {
+            $table->dropUnique(['direct_key']);
+            $table->dropColumn(['is_direct', 'direct_key']);
+            $table->string('name')->nullable(false)->change();
+        });
+    }
+};

--- a/database/migrations/2026_06_16_022640_create_conversation_user_table.php
+++ b/database/migrations/2026_06_16_022640_create_conversation_user_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('conversation_user', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('conversation_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->timestamp('last_read_at')->nullable();
+            $table->timestamps();
+
+            $table->unique(['conversation_id', 'user_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('conversation_user');
+    }
+};

--- a/database/migrations/2026_06_16_022641_make_conversations_title_nullable.php
+++ b/database/migrations/2026_06_16_022641_make_conversations_title_nullable.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('conversations', function (Blueprint $table): void {
+            $table->string('title')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('conversations', function (Blueprint $table): void {
+            $table->string('title')->nullable(false)->change();
+        });
+    }
+};

--- a/resources/views/components/layouts/app/sidebar.blade.php
+++ b/resources/views/components/layouts/app/sidebar.blade.php
@@ -24,6 +24,7 @@
                 <flux:sidebar.group expandable icon="church" :heading="__('Congregation')">
                     <flux:sidebar.item icon="users" :href="route('people.index')" :current="request()->routeIs('people.*')" wire:navigate>{{ __('People') }}</flux:sidebar.item>
                     <flux:sidebar.item icon="user-group" :href="route('groups.index')" :current="request()->routeIs('groups.*')" wire:navigate>{{ __('Groups') }}</flux:sidebar.item>
+                    <livewire:sidebar.messages />
                     <flux:sidebar.item icon="calendar-date-range" wire:navigate>{{ __('Prayer Schedule') }}</flux:sidebar.item>
                 </flux:sidebar.group>
             </flux:sidebar.nav>

--- a/resources/views/livewire/sidebar/messages.blade.php
+++ b/resources/views/livewire/sidebar/messages.blade.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Support\Facades\Auth;
+use Livewire\Attributes\Computed;
+use Livewire\Attributes\On;
+use Livewire\Component;
+
+new class extends Component {
+    #[Computed]
+    public function unreadCount(): int
+    {
+        return Auth::user()->unreadDirectCount();
+    }
+
+    #[On('messages-unread-updated')]
+    public function refresh(): void
+    {
+        unset($this->unreadCount);
+    }
+}; ?>
+
+<div>
+    <flux:sidebar.item
+        icon="chat-bubble-left-right"
+        :href="route('messages.index')"
+        :current="request()->routeIs('messages.*')"
+        :badge="$this->unreadCount > 0 ? $this->unreadCount : null"
+        wire:navigate
+    >{{ __('Messages') }}</flux:sidebar.item>
+
+    @script
+    <script>
+        window.addEventListener('stave:notification', () => $wire.refresh());
+    </script>
+    @endscript
+</div>

--- a/resources/views/pages/groups/index.blade.php
+++ b/resources/views/pages/groups/index.blade.php
@@ -56,6 +56,7 @@ new class extends Component {
     public function myGroups(): Collection
     {
         return Auth::user()->groups()
+            ->where('groups.is_direct', false)
             ->withCount('members')
             ->with([
                 'members' => fn ($q) => $q->limit(4),

--- a/resources/views/pages/messages/index.blade.php
+++ b/resources/views/pages/messages/index.blade.php
@@ -274,7 +274,10 @@ new class extends Component {
 
         if ($count >= 2) {
             if ($this->addPersonFrom !== null) {
-                $from = Conversation::find($this->addPersonFrom);
+                $from = $this->user()
+                    ->directConversations()
+                    ->whereKey($this->addPersonFrom)
+                    ->first();
                 $fromTitle = $from?->displayTitleFor($this->user()) ?? 'this thread';
 
                 return ['tone' => 'warn', 'title' => 'This starts a new conversation', 'body' => "Stave keeps one conversation per set of people. Your existing thread ({$fromTitle}) stays exactly as it is — these messages won’t appear there."];

--- a/resources/views/pages/messages/index.blade.php
+++ b/resources/views/pages/messages/index.blade.php
@@ -1,0 +1,815 @@
+<?php
+
+use App\Models\Comment;
+use App\Models\Conversation;
+use App\Models\Group;
+use App\Models\User;
+use App\Services\ScriptureLinker;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Str;
+use Livewire\Attributes\Computed;
+use Livewire\Attributes\Url;
+use Livewire\Component;
+
+new class extends Component {
+    public ?int $activeConversationId = null;
+
+    /** @var 'thread'|'compose'|'empty' */
+    public string $mode = 'empty';
+
+    #[Url(as: 'q')]
+    public string $search = '';
+
+    /** @var array<int, int> */
+    public array $composeRecipients = [];
+
+    public string $composeQuery = '';
+
+    public ?int $addPersonFrom = null;
+
+    public string $reply = '';
+
+    public function mount(?Conversation $conversation = null): void
+    {
+        if ($conversation === null) {
+            return;
+        }
+
+        abort_unless(
+            $conversation->group->is_direct && $conversation->group->hasActiveMember($this->user()),
+            404,
+        );
+
+        $this->activeConversationId = $conversation->id;
+        $this->mode = 'thread';
+        $this->markRead($conversation);
+    }
+
+    private function user(): User
+    {
+        /** @var User $user */
+        $user = Auth::user();
+
+        return $user;
+    }
+
+    /* ----------------------------- list ----------------------------- */
+
+    /** @return Collection<int, array<string, mixed>> */
+    #[Computed]
+    public function threads(): Collection
+    {
+        $user = $this->user();
+        $search = Str::lower(trim($this->search));
+
+        return $user
+            ->directConversations()
+            ->with(['group.members', 'lastComment.commentator', 'participants'])
+            ->get()
+            ->sortByDesc(fn (Conversation $conversation): int => $conversation->last_comment_at?->getTimestamp() ?? 0)
+            ->map(fn (Conversation $conversation): array => $this->rowFor($conversation, $user))
+            ->when($search !== '', fn (Collection $rows): Collection => $rows->filter(
+                fn (array $row): bool => str_contains(Str::lower($row['title']), $search)
+                    || str_contains(Str::lower($row['preview']), $search),
+            ))
+            ->values();
+    }
+
+    /** @return array<string, mixed> */
+    private function rowFor(Conversation $conversation, User $user): array
+    {
+        $others = $conversation->otherMembersFor($user);
+        $isGroup = $others->count() > 1;
+
+        return [
+            'id' => $conversation->id,
+            'title' => $conversation->displayTitleFor($user),
+            'preview' => $this->previewFor($conversation, $user, $isGroup),
+            'when' => $this->relativeTime($conversation->last_comment_at),
+            'unread' => $conversation->unreadCountFor($user),
+            'isGroup' => $isGroup,
+            'members' => $others,
+        ];
+    }
+
+    private function previewFor(Conversation $conversation, User $user, bool $isGroup): string
+    {
+        /** @var ?Comment $last */
+        $last = $conversation->lastComment->first();
+
+        if ($last === null) {
+            return 'No messages yet';
+        }
+
+        $text = Str::limit(trim((string) preg_replace('/\s+/', ' ', strip_tags($last->text))), 60);
+        $author = $last->commentator;
+
+        if ($author instanceof User && $author->id === $user->id) {
+            return 'You: '.$text;
+        }
+
+        if ($author instanceof User && $isGroup) {
+            return Str::of($author->name)->trim()->before(' ').': '.$text;
+        }
+
+        return $text;
+    }
+
+    private function relativeTime(?Carbon $when): string
+    {
+        if ($when === null) {
+            return '';
+        }
+
+        $now = now();
+
+        if ($when->isToday()) {
+            $minutes = (int) $when->diffInMinutes($now);
+
+            if ($minutes < 1) {
+                return 'now';
+            }
+
+            if ($minutes < 60) {
+                return $minutes.'m';
+            }
+
+            return (int) $when->diffInHours($now).'h';
+        }
+
+        if ($when->isYesterday()) {
+            return 'Yesterday';
+        }
+
+        if ($when->greaterThan($now->copy()->subDays(7))) {
+            return $when->format('D');
+        }
+
+        return $when->format('M j');
+    }
+
+    /* ---------------------------- thread ---------------------------- */
+
+    #[Computed]
+    public function activeConversation(): ?Conversation
+    {
+        if ($this->activeConversationId === null) {
+            return null;
+        }
+
+        return $this->user()
+            ->directConversations()
+            ->with(['group.members'])
+            ->whereKey($this->activeConversationId)
+            ->first();
+    }
+
+    /** @return EloquentCollection<int, Comment> */
+    #[Computed]
+    public function messages(): EloquentCollection
+    {
+        $conversation = $this->activeConversation;
+
+        if ($conversation === null) {
+            return new EloquentCollection();
+        }
+
+        /** @var EloquentCollection<int, Comment> */
+        return $conversation->comments()
+            ->with('commentator')
+            ->orderBy('created_at')
+            ->get();
+    }
+
+    /** @return Collection<string, EloquentCollection<int, Comment>> */
+    #[Computed]
+    public function groupedMessages(): Collection
+    {
+        return $this->messages->groupBy(fn (Comment $comment): string => $comment->created_at->toDateString());
+    }
+
+    public function dayLabel(string $dateString): string
+    {
+        $date = Carbon::parse($dateString);
+
+        return match (true) {
+            $date->isToday() => 'Today',
+            $date->isYesterday() => 'Yesterday',
+            $date->isCurrentYear() => $date->format('M j'),
+            default => $date->format('M j, Y'),
+        };
+    }
+
+    #[Computed]
+    public function isMuted(): bool
+    {
+        $conversation = $this->activeConversation;
+
+        return $conversation !== null && $this->user()->hasMuted($conversation);
+    }
+
+    /* --------------------------- compose ---------------------------- */
+
+    /** @return EloquentCollection<int, User> */
+    #[Computed]
+    public function suggestions(): EloquentCollection
+    {
+        $query = trim($this->composeQuery);
+
+        /** @var EloquentCollection<int, User> */
+        return User::query()
+            ->where('id', '!=', $this->user()->id)
+            ->whereNotIn('id', $this->composeRecipients)
+            ->when($query !== '', fn ($builder) => $builder->where(fn ($inner) => $inner
+                ->where('name', 'like', "%{$query}%")
+                ->orWhere('email', 'like', "%{$query}%")
+            ))
+            ->orderBy('name')
+            ->limit(8)
+            ->get();
+    }
+
+    /** @return Collection<int, User> */
+    #[Computed]
+    public function recipientChips(): Collection
+    {
+        if ($this->composeRecipients === []) {
+            return collect();
+        }
+
+        $order = array_flip($this->composeRecipients);
+
+        return User::query()
+            ->whereIn('id', $this->composeRecipients)
+            ->get()
+            ->sortBy(fn (User $user): int => $order[$user->id] ?? 0)
+            ->values();
+    }
+
+    /** @return array{tone: string, title: string, body: string}|null */
+    #[Computed]
+    public function noteBanner(): ?array
+    {
+        $recipients = $this->composeRecipients;
+        $count = count($recipients);
+
+        if ($count === 1) {
+            $existing = $this->existingOneToOne($recipients[0]);
+            $recipient = User::find($recipients[0]);
+            $name = $recipient instanceof User ? $recipient->name : 'this person';
+
+            if ($existing && $this->addPersonFrom !== null) {
+                return ['tone' => 'info', 'title' => 'Same person', 'body' => "You removed everyone you added — this will continue your existing conversation with {$name}."];
+            }
+
+            if ($existing) {
+                return ['tone' => 'info', 'title' => 'Existing conversation', 'body' => "You already message {$name}. Your message will be added to that thread instead of starting a new one."];
+            }
+
+            return null;
+        }
+
+        if ($count >= 2) {
+            if ($this->addPersonFrom !== null) {
+                $from = Conversation::find($this->addPersonFrom);
+                $fromTitle = $from?->displayTitleFor($this->user()) ?? 'this thread';
+
+                return ['tone' => 'warn', 'title' => 'This starts a new conversation', 'body' => "Stave keeps one conversation per set of people. Your existing thread ({$fromTitle}) stays exactly as it is — these messages won’t appear there."];
+            }
+
+            return ['tone' => 'neutral', 'title' => 'New group conversation', 'body' => "This creates a group conversation with {$count} people. Everyone can see messages from here on."];
+        }
+
+        return null;
+    }
+
+    private function existingOneToOne(int $otherUserId): ?Group
+    {
+        $key = Group::directKeyFor([$this->user()->id, $otherUserId]);
+
+        return Group::query()->direct()->where('direct_key', $key)->first();
+    }
+
+    /* --------------------------- actions ---------------------------- */
+
+    public function openConversation(int $conversationId): void
+    {
+        $conversation = $this->user()->directConversations()->whereKey($conversationId)->first();
+
+        if ($conversation === null) {
+            return;
+        }
+
+        $this->activeConversationId = $conversation->id;
+        $this->mode = 'thread';
+        $this->reset('composeRecipients', 'composeQuery', 'addPersonFrom', 'reply');
+        $this->markRead($conversation);
+
+        unset($this->activeConversation, $this->messages, $this->groupedMessages, $this->threads, $this->isMuted);
+        $this->dispatch('messages-unread-updated');
+    }
+
+    public function newMessage(): void
+    {
+        $this->mode = 'compose';
+        $this->activeConversationId = null;
+        $this->reset('composeRecipients', 'composeQuery', 'addPersonFrom', 'reply');
+
+        unset($this->activeConversation, $this->messages, $this->suggestions, $this->recipientChips, $this->noteBanner);
+    }
+
+    public function beginAddPeople(): void
+    {
+        $conversation = $this->activeConversation;
+
+        if ($conversation === null) {
+            return;
+        }
+
+        $this->addPersonFrom = $conversation->id;
+        $this->composeRecipients = $conversation->otherMembersFor($this->user())->pluck('id')->all();
+        $this->composeQuery = '';
+        $this->reply = '';
+        $this->mode = 'compose';
+        $this->activeConversationId = null;
+
+        unset($this->activeConversation, $this->messages, $this->suggestions, $this->recipientChips, $this->noteBanner);
+    }
+
+    public function addRecipient(int $userId): void
+    {
+        if (! in_array($userId, $this->composeRecipients, true)) {
+            $this->composeRecipients[] = $userId;
+        }
+
+        $this->composeQuery = '';
+        unset($this->suggestions, $this->recipientChips, $this->noteBanner);
+    }
+
+    public function removeRecipient(int $userId): void
+    {
+        $this->composeRecipients = array_values(array_filter(
+            $this->composeRecipients,
+            fn (int $id): bool => $id !== $userId,
+        ));
+
+        unset($this->suggestions, $this->recipientChips, $this->noteBanner);
+    }
+
+    public function sendThread(): void
+    {
+        $conversation = $this->activeConversation;
+
+        if ($conversation === null) {
+            return;
+        }
+
+        $this->authorize('comment', $conversation);
+
+        if (trim(strip_tags($this->reply)) === '') {
+            $this->addError('reply', 'Write a message.');
+
+            return;
+        }
+
+        $conversation->postComment(trim($this->reply), $this->user());
+        $conversation->markReadFor($this->user());
+
+        $this->reply = '';
+        unset($this->messages, $this->groupedMessages, $this->threads, $this->activeConversation);
+        $this->dispatch('messages-unread-updated');
+    }
+
+    public function sendCompose(): void
+    {
+        if (trim(strip_tags($this->reply)) === '') {
+            $this->addError('reply', 'Write a message.');
+
+            return;
+        }
+
+        if ($this->composeRecipients === []) {
+            $this->addError('composeRecipients', 'Add at least one person.');
+
+            return;
+        }
+
+        $user = $this->user();
+        $group = Group::findOrCreateDirect($user, $this->composeRecipients);
+
+        /** @var Conversation $conversation */
+        $conversation = $group->directConversation()->firstOrFail();
+
+        $this->authorize('comment', $conversation);
+
+        $conversation->postComment(trim($this->reply), $user);
+        $conversation->markReadFor($user);
+
+        $this->reset('composeRecipients', 'composeQuery', 'addPersonFrom', 'reply');
+        $this->openConversation($conversation->id);
+    }
+
+    public function cancelCompose(): void
+    {
+        $return = $this->addPersonFrom;
+        $this->reset('composeRecipients', 'composeQuery', 'addPersonFrom', 'reply');
+
+        if ($return !== null && $this->user()->directConversations()->whereKey($return)->exists()) {
+            $this->openConversation($return);
+
+            return;
+        }
+
+        $first = $this->user()->directConversations()->orderByDesc('last_comment_at')->first();
+
+        if ($first !== null) {
+            $this->openConversation($first->id);
+
+            return;
+        }
+
+        $this->mode = 'empty';
+        $this->activeConversationId = null;
+    }
+
+    public function toggleMute(): void
+    {
+        $conversation = $this->activeConversation;
+
+        if ($conversation === null) {
+            return;
+        }
+
+        $user = $this->user();
+
+        if ($user->hasMuted($conversation)) {
+            $user->mutedCommentables()
+                ->where('commentable_type', $conversation->getMorphClass())
+                ->where('commentable_id', $conversation->getKey())
+                ->delete();
+        } else {
+            $user->mutedCommentables()->create([
+                'commentable_type' => $conversation->getMorphClass(),
+                'commentable_id' => $conversation->getKey(),
+            ]);
+        }
+
+        unset($this->isMuted);
+    }
+
+    public function deleteConversation(): void
+    {
+        $conversation = $this->activeConversation;
+
+        if ($conversation === null) {
+            return;
+        }
+
+        abort_unless($conversation->group->hasActiveMember($this->user()), 403);
+
+        $this->activeConversationId = null;
+        $this->mode = 'empty';
+        $this->reply = '';
+
+        $conversation->comments()->delete();
+        $conversation->notificationSubscriptions()->delete();
+        $conversation->group->delete();
+
+        unset($this->threads, $this->activeConversation, $this->messages, $this->groupedMessages);
+        $this->dispatch('messages-unread-updated');
+    }
+
+    public function handleIncoming(?int $conversationId = null): void
+    {
+        unset($this->threads);
+
+        if ($conversationId !== null && $conversationId === $this->activeConversationId) {
+            $conversation = $this->activeConversation;
+
+            if ($conversation !== null) {
+                $this->markRead($conversation);
+            }
+
+            unset($this->messages, $this->groupedMessages, $this->activeConversation);
+        }
+
+        $this->dispatch('messages-unread-updated');
+    }
+
+    private function markRead(Conversation $conversation): void
+    {
+        $user = $this->user();
+        $conversation->markReadFor($user);
+
+        $user->unreadNotifications()
+            ->where('data->conversation_id', $conversation->id)
+            ->update(['read_at' => now()]);
+    }
+}; ?>
+
+<section class="-m-6 flex h-[calc(100vh-3rem)] min-h-0" data-test="messages-page">
+    {{-- ============ LEFT RAIL ============ --}}
+    <div class="flex w-[344px] shrink-0 flex-col border-e border-zinc-200 dark:border-zinc-700">
+        <div class="border-b border-zinc-200 px-4 pb-3 pt-4 dark:border-zinc-700">
+            <div class="mb-3 flex items-center justify-between">
+                <flux:heading size="xl" class="font-extrabold tracking-tight">{{ __('Messages') }}</flux:heading>
+                <flux:button size="sm" variant="primary" icon="pencil-square" wire:click="newMessage" data-test="new-message">
+                    {{ __('New') }}
+                </flux:button>
+            </div>
+
+            <flux:input
+                size="sm"
+                icon="magnifying-glass"
+                placeholder="{{ __('Search messages…') }}"
+                wire:model.live.debounce.250ms="search"
+                data-test="messages-search"
+            />
+        </div>
+
+        <div class="flex-1 overflow-y-auto p-2" data-test="conversation-list">
+            <div class="flex items-center gap-2 px-3 pb-1.5 pt-2.5">
+                <span class="text-[11px] font-bold uppercase tracking-wider text-zinc-500 dark:text-zinc-400">{{ __('Direct Messages') }}</span>
+                <flux:badge size="sm" color="zinc">{{ $this->threads->count() }}</flux:badge>
+            </div>
+
+            @forelse ($this->threads as $row)
+                <button
+                    type="button"
+                    wire:key="thread-{{ $row['id'] }}"
+                    wire:click="openConversation({{ $row['id'] }})"
+                    @class([
+                        'group flex w-full items-center gap-3 rounded-lg px-3.5 py-2.5 text-left transition',
+                        'bg-accent/10 shadow-[inset_3px_0_0_var(--color-accent)]' => $row['id'] === $activeConversationId && $mode === 'thread',
+                        'hover:bg-zinc-100 dark:hover:bg-zinc-800' => ! ($row['id'] === $activeConversationId && $mode === 'thread'),
+                    ])
+                    data-test="conversation-row"
+                >
+                    <div class="shrink-0">
+                        @if ($row['isGroup'])
+                            <flux:avatar.group>
+                                @foreach ($row['members']->take(2) as $member)
+                                    <flux:avatar size="sm" :name="$member->name" :src="$member->gravatar" color="auto" />
+                                @endforeach
+                            </flux:avatar.group>
+                        @else
+                            <flux:avatar size="lg" :name="$row['members']->first()?->name" :src="$row['members']->first()?->gravatar" color="auto" />
+                        @endif
+                    </div>
+
+                    <div class="min-w-0 flex-1">
+                        <div class="flex items-baseline gap-2">
+                            <span @class([
+                                'flex-1 truncate text-sm tracking-tight text-zinc-900 dark:text-zinc-100',
+                                'font-extrabold' => $row['unread'] > 0,
+                                'font-semibold' => $row['unread'] === 0,
+                            ])>{{ $row['title'] }}</span>
+                            <span @class([
+                                'shrink-0 text-[11px]',
+                                'font-bold text-accent' => $row['unread'] > 0,
+                                'font-medium text-zinc-400' => $row['unread'] === 0,
+                            ])>{{ $row['when'] }}</span>
+                        </div>
+                        <div class="mt-0.5 flex items-center gap-1.5">
+                            <span @class([
+                                'min-w-0 flex-1 truncate text-[13px]',
+                                'font-semibold text-zinc-600 dark:text-zinc-300' => $row['unread'] > 0,
+                                'text-zinc-500 dark:text-zinc-400' => $row['unread'] === 0,
+                            ])>{{ $row['preview'] }}</span>
+                            @if ($row['unread'] > 0)
+                                <span class="grid h-[18px] min-w-[18px] place-items-center rounded-full bg-accent px-1.5 text-[11px] font-bold text-white" data-test="unread-badge">
+                                    {{ $row['unread'] > 9 ? '9+' : $row['unread'] }}
+                                </span>
+                            @endif
+                        </div>
+                    </div>
+                </button>
+            @empty
+                <div class="px-4 py-10 text-center text-[13px] text-zinc-500 dark:text-zinc-400">
+                    {{ $search !== '' ? __('No conversations match your search.') : __('No messages yet. Start a new conversation.') }}
+                </div>
+            @endforelse
+        </div>
+    </div>
+
+    {{-- ============ RIGHT PANE ============ --}}
+    <div class="flex min-w-0 flex-1 flex-col bg-white dark:bg-zinc-800">
+        @if ($mode === 'thread' && $this->activeConversation)
+            @php($conversation = $this->activeConversation)
+            @php($others = $conversation->otherMembersFor($this->user()))
+
+            {{-- thread header --}}
+            <header class="flex items-center gap-3 border-b border-zinc-200 px-5 py-3.5 dark:border-zinc-700">
+                <div class="shrink-0">
+                    @if ($others->count() > 1)
+                        <flux:avatar.group>
+                            @foreach ($others->take(3) as $member)
+                                <flux:avatar size="sm" :name="$member->name" :src="$member->gravatar" color="auto" />
+                            @endforeach
+                        </flux:avatar.group>
+                    @else
+                        <flux:avatar size="md" :name="$others->first()?->name" :src="$others->first()?->gravatar" color="auto" />
+                    @endif
+                </div>
+
+                <div class="min-w-0 flex-1">
+                    <flux:heading class="truncate" size="lg">{{ $conversation->displayTitleFor($this->user()) }}</flux:heading>
+                    <div class="truncate text-[12.5px] text-zinc-500 dark:text-zinc-400">{{ $conversation->sublineFor($this->user()) }}</div>
+                </div>
+
+                <flux:button size="sm" variant="ghost" icon="user-plus" wire:click="beginAddPeople" data-test="add-people">
+                    {{ __('Add people') }}
+                </flux:button>
+
+                <flux:dropdown position="bottom" align="end">
+                    <flux:button size="sm" variant="ghost" icon="ellipsis-horizontal" />
+
+                    <flux:menu>
+                        <flux:menu.item icon="{{ $this->isMuted ? 'bell' : 'bell-slash' }}" wire:click="toggleMute">
+                            {{ $this->isMuted ? __('Unmute') : __('Mute') }}
+                        </flux:menu.item>
+                        <flux:menu.separator />
+                        <flux:menu.item
+                            icon="trash"
+                            variant="danger"
+                            wire:click="deleteConversation"
+                            wire:confirm="{{ __('Delete this conversation for everyone? This cannot be undone.') }}"
+                            data-test="delete-conversation"
+                        >
+                            {{ __('Delete conversation') }}
+                        </flux:menu.item>
+                    </flux:menu>
+                </flux:dropdown>
+            </header>
+
+            {{-- messages --}}
+            <div class="flex-1 space-y-4 overflow-y-auto px-6 py-5" data-test="messages-area">
+                @foreach ($this->groupedMessages as $dateString => $dayMessages)
+                    <x-conversation.day-divider :label="$this->dayLabel($dateString)" />
+
+                    @foreach ($dayMessages as $comment)
+                        @php($author = $comment->commentator)
+                        @php($isMine = $author instanceof App\Models\User && $author->id === $this->user()->id)
+                        @php($showAuthor = ! $isMine && $others->count() > 1)
+
+                        <div @class(['flex flex-col gap-1', 'items-end' => $isMine, 'items-start' => ! $isMine]) wire:key="msg-{{ $comment->id }}" data-test="message">
+                            <div @class(['flex items-center gap-2', 'flex-row-reverse' => $isMine])>
+                                @if ($showAuthor)
+                                    <flux:avatar size="xs" :name="$author?->name" :src="$author?->gravatar" color="auto" />
+                                    <span class="text-xs font-bold text-zinc-700 dark:text-zinc-200">{{ $author?->name }}</span>
+                                @endif
+                                <span class="text-[11px] text-zinc-400">{{ $comment->created_at->format('g:i A') }}</span>
+                            </div>
+
+                            <div @class([
+                                'max-w-[min(560px,78%)] break-words rounded-xl px-3.5 py-2.5 text-sm leading-relaxed',
+                                'rounded-tr-sm bg-accent text-white' => $isMine,
+                                'rounded-tl-sm bg-zinc-100 text-zinc-900 dark:bg-zinc-700 dark:text-zinc-100' => ! $isMine,
+                            ])>
+                                <div class="**:[a]:underline **:[strong]:font-semibold **:[em]:italic **:[u]:underline **:[s]:line-through **:[ol]:ml-5 **:[ol]:list-decimal **:[ul]:ml-5 **:[ul]:list-disc **:[blockquote]:border-l-2 **:[blockquote]:pl-2 **:[p]:not-first:mt-2">
+                                    {!! app(ScriptureLinker::class)->linkify($comment->text) !!}
+                                </div>
+                            </div>
+                        </div>
+                    @endforeach
+                @endforeach
+            </div>
+
+            {{-- composer --}}
+            <div class="px-5 pb-4 pt-3">
+                <x-conversation-composer
+                    editor-model="reply"
+                    submit-action="sendThread"
+                    submit-label="Send"
+                    :allow-prayer="false"
+                    :allow-mentions="false"
+                    test-prefix="dm-composer"
+                />
+            </div>
+        @elseif ($mode === 'compose')
+            {{-- compose header --}}
+            <header class="flex items-center gap-3 border-b border-zinc-200 px-5 py-3.5 dark:border-zinc-700">
+                <div class="min-w-0 flex-1">
+                    <flux:heading size="lg">{{ $addPersonFrom ? __('Add people') : __('New message') }}</flux:heading>
+                    <div class="text-[12.5px] text-zinc-500 dark:text-zinc-400">
+                        {{ $addPersonFrom ? __('Starts a separate conversation with everyone below') : __('Pick one person for a direct message, or several for a group') }}
+                    </div>
+                </div>
+                <flux:button size="sm" variant="ghost" icon="x-mark" wire:click="cancelCompose" data-test="cancel-compose" />
+            </header>
+
+            {{-- To: field --}}
+            <div class="border-b border-zinc-200 px-5 py-4 dark:border-zinc-700">
+                <div class="flex items-start gap-2" x-data @click="$refs.recipientInput?.focus()">
+                    <span class="pt-1.5 text-sm font-semibold text-zinc-600 dark:text-zinc-300">{{ __('To:') }}</span>
+                    <div class="flex min-w-0 flex-1 flex-wrap items-center gap-1.5">
+                        @foreach ($this->recipientChips as $chip)
+                            <span
+                                wire:key="chip-{{ $chip->id }}"
+                                class="inline-flex h-7 items-center gap-1.5 rounded-full border border-accent/30 bg-accent/10 pl-1 pr-1.5 text-[13px] font-semibold text-accent-content"
+                                data-test="recipient-chip"
+                            >
+                                <flux:avatar size="xs" :name="$chip->name" :src="$chip->gravatar" color="auto" />
+                                <span class="text-accent">{{ $chip->name }}</span>
+                                <button type="button" wire:click="removeRecipient({{ $chip->id }})" class="grid size-4 place-items-center rounded-full text-accent hover:bg-accent/20" aria-label="Remove">
+                                    <flux:icon.x-mark variant="micro" class="size-2.5" />
+                                </button>
+                            </span>
+                        @endforeach
+
+                        <input
+                            x-ref="recipientInput"
+                            type="text"
+                            wire:model.live.debounce.200ms="composeQuery"
+                            @if ($this->recipientChips->isNotEmpty())
+                                @keydown.backspace="if ($event.target.value === '') $wire.removeRecipient({{ $this->recipientChips->last()->id }})"
+                            @endif
+                            placeholder="{{ $this->recipientChips->isEmpty() ? __('Type a name…') : '' }}"
+                            class="h-7 min-w-[120px] flex-1 border-0 bg-transparent text-sm text-zinc-900 placeholder-zinc-400 focus:outline-none focus:ring-0 dark:text-zinc-100"
+                        />
+                    </div>
+                </div>
+                <flux:error name="composeRecipients" class="mt-1.5" />
+            </div>
+
+            {{-- body --}}
+            <div class="flex-1 overflow-y-auto px-5 py-4">
+                @if ($this->noteBanner)
+                    @php($tone = $this->noteBanner['tone'])
+                    <div @class([
+                        'mb-3.5 flex gap-2.5 rounded-xl border px-3.5 py-3',
+                        'border-accent/30 bg-accent/10 text-accent' => $tone === 'info',
+                        'border-amber-300 bg-amber-50 text-amber-800 dark:border-amber-700 dark:bg-amber-900/30 dark:text-amber-200' => $tone === 'warn',
+                        'border-zinc-200 bg-zinc-50 text-zinc-600 dark:border-zinc-700 dark:bg-zinc-800/60 dark:text-zinc-300' => $tone === 'neutral',
+                    ]) data-test="note-banner" data-tone="{{ $tone }}">
+                        <flux:icon.information-circle class="mt-0.5 size-4 shrink-0" />
+                        <div>
+                            <div class="text-[13px] font-bold">{{ $this->noteBanner['title'] }}</div>
+                            <div class="mt-0.5 text-[12.5px] leading-relaxed opacity-90">{{ $this->noteBanner['body'] }}</div>
+                        </div>
+                    </div>
+                @endif
+
+                <div class="mb-2 text-[11px] font-bold uppercase tracking-wider text-zinc-500 dark:text-zinc-400">{{ __('Suggested') }}</div>
+
+                @forelse ($this->suggestions as $person)
+                    <button
+                        type="button"
+                        wire:key="suggestion-{{ $person->id }}"
+                        wire:click="addRecipient({{ $person->id }})"
+                        class="flex w-full items-center gap-3 rounded-lg px-2.5 py-2 text-left transition hover:bg-zinc-100 dark:hover:bg-zinc-800"
+                        data-test="suggestion"
+                    >
+                        <flux:avatar size="sm" :name="$person->name" :src="$person->gravatar" color="auto" />
+                        <span class="min-w-0 flex-1">
+                            <span class="block truncate text-sm font-semibold text-zinc-900 dark:text-zinc-100">{{ $person->name }}</span>
+                            <span class="block truncate text-xs text-zinc-500 dark:text-zinc-400">{{ $person->email }}</span>
+                        </span>
+                        <flux:icon.plus class="size-4 text-zinc-400" />
+                    </button>
+                @empty
+                    <div class="px-2.5 py-6 text-[13px] text-zinc-500 dark:text-zinc-400">
+                        {{ $composeQuery !== '' ? __('No people match.') : __('Everyone is already added.') }}
+                    </div>
+                @endforelse
+            </div>
+
+            {{-- first-message composer --}}
+            <div class="border-t border-zinc-200 px-5 pb-4 pt-3 dark:border-zinc-700">
+                <x-conversation-composer
+                    editor-model="reply"
+                    submit-action="sendCompose"
+                    :submit-label="count($composeRecipients) >= 2 ? __('Start conversation') : __('Send')"
+                    :allow-prayer="false"
+                    :allow-mentions="false"
+                    test-prefix="dm-compose"
+                />
+            </div>
+        @else
+            {{-- empty --}}
+            <div class="flex flex-1 flex-col items-center justify-center gap-3.5 p-10 text-center" data-test="messages-empty">
+                <div class="grid size-14 place-items-center rounded-2xl bg-accent/10">
+                    <flux:icon.chat-bubble-left-right class="size-7 text-accent" />
+                </div>
+                <flux:heading size="lg">{{ __('Select a conversation') }}</flux:heading>
+                <flux:text class="max-w-[300px]">{{ __('Pick a thread on the left, or start a new message to anyone in your congregation.') }}</flux:text>
+                <flux:button variant="primary" icon="pencil-square" wire:click="newMessage" class="mt-1">{{ __('New message') }}</flux:button>
+            </div>
+        @endif
+    </div>
+
+    @script
+    <script>
+        window.addEventListener('stave:notification', (event) => {
+            const detail = event.detail ?? {};
+
+            if (detail.is_direct || detail.conversation_id) {
+                $wire.handleIncoming(detail.conversation_id ?? null);
+            }
+        });
+    </script>
+    @endscript
+</section>

--- a/routes/web.php
+++ b/routes/web.php
@@ -82,6 +82,13 @@ Route::middleware(['auth'])->group(function (): void {
         });
 
     Route::livewire('/people', 'pages::people.index')->name('people.index');
+
+    Route::name('messages.')
+        ->prefix('messages')
+        ->group(function (): void {
+            Route::livewire('/', 'pages::messages.index')->name('index');
+            Route::livewire('/{conversation}', 'pages::messages.index')->name('show');
+        });
 });
 
 require __DIR__.'/auth.php';

--- a/tests/Feature/DirectMessagingTest.php
+++ b/tests/Feature/DirectMessagingTest.php
@@ -1,0 +1,249 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Group;
+use App\Models\User;
+use App\Notifications\DirectMessageNotification;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+/* --------------------------- page / access --------------------------- */
+
+test('the messages index renders for an authenticated user', function (): void {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->get(route('messages.index'))
+        ->assertOk()
+        ->assertSee('Messages');
+});
+
+test('a non-participant cannot deep-link into a direct conversation', function (): void {
+    $me = User::factory()->create();
+    $other = User::factory()->create();
+    $stranger = User::factory()->create();
+
+    $conversation = Group::findOrCreateDirect($me, [$other->id])->directConversation;
+
+    $this->actingAs($stranger)
+        ->get(route('messages.show', $conversation))
+        ->assertNotFound();
+
+    $this->actingAs($me)
+        ->get(route('messages.show', $conversation))
+        ->assertOk();
+});
+
+/* ------------------------------ compose ------------------------------ */
+
+test('composing a one-to-one message creates a direct group, conversation, and comment', function (): void {
+    $me = User::factory()->create();
+    $other = User::factory()->create(['name' => 'Bruce Green']);
+
+    Livewire::actingAs($me)
+        ->test('pages::messages.index')
+        ->call('newMessage')
+        ->call('addRecipient', $other->id)
+        ->set('reply', '<p>Hello Bruce</p>')
+        ->call('sendCompose')
+        ->assertHasNoErrors();
+
+    $group = Group::query()->direct()->sole();
+
+    expect($group->is_direct)->toBeTrue()
+        ->and($group->direct_key)->toBe(Group::directKeyFor([$me->id, $other->id]))
+        ->and($group->directConversation->comments()->count())->toBe(1);
+});
+
+test('messaging the same person again reuses the existing thread (no duplicate)', function (): void {
+    $me = User::factory()->create();
+    $other = User::factory()->create();
+
+    $component = Livewire::actingAs($me)->test('pages::messages.index');
+
+    $component->call('newMessage')->call('addRecipient', $other->id)
+        ->set('reply', '<p>first</p>')->call('sendCompose')->assertHasNoErrors();
+
+    $component->call('newMessage')->call('addRecipient', $other->id)
+        ->set('reply', '<p>second</p>')->call('sendCompose')->assertHasNoErrors();
+
+    expect(Group::query()->direct()->count())->toBe(1)
+        ->and(Group::query()->direct()->sole()->directConversation->comments()->count())->toBe(2);
+});
+
+test('composing a multi-person message always creates a new group (no dedupe)', function (): void {
+    $me = User::factory()->create();
+    $a = User::factory()->create();
+    $b = User::factory()->create();
+
+    $component = Livewire::actingAs($me)->test('pages::messages.index');
+
+    $component->call('newMessage')->call('addRecipient', $a->id)->call('addRecipient', $b->id)
+        ->set('reply', '<p>one</p>')->call('sendCompose')->assertHasNoErrors();
+
+    $component->call('newMessage')->call('addRecipient', $a->id)->call('addRecipient', $b->id)
+        ->set('reply', '<p>two</p>')->call('sendCompose')->assertHasNoErrors();
+
+    expect(Group::query()->direct()->count())->toBe(2);
+});
+
+/* ----------------------------- add people ---------------------------- */
+
+test('add people branches a new conversation and leaves the original intact', function (): void {
+    $me = User::factory()->create();
+    $a = User::factory()->create();
+    $b = User::factory()->create();
+
+    $original = Group::findOrCreateDirect($me, [$a->id])->directConversation;
+    $original->postComment('<p>original</p>', $me);
+
+    Livewire::actingAs($me)
+        ->test('pages::messages.index', ['conversation' => $original])
+        ->call('beginAddPeople')
+        ->call('addRecipient', $b->id)
+        ->set('reply', '<p>group hello</p>')
+        ->call('sendCompose')
+        ->assertHasNoErrors();
+
+    $branched = Group::query()->direct()->whereNull('direct_key')->sole();
+
+    expect(Group::query()->direct()->count())->toBe(2)
+        ->and($original->fresh()->comments()->count())->toBe(1)
+        ->and($branched->members()->count())->toBe(3);
+});
+
+test('removing added people back to the original recipient reuses the 1:1 thread', function (): void {
+    $me = User::factory()->create();
+    $a = User::factory()->create();
+    $b = User::factory()->create();
+
+    $original = Group::findOrCreateDirect($me, [$a->id])->directConversation;
+    $original->postComment('<p>original</p>', $me);
+
+    Livewire::actingAs($me)
+        ->test('pages::messages.index', ['conversation' => $original])
+        ->call('beginAddPeople')
+        ->call('addRecipient', $b->id)
+        ->call('removeRecipient', $b->id)
+        ->set('reply', '<p>back to a</p>')
+        ->call('sendCompose')
+        ->assertHasNoErrors();
+
+    expect(Group::query()->direct()->count())->toBe(1)
+        ->and($original->fresh()->comments()->count())->toBe(2);
+});
+
+/* ------------------------------ banners ------------------------------ */
+
+test('compose shows the existing-conversation banner for a known 1:1', function (): void {
+    $me = User::factory()->create();
+    $other = User::factory()->create();
+    Group::findOrCreateDirect($me, [$other->id]);
+
+    Livewire::actingAs($me)
+        ->test('pages::messages.index')
+        ->call('newMessage')
+        ->call('addRecipient', $other->id)
+        ->assertSee('You already message');
+});
+
+test('compose shows the new-group banner for multiple fresh recipients', function (): void {
+    $me = User::factory()->create();
+    $a = User::factory()->create();
+    $b = User::factory()->create();
+
+    Livewire::actingAs($me)
+        ->test('pages::messages.index')
+        ->call('newMessage')
+        ->call('addRecipient', $a->id)
+        ->call('addRecipient', $b->id)
+        ->assertSee('New group conversation');
+});
+
+test('add people shows the branch warning banner', function (): void {
+    $me = User::factory()->create();
+    $a = User::factory()->create();
+    $b = User::factory()->create();
+
+    $conversation = Group::findOrCreateDirect($me, [$a->id])->directConversation;
+
+    Livewire::actingAs($me)
+        ->test('pages::messages.index', ['conversation' => $conversation])
+        ->call('beginAddPeople')
+        ->call('addRecipient', $b->id)
+        ->assertSee('This starts a new conversation');
+});
+
+/* --------------------------- notifications --------------------------- */
+
+test('sending a direct message notifies the other participants but not the author', function (): void {
+    Notification::fake();
+
+    $me = User::factory()->create();
+    $other = User::factory()->create();
+
+    Livewire::actingAs($me)
+        ->test('pages::messages.index')
+        ->call('newMessage')
+        ->call('addRecipient', $other->id)
+        ->set('reply', '<p>hi there</p>')
+        ->call('sendCompose')
+        ->assertHasNoErrors();
+
+    Notification::assertSentTo($other, DirectMessageNotification::class);
+    Notification::assertNotSentTo($me, DirectMessageNotification::class);
+});
+
+/* ------------------------------ unread ------------------------------- */
+
+test('opening a conversation marks it read and clears its bell notifications', function (): void {
+    $me = User::factory()->create();
+    $other = User::factory()->create();
+
+    $conversation = Group::findOrCreateDirect($other, [$me->id])->directConversation;
+    $conversation->postComment('<p>hello you</p>', $other);
+
+    expect($conversation->unreadCountFor($me))->toBe(1)
+        ->and($me->fresh()->unreadNotifications()->where('data->conversation_id', $conversation->id)->count())
+        ->toBeGreaterThan(0);
+
+    Livewire::actingAs($me)
+        ->test('pages::messages.index')
+        ->call('openConversation', $conversation->id);
+
+    expect($conversation->fresh()->unreadCountFor($me))->toBe(0)
+        ->and($me->fresh()->unreadNotifications()->where('data->conversation_id', $conversation->id)->count())
+        ->toBe(0);
+});
+
+test('a sent message does not count as unread for its author', function (): void {
+    $me = User::factory()->create();
+    $other = User::factory()->create();
+
+    $conversation = Group::findOrCreateDirect($me, [$other->id])->directConversation;
+    $conversation->postComment('<p>mine</p>', $me);
+
+    expect($conversation->unreadCountFor($me))->toBe(0)
+        ->and($conversation->unreadCountFor($other))->toBe(1)
+        ->and($me->unreadDirectCount())->toBe(0)
+        ->and($other->unreadDirectCount())->toBe(1);
+});
+
+/* --------------------- separation from named groups ------------------ */
+
+test('direct groups are excluded from a user\'s named groups', function (): void {
+    $me = User::factory()->create();
+    $other = User::factory()->create();
+
+    $direct = Group::findOrCreateDirect($me, [$other->id]);
+
+    $visibleIds = $me->fresh()->groups()->where('groups.is_direct', false)->pluck('groups.id');
+
+    expect($visibleIds)->not->toContain($direct->id);
+
+    $this->actingAs($me)->get(route('groups.index'))->assertOk();
+});


### PR DESCRIPTION
## Summary

- Adds 1:1 and multi-person direct messaging as a standalone feature, backed by lightweight "direct groups" (`is_direct` flag on groups table) with per-user read tracking via a `conversation_user` pivot table.
- Full-page Livewire messaging UI at `/messages` with compose flow, thread view, search, add-people branching, unread badges, mute/delete, and real-time notification updates.
- Dedicated `DirectMessageNotification` dispatched to all DM participants (mail, broadcast, web push), with the notification listener updated to route direct-message threads separately.
- Sidebar shows a Messages item with a live unread-count badge computed in a single optimized query.
- Direct groups are excluded from the named-groups index and discover pages.

## Test plan

- [x] 14 Pest feature tests covering page access, compose (1:1, multi-person, dedup), add-people branching, contextual banners, notifications, unread tracking, and group separation
- [ ] Manual: verify sidebar badge updates in real time via Echo/Reverb
- [ ] Manual: confirm compose flow, thread rendering, and mute/delete in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added direct messaging with one-to-one and multi-recipient conversations, including compose/search and recipient chips.
  * Introduced a dedicated Messages area with threaded viewing, contextual compose banners, and conversation mute/delete.
  * Implemented notifications for direct replies (email, realtime updates, and web push) and per-user read/unread tracking.
  * Added a realtime sidebar unread counter for direct messages; excluded direct conversations from the “My Groups” list.

* **Tests**
  * Added end-to-end direct messaging feature coverage (compose, notifications, read states, UI behaviors).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->