### PR TITLE
Fix Messages page not filling viewport height

### DIFF
--- a/resources/views/pages/messages/index.blade.php
+++ b/resources/views/pages/messages/index.blade.php
@@ -513,7 +513,7 @@ new class extends Component {
     }
 }; ?>
 
-<section class="-m-6 flex h-[calc(100vh-3rem)] min-h-0" data-test="messages-page">
+<section class="-m-6 lg:-m-8 flex h-[calc(100vh-3rem)] lg:h-screen min-h-0" data-test="messages-page">
     {{-- ============ LEFT RAIL ============ --}}
     <div class="flex w-[344px] shrink-0 flex-col border-e border-zinc-200 dark:border-zinc-700">
         <div class="border-b border-zinc-200 px-4 pb-3 pt-4 dark:border-zinc-700">


### PR DESCRIPTION
The Messages page's root `<section>` reserved 3rem of height for a header that is hidden on desktop and under-cancelled `flux:main`'s `lg:p-8` padding, leaving an empty band at the bottom of the screen. This adds `lg:-m-8` and `lg:h-screen` so the conversation list and conversation/composer panel fill the full viewport on desktop, matching the existing group conversations layout. Mobile behavior is unchanged. Verified with `php artisan test --filter=Message` (29 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)