### PR TITLE
Add households and enhance people management

### DIFF
--- a/app/Enums/Gender.php
+++ b/app/Enums/Gender.php
@@ -6,12 +6,14 @@ enum Gender: string
 {
     case MALE = 'male';
     case FEMALE = 'female';
+    case PREFER_NOT_TO_SAY = 'prefer_not_to_say';
 
     public function label(): string
     {
         return match ($this) {
             self::MALE => 'Male',
             self::FEMALE => 'Female',
+            self::PREFER_NOT_TO_SAY => 'Prefer not to say',
         };
     }
 
@@ -20,6 +22,7 @@ enum Gender: string
         return match ($this) {
             self::FEMALE => 'pink',
             self::MALE => 'blue',
+            self::PREFER_NOT_TO_SAY => 'zinc',
         };
     }
 }

--- a/app/Enums/HouseholdRole.php
+++ b/app/Enums/HouseholdRole.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Enums;
+
+enum HouseholdRole: string
+{
+    case HEAD_OF_HOUSEHOLD = 'head_of_household';
+    case SPOUSE = 'spouse';
+    case CHILD = 'child';
+    case DEPENDENT = 'dependent';
+    case OTHER = 'other';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::HEAD_OF_HOUSEHOLD => 'Head of household',
+            self::SPOUSE => 'Spouse',
+            self::CHILD => 'Child',
+            self::DEPENDENT => 'Dependent',
+            self::OTHER => 'Other',
+        };
+    }
+}

--- a/app/Livewire/Forms/PersonForm.php
+++ b/app/Livewire/Forms/PersonForm.php
@@ -3,6 +3,7 @@
 namespace App\Livewire\Forms;
 
 use App\Enums\Gender;
+use App\Enums\HouseholdRole;
 use App\Enums\MembershipStatus;
 use App\Enums\TerminationReason;
 use App\Models\Person;
@@ -40,6 +41,16 @@ class PersonForm extends Form
 
     public ?string $gender = null;
 
+    public ?string $birth_date = null;
+
+    public bool $baptized = false;
+
+    public ?string $baptism_date = null;
+
+    public ?int $household_id = null;
+
+    public ?string $household_role = null;
+
     public string $membership_status = MembershipStatus::VISITOR->value;
 
     public ?string $membership_since = null;
@@ -52,6 +63,11 @@ class PersonForm extends Form
     {
         return [
             'gender' => ['nullable', Rule::enum(Gender::class)],
+            'birth_date' => ['nullable', 'date'],
+            'baptized' => ['boolean'],
+            'baptism_date' => ['nullable', 'date'],
+            'household_id' => ['nullable', 'integer', Rule::exists('households', 'id')],
+            'household_role' => ['nullable', Rule::enum(HouseholdRole::class)],
             'membership_status' => ['required', Rule::enum(MembershipStatus::class)],
             'membership_since' => ['nullable', 'date'],
             'termination_reason' => ['nullable', Rule::enum(TerminationReason::class)],
@@ -72,6 +88,11 @@ class PersonForm extends Form
         $this->address_state = $person->address_state;
         $this->address_zip = $person->address_zip;
         $this->gender = $person->gender?->value;
+        $this->birth_date = $person->birth_date?->toDateString();
+        $this->baptized = $person->baptized;
+        $this->baptism_date = $person->baptism_date?->toDateString();
+        $this->household_id = $person->household_id;
+        $this->household_role = $person->household_role?->value;
         $this->membership_status = $person->membership_status->value;
         $this->membership_since = $person->membership_since?->toDateString();
         $this->termination_reason = $person->termination_reason?->value;
@@ -105,10 +126,17 @@ class PersonForm extends Form
             'address_state',
             'address_zip',
             'gender',
+            'birth_date',
+            'baptized',
+            'household_id',
             'membership_status',
             'membership_since',
             'pastoral_care_elder_id',
         ]);
+
+        $data['baptism_date'] = $this->baptized ? $this->baptism_date : null;
+
+        $data['household_role'] = $this->household_id ? $this->household_role : null;
 
         $data['termination_reason'] = $this->membership_status === MembershipStatus::TERMINATED->value
             ? $this->termination_reason

--- a/app/Models/Household.php
+++ b/app/Models/Household.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\HouseholdFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+#[Fillable(['name', 'address'])]
+class Household extends Model
+{
+    /** @use HasFactory<HouseholdFactory> */
+    use HasFactory;
+
+    protected static function booted(): void
+    {
+        static::deleting(function (Household $household): void {
+            $household->people()->update([
+                'household_id' => null,
+                'household_role' => null,
+            ]);
+        });
+    }
+
+    /** @return HasMany<Person, $this> */
+    public function people(): HasMany
+    {
+        return $this->hasMany(Person::class);
+    }
+}

--- a/app/Models/Person.php
+++ b/app/Models/Person.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Enums\Gender;
+use App\Enums\HouseholdRole;
 use App\Enums\MembershipStatus;
 use App\Enums\TerminationReason;
 use App\Models\Traits\HasGravatar;
@@ -24,6 +25,10 @@ use Illuminate\Support\Carbon;
  * @property ?Carbon $membership_since
  * @property ?Carbon $last_active_at
  * @property ?Carbon $birth_date
+ * @property bool $baptized
+ * @property ?Carbon $baptism_date
+ * @property ?int $household_id
+ * @property ?HouseholdRole $household_role
  */
 #[Fillable([
     'first_name',
@@ -36,6 +41,10 @@ use Illuminate\Support\Carbon;
     'address_zip',
     'birth_date',
     'gender',
+    'baptized',
+    'baptism_date',
+    'household_id',
+    'household_role',
     'membership_status',
     'membership_since',
     'termination_reason',
@@ -55,6 +64,9 @@ class Person extends Model
         return [
             'gender' => Gender::class,
             'birth_date' => 'date',
+            'baptized' => 'boolean',
+            'baptism_date' => 'date',
+            'household_role' => HouseholdRole::class,
             'membership_status' => MembershipStatus::class,
             'membership_since' => 'date',
             'termination_reason' => TerminationReason::class,
@@ -84,6 +96,12 @@ class Person extends Model
     public function allOffices(): HasMany
     {
         return $this->hasMany(PersonOffice::class);
+    }
+
+    /** @return BelongsTo<Household, $this> */
+    public function household(): BelongsTo
+    {
+        return $this->belongsTo(Household::class);
     }
 
     /** @return BelongsTo<Person, $this> */

--- a/database/factories/HouseholdFactory.php
+++ b/database/factories/HouseholdFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Household;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Household>
+ */
+class HouseholdFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => 'The '.fake()->lastName().' Household',
+            'address' => fake()->optional(0.7)->streetAddress(),
+        ];
+    }
+}

--- a/database/factories/PersonFactory.php
+++ b/database/factories/PersonFactory.php
@@ -3,7 +3,9 @@
 namespace Database\Factories;
 
 use App\Enums\Gender;
+use App\Enums\HouseholdRole;
 use App\Enums\MembershipStatus;
+use App\Models\Household;
 use App\Models\Person;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
@@ -28,6 +30,8 @@ class PersonFactory extends Factory
             'address_zip' => fake()->optional(0.6)->postcode(),
             'birth_date' => fake()->date(),
             'gender' => fake()->randomElement(Gender::cases()),
+            'baptized' => $baptized = fake()->boolean(),
+            'baptism_date' => $baptized ? fake()->optional(0.8)->date() : null,
             'membership_status' => fake()->randomElement([
                 MembershipStatus::VISITOR,
                 MembershipStatus::ADHERENT,
@@ -56,5 +60,13 @@ class PersonFactory extends Factory
     public function member(): self
     {
         return $this->state(['membership_status' => MembershipStatus::MEMBER]);
+    }
+
+    public function inHousehold(Household $household, HouseholdRole $role = HouseholdRole::OTHER): self
+    {
+        return $this->state([
+            'household_id' => $household->id,
+            'household_role' => $role,
+        ]);
     }
 }

--- a/database/migrations/2026_06_18_021057_create_households_table.php
+++ b/database/migrations/2026_06_18_021057_create_households_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('households', function (Blueprint $table): void {
+            $table->id();
+            $table->string('name');
+            $table->string('address')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('households');
+    }
+};

--- a/database/migrations/2026_06_18_021111_add_household_and_baptism_to_people_table.php
+++ b/database/migrations/2026_06_18_021111_add_household_and_baptism_to_people_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('people', function (Blueprint $table): void {
+            $table->boolean('baptized')->default(false)->after('birth_date');
+            $table->date('baptism_date')->nullable()->after('baptized');
+
+            $table->foreignId('household_id')
+                ->nullable()
+                ->after('baptism_date')
+                ->constrained('households')
+                ->nullOnDelete();
+
+            $table->string('household_role')->nullable()->after('household_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('people', function (Blueprint $table): void {
+            $table->dropForeign(['household_id']);
+            $table->dropColumn([
+                'baptized',
+                'baptism_date',
+                'household_id',
+                'household_role',
+            ]);
+        });
+    }
+};

--- a/resources/views/components/layouts/app/sidebar.blade.php
+++ b/resources/views/components/layouts/app/sidebar.blade.php
@@ -24,6 +24,7 @@
                 <flux:sidebar.group expandable icon="church" :heading="__('Congregation')">
                     <flux:sidebar.item icon="users" :href="route('people.index')" :current="request()->routeIs('people.*')" wire:navigate>{{ __('People') }}</flux:sidebar.item>
                     <flux:sidebar.item icon="user-group" :href="route('groups.index')" :current="request()->routeIs('groups.*')" wire:navigate>{{ __('Groups') }}</flux:sidebar.item>
+                    <flux:sidebar.item icon="home-modern" :href="route('households.index')" :current="request()->routeIs('households.*')" wire:navigate>{{ __('Households') }}</flux:sidebar.item>
                     <livewire:sidebar.messages />
                     <flux:sidebar.item icon="calendar-date-range" wire:navigate>{{ __('Prayer Schedule') }}</flux:sidebar.item>
                 </flux:sidebar.group>

--- a/resources/views/livewire/people/drawer.blade.php
+++ b/resources/views/livewire/people/drawer.blade.php
@@ -2,12 +2,15 @@
 
 use App\Enums\AccessRole;
 use App\Enums\Gender;
+use App\Enums\HouseholdRole;
 use App\Enums\MembershipStatus;
 use App\Enums\Office;
 use App\Livewire\Forms\PersonForm;
+use App\Models\Household;
 use App\Models\Person;
 use App\Models\PersonOffice;
 use Flux\Flux;
+use Illuminate\Database\Eloquent\Collection;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Locked;
 use Livewire\Attributes\On;
@@ -18,6 +21,13 @@ new class extends Component
     public ?int $personId = null;
 
     public bool $showElderPicker = false;
+
+    public bool $creatingHousehold = false;
+
+    public string $newHouseholdName = '';
+
+    /** Bound to the household <select>; holds '' | household id | '__new__'. */
+    public string $householdSelection = '';
 
     public PersonForm $form;
 
@@ -35,7 +45,7 @@ new class extends Component
             return null;
         }
 
-        return Person::with(['allOffices', 'user', 'pastoralCareElder', 'assignedCongregants'])->find($this->personId);
+        return Person::with(['allOffices', 'user', 'pastoralCareElder', 'assignedCongregants', 'household'])->find($this->personId);
     }
 
     #[Computed]
@@ -44,9 +54,9 @@ new class extends Component
         return (bool) $this->person?->allOffices->contains(fn (PersonOffice $o) => $o->kind === Office::ELDER && $o->ended_on === null);
     }
 
-    /** @return \Illuminate\Support\Collection<int, Person> */
+    /** @return Collection<int, Person> */
     #[Computed]
-    public function elderCandidates()
+    public function elderCandidates(): Collection
     {
         return Person::query()
             ->whereHas('offices', fn ($q) => $q->where('kind', Office::ELDER))
@@ -55,14 +65,73 @@ new class extends Component
             ->get();
     }
 
+    /** @return Collection<int, Household> */
+    #[Computed]
+    public function households(): Collection
+    {
+        return Household::orderBy('name')->get();
+    }
+
     #[On('open-person-drawer')]
     public function openPerson(int $personId): void
     {
         $this->personId = $personId;
         $this->showElderPicker = false;
+        $this->creatingHousehold = false;
+        $this->newHouseholdName = '';
         $this->loadForm();
         $this->loadAccessRoles();
         Flux::modal('person-drawer')->show();
+    }
+
+    public function updatedHouseholdSelection(string $value): void
+    {
+        if ($value === '__new__') {
+            $this->creatingHousehold = true;
+            $this->householdSelection = '';
+            $this->form->household_id = null;
+            $this->form->household_role = null;
+
+            return;
+        }
+
+        if ($value === '') {
+            $this->form->household_id = null;
+            $this->form->household_role = null;
+
+            return;
+        }
+
+        $this->form->household_id = (int) $value;
+        $this->form->household_role = $this->form->household_role ?: HouseholdRole::OTHER->value;
+    }
+
+    public function createHousehold(): void
+    {
+        $name = trim($this->newHouseholdName);
+
+        if ($name === '') {
+            return;
+        }
+
+        $household = Household::create(['name' => $name]);
+
+        $this->form->household_id = $household->id;
+        $this->form->household_role = $this->form->household_role ?: HouseholdRole::HEAD_OF_HOUSEHOLD->value;
+        $this->householdSelection = (string) $household->id;
+
+        $this->creatingHousehold = false;
+        $this->newHouseholdName = '';
+        unset($this->households);
+    }
+
+    public function cancelCreateHousehold(): void
+    {
+        $this->creatingHousehold = false;
+        $this->newHouseholdName = '';
+        $this->form->household_id = $this->person?->household_id;
+        $this->form->household_role = $this->person?->household_role?->value;
+        $this->householdSelection = (string) ($this->person?->household_id ?? '');
     }
 
     public function toggleElderPicker(): void
@@ -76,6 +145,7 @@ new class extends Component
 
         if ($person) {
             $this->form->setPerson($person);
+            $this->householdSelection = (string) ($person->household_id ?? '');
         }
     }
 
@@ -266,6 +336,82 @@ new class extends Component
                             <flux:input wire:model="form.address_zip" />
                         </flux:field>
                     </div>
+                </section>
+
+                {{-- Personal --}}
+                <section>
+                    <flux:heading class="!text-xs uppercase tracking-wider text-zinc-500 mb-2">Personal</flux:heading>
+                    <div class="grid grid-cols-2 gap-3">
+                        <flux:field>
+                            <flux:label>Birthdate</flux:label>
+                            <flux:date-picker wire:model="form.birth_date" />
+                            <flux:error name="form.birth_date" />
+                        </flux:field>
+                        <flux:field>
+                            <flux:label>Gender</flux:label>
+                            <flux:select variant="listbox" wire:model="form.gender" placeholder="Not specified" clearable>
+                                @foreach (Gender::cases() as $gender)
+                                    <flux:select.option :value="$gender->value">{{ $gender->label() }}</flux:select.option>
+                                @endforeach
+                            </flux:select>
+                            <flux:error name="form.gender" />
+                        </flux:field>
+                    </div>
+
+                    <flux:card class="!p-4 mt-4 bg-zinc-50 dark:bg-zinc-800 space-y-4">
+                        <div class="flex items-center justify-between gap-3">
+                            <div class="flex items-center gap-2">
+                                <flux:icon icon="waves" class="size-[18px] text-emerald-600 dark:text-emerald-400" />
+                                <flux:heading class="!text-sm">Baptized</flux:heading>
+                            </div>
+                            <flux:switch wire:model.live="form.baptized" />
+                        </div>
+                        @if ($form->baptized)
+                            <flux:field>
+                                <flux:label>Baptism date</flux:label>
+                                <flux:date-picker wire:model="form.baptism_date" />
+                                <flux:error name="form.baptism_date" />
+                            </flux:field>
+                        @endif
+                    </flux:card>
+                </section>
+
+                {{-- Household --}}
+                <section>
+                    <flux:heading class="!text-xs uppercase tracking-wider text-zinc-500 mb-2">Household</flux:heading>
+                    @if ($creatingHousehold)
+                        <flux:field>
+                            <flux:label>New household name</flux:label>
+                            <div class="flex gap-2">
+                                <flux:input wire:model="newHouseholdName" placeholder="e.g. The Baker Household" class="flex-1" wire:keydown.enter.prevent="createHousehold" />
+                                <flux:button variant="primary" wire:click="createHousehold">Create</flux:button>
+                                <flux:button variant="ghost" wire:click="cancelCreateHousehold">Cancel</flux:button>
+                            </div>
+                        </flux:field>
+                    @else
+                        <flux:field>
+                            <flux:label>Household</flux:label>
+                            <flux:select variant="listbox" wire:model.live="householdSelection" placeholder="Not in a household" clearable>
+                                @foreach ($this->households as $household)
+                                    <flux:select.option :value="(string) $household->id">{{ $household->name }}</flux:select.option>
+                                @endforeach
+                                <flux:select.option value="__new__">+ Create new household…</flux:select.option>
+                            </flux:select>
+                            <flux:error name="form.household_id" />
+                        </flux:field>
+
+                        @if ($form->household_id)
+                            <flux:field class="mt-3">
+                                <flux:label>Role in household</flux:label>
+                                <flux:select variant="listbox" wire:model="form.household_role">
+                                    @foreach (HouseholdRole::cases() as $role)
+                                        <flux:select.option :value="$role->value">{{ $role->label() }}</flux:select.option>
+                                    @endforeach
+                                </flux:select>
+                                <flux:error name="form.household_role" />
+                            </flux:field>
+                        @endif
+                    @endif
                 </section>
 
                 {{-- Membership --}}
@@ -521,8 +667,34 @@ new class extends Component
                         <dd>{{ $person->last_active_at?->diffForHumans() ?? '—' }}</dd>
                         <dt class="text-zinc-500">Added</dt>
                         <dd>{{ $person->created_at->toFormattedDayDateString() }}</dd>
+                        <dt class="text-zinc-500">Birthdate</dt>
+                        <dd>
+                            @if ($person->birth_date)
+                                {{ $person->birth_date->format('M j, Y') }} · {{ $person->birth_date->age }} yrs
+                            @else
+                                <span class="text-zinc-400">—</span>
+                            @endif
+                        </dd>
                         <dt class="text-zinc-500">Gender</dt>
                         <dd>{{ $person->gender?->label() ?? '—' }}</dd>
+                        <dt class="text-zinc-500">Baptism</dt>
+                        <dd>
+                            @if ($person->baptized && $person->baptism_date)
+                                {{ $person->baptism_date->format('M j, Y') }}
+                            @elseif ($person->baptized)
+                                Yes — date not set
+                            @else
+                                Not baptized
+                            @endif
+                        </dd>
+                        <dt class="text-zinc-500">Household</dt>
+                        <dd>
+                            @if ($person->household)
+                                {{ $person->household->name }}@if ($person->household_role) · {{ $person->household_role->label() }}@endif
+                            @else
+                                <span class="text-zinc-400">—</span>
+                            @endif
+                        </dd>
                     </dl>
                 </section>
 

--- a/resources/views/livewire/people/drawer.blade.php
+++ b/resources/views/livewire/people/drawer.blade.php
@@ -131,7 +131,7 @@ new class extends Component
         $this->newHouseholdName = '';
         $this->form->household_id = $this->person?->household_id;
         $this->form->household_role = $this->person?->household_role?->value;
-        $this->householdSelection = (string) ($this->person?->household_id ?? '');
+        $this->householdSelection = (string) ($this->form->household_id ?? '');
     }
 
     public function toggleElderPicker(): void

--- a/resources/views/pages/households/index.blade.php
+++ b/resources/views/pages/households/index.blade.php
@@ -1,0 +1,182 @@
+<?php
+
+use App\Models\Household;
+use Flux\Flux;
+use Illuminate\Database\Eloquent\Collection;
+use Livewire\Attributes\Computed;
+use Livewire\Attributes\Validate;
+use Livewire\Component;
+
+new class extends Component
+{
+    public bool $showForm = false;
+
+    public ?int $editingId = null;
+
+    #[Validate('required|string|max:255')]
+    public string $hhName = '';
+
+    #[Validate('nullable|string|max:255')]
+    public ?string $hhAddress = null;
+
+    /** @return Collection<int, Household> */
+    #[Computed]
+    public function households(): Collection
+    {
+        return Household::with(['people' => fn ($q) => $q->orderBy('last_name')->orderBy('first_name')])
+            ->orderBy('name')
+            ->get();
+    }
+
+    public function openNew(): void
+    {
+        $this->reset('hhName', 'hhAddress', 'editingId');
+        $this->resetValidation();
+        $this->showForm = true;
+    }
+
+    public function editHousehold(int $id): void
+    {
+        $household = Household::findOrFail($id);
+
+        $this->editingId = $household->id;
+        $this->hhName = $household->name;
+        $this->hhAddress = $household->address;
+        $this->resetValidation();
+        $this->showForm = true;
+    }
+
+    public function cancelForm(): void
+    {
+        $this->reset('hhName', 'hhAddress', 'editingId', 'showForm');
+        $this->resetValidation();
+    }
+
+    public function save(): void
+    {
+        $this->validate();
+
+        $data = [
+            'name' => trim($this->hhName),
+            'address' => $this->hhAddress ? trim($this->hhAddress) : null,
+        ];
+
+        if ($this->editingId) {
+            Household::findOrFail($this->editingId)->update($data);
+            Flux::toast(variant: 'success', text: 'Household updated.');
+        } else {
+            Household::create($data);
+            Flux::toast(variant: 'success', text: 'Household created.');
+        }
+
+        unset($this->households);
+        $this->cancelForm();
+    }
+
+    public function deleteHousehold(int $id): void
+    {
+        Household::findOrFail($id)->delete();
+
+        unset($this->households);
+        Flux::toast(variant: 'danger', text: 'Household deleted.');
+    }
+
+    public function openPerson(int $id): void
+    {
+        $this->dispatch('open-person-drawer', personId: $id)->to('people.drawer');
+    }
+}; ?>
+
+<section class="w-full">
+    <div class="flex items-end justify-between gap-4 mb-4">
+        <div>
+            <flux:heading size="xl" level="1">Households</flux:heading>
+            <flux:subheading size="lg">Group people into households for directories, pastoral visits, and mailings.</flux:subheading>
+        </div>
+        <flux:button size="sm" variant="primary" icon="plus" wire:click="openNew">New Household</flux:button>
+    </div>
+
+    @if ($showForm)
+        <flux:card class="mb-6">
+            <form wire:submit="save" class="space-y-4">
+                <flux:heading class="!text-xs uppercase tracking-wider text-zinc-500">
+                    {{ $editingId ? 'Edit household' : 'New household' }}
+                </flux:heading>
+                <div class="grid gap-4 sm:grid-cols-[1fr_1.4fr]">
+                    <flux:field>
+                        <flux:label>Household name</flux:label>
+                        <flux:input wire:model="hhName" placeholder="e.g. The Baker Household" autofocus />
+                        <flux:error name="hhName" />
+                    </flux:field>
+                    <flux:field>
+                        <flux:label>Home address <flux:text size="sm" class="text-zinc-400">(optional)</flux:text></flux:label>
+                        <flux:input wire:model="hhAddress" placeholder="128 Elm Street, Lexington" />
+                        <flux:error name="hhAddress" />
+                    </flux:field>
+                </div>
+                <div class="flex justify-end gap-2">
+                    <flux:button variant="ghost" type="button" wire:click="cancelForm">Cancel</flux:button>
+                    <flux:button variant="primary" type="submit">{{ $editingId ? 'Save' : 'Create household' }}</flux:button>
+                </div>
+            </form>
+        </flux:card>
+    @endif
+
+    @if ($this->households->isEmpty())
+        <flux:callout icon="home-modern" class="max-w-lg">
+            <flux:callout.heading>No households yet</flux:callout.heading>
+            <flux:callout.text>Create a household to group members for directories, pastoral visits, and mailings.</flux:callout.text>
+        </flux:callout>
+    @else
+        <div class="grid gap-4 grid-cols-[repeat(auto-fill,minmax(330px,1fr))]">
+            @foreach ($this->households as $household)
+                <flux:card>
+                    <div class="flex items-center gap-3">
+                        <div class="grid size-[42px] place-items-center rounded-[10px] bg-emerald-50 dark:bg-emerald-950 text-emerald-600 dark:text-emerald-300 shrink-0">
+                            <flux:icon icon="home-modern" class="size-5" />
+                        </div>
+                        <div class="flex-1 min-w-0">
+                            <flux:heading class="!text-base truncate">{{ $household->name }}</flux:heading>
+                            <flux:text size="sm" class="text-zinc-500 truncate">
+                                @if ($household->address){{ $household->address }} · @endif{{ $household->people->count() }} {{ Str::plural('member', $household->people->count()) }}
+                            </flux:text>
+                        </div>
+                        <flux:dropdown>
+                            <flux:button variant="ghost" size="sm" icon="ellipsis-horizontal" />
+                            <flux:menu>
+                                <flux:menu.item icon="pencil-square" wire:click="editHousehold({{ $household->id }})">Edit</flux:menu.item>
+                                <flux:menu.item
+                                    icon="trash"
+                                    variant="danger"
+                                    wire:click="deleteHousehold({{ $household->id }})"
+                                    wire:confirm="Delete this household? Members will be unassigned but not deleted."
+                                >Delete</flux:menu.item>
+                            </flux:menu>
+                        </flux:dropdown>
+                    </div>
+
+                    @if ($household->people->isNotEmpty())
+                        <flux:separator class="my-3.5" />
+                        <div class="space-y-0.5">
+                            @foreach ($household->people as $member)
+                                <button
+                                    type="button"
+                                    wire:click="openPerson({{ $member->id }})"
+                                    class="flex w-full items-center gap-3 rounded-lg px-1.5 py-2 text-left hover:bg-zinc-50 dark:hover:bg-zinc-800"
+                                >
+                                    <x-person-avatar :person="$member" size="xs" />
+                                    <span class="flex-1 min-w-0 truncate text-sm font-medium text-zinc-700 dark:text-zinc-200">{{ $member->full_name }}</span>
+                                    @if ($member->household_role)
+                                        <flux:badge size="sm" color="zinc">{{ $member->household_role->label() }}</flux:badge>
+                                    @endif
+                                </button>
+                            @endforeach
+                        </div>
+                    @endif
+                </flux:card>
+            @endforeach
+        </div>
+    @endif
+
+    <livewire:people.drawer :person-id="null" />
+</section>

--- a/routes/web.php
+++ b/routes/web.php
@@ -83,6 +83,8 @@ Route::middleware(['auth'])->group(function (): void {
 
     Route::livewire('/people', 'pages::people.index')->name('people.index');
 
+    Route::livewire('/households', 'pages::households.index')->name('households.index');
+
     Route::name('messages.')
         ->prefix('messages')
         ->group(function (): void {

--- a/tests/Feature/HouseholdTest.php
+++ b/tests/Feature/HouseholdTest.php
@@ -1,0 +1,47 @@
+<?php
+
+use App\Enums\Gender;
+use App\Enums\HouseholdRole;
+use App\Models\Household;
+use App\Models\Person;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+test('a household has many people', function (): void {
+    $household = Household::factory()->create();
+    Person::factory()->count(3)->inHousehold($household)->create();
+    Person::factory()->create(['household_id' => null]);
+
+    expect($household->refresh()->people)->toHaveCount(3);
+});
+
+test('person casts household_role and belongs to a household', function (): void {
+    $household = Household::factory()->create(['name' => 'The Baker Household']);
+    $person = Person::factory()->inHousehold($household, HouseholdRole::CHILD)->create();
+
+    $person->refresh();
+    expect($person->household_role)->toBe(HouseholdRole::CHILD);
+    expect($person->household->name)->toBe('The Baker Household');
+});
+
+test('deleting a household unassigns members without deleting them', function (): void {
+    $household = Household::factory()->create();
+    $members = Person::factory()->count(2)->inHousehold($household, HouseholdRole::SPOUSE)->create();
+
+    $household->delete();
+
+    foreach ($members as $member) {
+        $member->refresh();
+        expect($member->exists)->toBeTrue();
+        expect($member->household_id)->toBeNull();
+        expect($member->household_role)->toBeNull();
+    }
+
+    expect(Person::count())->toBe(2);
+    expect(Household::count())->toBe(0);
+});
+
+test('gender enum exposes prefer not to say', function (): void {
+    expect(Gender::PREFER_NOT_TO_SAY->label())->toBe('Prefer not to say');
+});

--- a/tests/Feature/Households/IndexTest.php
+++ b/tests/Feature/Households/IndexTest.php
@@ -1,0 +1,95 @@
+<?php
+
+use App\Enums\HouseholdRole;
+use App\Models\Household;
+use App\Models\Person;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function (): void {
+    $this->actingAs(User::factory()->create());
+});
+
+test('renders the households index', function (): void {
+    $household = Household::factory()->create(['name' => 'The Baker Household']);
+    Person::factory()->inHousehold($household, HouseholdRole::CHILD)->create(['first_name' => 'Mary', 'last_name' => 'Baker']);
+
+    $this->get('/households')
+        ->assertOk()
+        ->assertSee('The Baker Household')
+        ->assertSee('Mary Baker')
+        ->assertSee('Child');
+});
+
+test('shows empty state when no households exist', function (): void {
+    $this->get('/households')->assertOk()->assertSee('No households yet');
+});
+
+test('creates a household', function (): void {
+    Livewire::test('pages::households.index')
+        ->call('openNew')
+        ->assertSet('showForm', true)
+        ->set('hhName', 'The Alkenbrack Household')
+        ->set('hhAddress', '44 Maple Ave')
+        ->call('save')
+        ->assertHasNoErrors()
+        ->assertSet('showForm', false);
+
+    $household = Household::where('name', 'The Alkenbrack Household')->first();
+    expect($household)->not->toBeNull();
+    expect($household->address)->toBe('44 Maple Ave');
+});
+
+test('requires a name to create a household', function (): void {
+    Livewire::test('pages::households.index')
+        ->call('openNew')
+        ->set('hhName', '')
+        ->call('save')
+        ->assertHasErrors(['hhName' => 'required']);
+
+    expect(Household::count())->toBe(0);
+});
+
+test('edits a household', function (): void {
+    $household = Household::factory()->create(['name' => 'Old Name', 'address' => null]);
+
+    Livewire::test('pages::households.index')
+        ->call('editHousehold', $household->id)
+        ->assertSet('editingId', $household->id)
+        ->assertSet('hhName', 'Old Name')
+        ->set('hhName', 'New Name')
+        ->set('hhAddress', '1 Main St')
+        ->call('save')
+        ->assertHasNoErrors();
+
+    $household->refresh();
+    expect($household->name)->toBe('New Name');
+    expect($household->address)->toBe('1 Main St');
+});
+
+test('deletes a household and unassigns its members', function (): void {
+    $household = Household::factory()->create();
+    $member = Person::factory()->inHousehold($household, HouseholdRole::SPOUSE)->create();
+
+    Livewire::test('pages::households.index')
+        ->call('deleteHousehold', $household->id);
+
+    expect(Household::count())->toBe(0);
+
+    $member->refresh();
+    expect($member->exists)->toBeTrue();
+    expect($member->household_id)->toBeNull();
+    expect($member->household_role)->toBeNull();
+});
+
+test('opening a member dispatches the drawer event', function (): void {
+    $household = Household::factory()->create();
+    $member = Person::factory()->inHousehold($household)->create();
+
+    Livewire::test('pages::households.index')
+        ->call('openPerson', $member->id)
+        ->assertDispatched('open-person-drawer');
+});

--- a/tests/Feature/People/DrawerTest.php
+++ b/tests/Feature/People/DrawerTest.php
@@ -1,9 +1,12 @@
 <?php
 
 use App\Enums\AccessRole;
+use App\Enums\Gender;
+use App\Enums\HouseholdRole;
 use App\Enums\MembershipStatus;
 use App\Enums\Office;
 use App\Enums\TerminationReason;
+use App\Models\Household;
 use App\Models\Person;
 use App\Models\PersonOffice;
 use App\Models\User;
@@ -215,6 +218,126 @@ test('toggles the elder picker', function (): void {
         ->assertSet('showElderPicker', true)
         ->call('toggleElderPicker')
         ->assertSet('showElderPicker', false);
+});
+
+test('saves personal fields', function (): void {
+    $person = Person::factory()->visitor()->create(['birth_date' => null, 'gender' => null, 'baptized' => false]);
+
+    Livewire::test('people.drawer')
+        ->call('openPerson', $person->id)
+        ->set('form.birth_date', '1998-06-18')
+        ->set('form.gender', Gender::FEMALE->value)
+        ->set('form.baptized', true)
+        ->set('form.baptism_date', '2010-04-15')
+        ->call('save')
+        ->assertHasNoErrors();
+
+    $person->refresh();
+    expect($person->birth_date->toDateString())->toBe('1998-06-18');
+    expect($person->gender)->toBe(Gender::FEMALE);
+    expect($person->baptized)->toBeTrue();
+    expect($person->baptism_date->toDateString())->toBe('2010-04-15');
+});
+
+test('clears baptism date when not baptized', function (): void {
+    $person = Person::factory()->create(['baptized' => true, 'baptism_date' => '2010-04-15']);
+
+    Livewire::test('people.drawer')
+        ->call('openPerson', $person->id)
+        ->set('form.baptized', false)
+        ->call('save')
+        ->assertHasNoErrors();
+
+    $person->refresh();
+    expect($person->baptized)->toBeFalse();
+    expect($person->baptism_date)->toBeNull();
+});
+
+test('selecting a household defaults role to other', function (): void {
+    $household = Household::factory()->create();
+    $person = Person::factory()->create(['household_id' => null, 'household_role' => null]);
+
+    Livewire::test('people.drawer')
+        ->call('openPerson', $person->id)
+        ->set('householdSelection', (string) $household->id)
+        ->assertSet('form.household_role', HouseholdRole::OTHER->value)
+        ->call('save')
+        ->assertHasNoErrors();
+
+    $person->refresh();
+    expect($person->household_id)->toBe($household->id);
+    expect($person->household_role)->toBe(HouseholdRole::OTHER);
+});
+
+test('clearing the household nulls the role', function (): void {
+    $household = Household::factory()->create();
+    $person = Person::factory()->inHousehold($household, HouseholdRole::CHILD)->create();
+
+    Livewire::test('people.drawer')
+        ->call('openPerson', $person->id)
+        ->set('householdSelection', '')
+        ->call('save')
+        ->assertHasNoErrors();
+
+    $person->refresh();
+    expect($person->household_id)->toBeNull();
+    expect($person->household_role)->toBeNull();
+});
+
+test('inline household creation assigns the person and defaults role to head', function (): void {
+    $person = Person::factory()->create(['household_id' => null, 'household_role' => null]);
+
+    Livewire::test('people.drawer')
+        ->call('openPerson', $person->id)
+        ->set('householdSelection', '__new__')
+        ->assertSet('creatingHousehold', true)
+        ->set('newHouseholdName', 'The Baker Household')
+        ->call('createHousehold')
+        ->assertSet('creatingHousehold', false)
+        ->call('save')
+        ->assertHasNoErrors();
+
+    $household = Household::where('name', 'The Baker Household')->first();
+    expect($household)->not->toBeNull();
+
+    $person->refresh();
+    expect($person->household_id)->toBe($household->id);
+    expect($person->household_role)->toBe(HouseholdRole::HEAD_OF_HOUSEHOLD);
+});
+
+test('inline household creation is a no-op for a blank name', function (): void {
+    $person = Person::factory()->create();
+
+    Livewire::test('people.drawer')
+        ->call('openPerson', $person->id)
+        ->set('householdSelection', '__new__')
+        ->set('newHouseholdName', '   ')
+        ->call('createHousehold')
+        ->assertSet('creatingHousehold', true);
+
+    expect(Household::count())->toBe(0);
+});
+
+test('canceling inline household creation restores the original household', function (): void {
+    $household = Household::factory()->create();
+    $person = Person::factory()->inHousehold($household, HouseholdRole::CHILD)->create();
+
+    Livewire::test('people.drawer')
+        ->call('openPerson', $person->id)
+        ->set('householdSelection', '__new__')
+        ->assertSet('creatingHousehold', true)
+        ->assertSet('form.household_id', null)
+        ->call('cancelCreateHousehold')
+        ->assertSet('creatingHousehold', false)
+        ->assertSet('form.household_id', $household->id)
+        ->assertSet('form.household_role', HouseholdRole::CHILD->value)
+        ->assertSet('householdSelection', (string) $household->id)
+        ->call('save')
+        ->assertHasNoErrors();
+
+    $person->refresh();
+    expect($person->household_id)->toBe($household->id);
+    expect($person->household_role)->toBe(HouseholdRole::CHILD);
 });
 
 test('deletes a person', function (): void {


### PR DESCRIPTION
## Summary

- Adds a Households feature with full CRUD (index page with card grid, inline create/edit/delete)
- Links people to households with role assignments (head, spouse, child, dependent, other)
- Adds birth date and baptism tracking (date + toggle) to the person drawer
- Extends the Gender enum with a "Prefer not to say" option
- Person drawer gets new Personal and Household sections in both edit and view modes, with inline household creation directly from the drawer

## Test plan

- [x] All 33 tests pass across HouseholdTest, Households/IndexTest, and People/DrawerTest
- [x] Household CRUD (create, edit, delete with member unassignment)
- [x] Person drawer saves personal fields (birthdate, gender, baptism)
- [x] Household selection defaults role, clearing nulls role, cancel restores original
- [x] Inline household creation from drawer assigns person as head

🤖 Generated with [Claude Code](https://claude.com/claude-code)