### PR TITLE
Add pastoral care, prayer requests, and prayer schedule

### DIFF
--- a/app/Console/Commands/SendPrayerScheduleDigestCommand.php
+++ b/app/Console/Commands/SendPrayerScheduleDigestCommand.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Enums\Office;
+use App\Mail\PrayerScheduleDigestMail;
+use App\Models\Person;
+use App\Models\PrayerScheduleSettings;
+use App\Models\User;
+use App\Services\PrayerScheduleService;
+use Illuminate\Console\Attributes\Description;
+use Illuminate\Console\Attributes\Signature;
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\Mail;
+
+#[Signature('stave:send-prayer-schedule {--week= : Zero-based week index to send (defaults to the current week)}')]
+#[Description('Email the elders the prayer rota for the week, including only open bulletin-visibility requests.')]
+class SendPrayerScheduleDigestCommand extends Command
+{
+    public function handle(PrayerScheduleService $service): int
+    {
+        $settings = PrayerScheduleSettings::current();
+
+        $week = $this->option('week') !== null
+            ? (int) $this->option('week')
+            : $service->currentWeekIndex($settings);
+
+        $people = $service->bulletinDigestForWeek($settings, $week);
+
+        if ($people === []) {
+            $this->info('No one is scheduled for this week — nothing to send.');
+
+            return self::SUCCESS;
+        }
+
+        /** @var Collection<int, User> $elders */
+        $elders = User::query()
+            ->whereHas('person.offices', fn ($query) => $query->where('kind', Office::ELDER))
+            ->get();
+
+        $eldersWithoutAccounts = Person::query()
+            ->whereHas('offices', fn ($query) => $query->where('kind', Office::ELDER))
+            ->whereDoesntHave('user')
+            ->count();
+
+        foreach ($elders as $elder) {
+            Mail::to($elder)->send(new PrayerScheduleDigestMail(
+                recipient: $elder,
+                people: $people,
+                weekNumber: $week + 1,
+                totalWeeks: $settings->cycle_weeks,
+                weekRange: $service->weekRange($settings, $week),
+            ));
+        }
+
+        $weekNumber = $week + 1;
+        $this->info("Sent the Week {$weekNumber} prayer rota to {$elders->count()} elders.");
+
+        if ($eldersWithoutAccounts > 0) {
+            $this->warn("{$eldersWithoutAccounts} elder(s) have no user account and were not emailed.");
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Enums/PrayerRequestVisibility.php
+++ b/app/Enums/PrayerRequestVisibility.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Enums;
+
+enum PrayerRequestVisibility: string
+{
+    case BULLETIN = 'bulletin';
+    case PRIVATE = 'private';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::BULLETIN => 'Bulletin',
+            self::PRIVATE => 'Private',
+        };
+    }
+
+    public function color(): string
+    {
+        return match ($this) {
+            self::BULLETIN => 'emerald',
+            self::PRIVATE => 'amber',
+        };
+    }
+
+    public function icon(): string
+    {
+        return match ($this) {
+            self::BULLETIN => 'megaphone',
+            self::PRIVATE => 'lock-closed',
+        };
+    }
+
+    public function description(): string
+    {
+        return match ($this) {
+            self::BULLETIN => 'Shared in the Sunday bulletin and the Monday elders\' email.',
+            self::PRIVATE => 'Confidential — never included in any email.',
+        };
+    }
+}

--- a/app/Enums/PrayerScheduleGrouping.php
+++ b/app/Enums/PrayerScheduleGrouping.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Enums;
+
+enum PrayerScheduleGrouping: string
+{
+    case ALPHA = 'alpha';
+    case HOUSEHOLD = 'household';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::ALPHA => 'Alphabetical',
+            self::HOUSEHOLD => 'By household',
+        };
+    }
+
+    public function icon(): string
+    {
+        return match ($this) {
+            self::ALPHA => 'bars-arrow-down',
+            self::HOUSEHOLD => 'home-modern',
+        };
+    }
+}

--- a/app/Mail/PrayerScheduleDigestMail.php
+++ b/app/Mail/PrayerScheduleDigestMail.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mail;
+
+use App\Models\User;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class PrayerScheduleDigestMail extends Mailable implements ShouldQueue
+{
+    use Queueable, SerializesModels;
+
+    /**
+     * @param  array<int, array{name: string, household: ?string, status: string, requests: array<int, string>}>  $people
+     */
+    public function __construct(
+        public User $recipient,
+        public array $people,
+        public int $weekNumber,
+        public int $totalWeeks,
+        public string $weekRange,
+    ) {}
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: "Prayer rota — Week {$this->weekNumber} of {$this->totalWeeks} ({$this->weekRange})",
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            markdown: 'mail.prayer-schedule-digest',
+        );
+    }
+}

--- a/app/Models/PastoralNote.php
+++ b/app/Models/PastoralNote.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\PastoralNoteFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+#[Fillable([
+    'person_id',
+    'author_id',
+    'body',
+])]
+class PastoralNote extends Model
+{
+    /** @use HasFactory<PastoralNoteFactory> */
+    use HasFactory;
+
+    /** @return BelongsTo<Person, $this> */
+    public function person(): BelongsTo
+    {
+        return $this->belongsTo(Person::class);
+    }
+
+    /** @return BelongsTo<User, $this> */
+    public function author(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'author_id');
+    }
+}

--- a/app/Models/Person.php
+++ b/app/Models/Person.php
@@ -116,6 +116,12 @@ class Person extends Model
         return $this->hasMany(Person::class, 'pastoral_care_elder_id');
     }
 
+    /** @return HasMany<PrayerRequest, $this> */
+    public function prayerRequests(): HasMany
+    {
+        return $this->hasMany(PrayerRequest::class);
+    }
+
     /** @return Attribute<string, never> */
     protected function fullName(): Attribute
     {

--- a/app/Models/Person.php
+++ b/app/Models/Person.php
@@ -122,6 +122,12 @@ class Person extends Model
         return $this->hasMany(PrayerRequest::class);
     }
 
+    /** @return HasMany<PastoralNote, $this> */
+    public function pastoralNotes(): HasMany
+    {
+        return $this->hasMany(PastoralNote::class);
+    }
+
     /** @return Attribute<string, never> */
     protected function fullName(): Attribute
     {

--- a/app/Models/PrayerRequest.php
+++ b/app/Models/PrayerRequest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\PrayerRequestVisibility;
+use Database\Factories\PrayerRequestFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property PrayerRequestVisibility $visibility
+ * @property ?Carbon $completed_at
+ */
+#[Fillable([
+    'person_id',
+    'body',
+    'visibility',
+    'created_by_user_id',
+    'completed_at',
+])]
+class PrayerRequest extends Model
+{
+    /** @use HasFactory<PrayerRequestFactory> */
+    use HasFactory;
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'visibility' => PrayerRequestVisibility::class,
+            'completed_at' => 'datetime',
+        ];
+    }
+
+    /** @return BelongsTo<Person, $this> */
+    public function person(): BelongsTo
+    {
+        return $this->belongsTo(Person::class);
+    }
+
+    /** @return BelongsTo<User, $this> */
+    public function createdBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by_user_id');
+    }
+
+    public function isOpen(): bool
+    {
+        return $this->completed_at === null;
+    }
+
+    /**
+     * @param  Builder<PrayerRequest>  $query
+     */
+    public function scopeOpen(Builder $query): void
+    {
+        $query->whereNull('completed_at');
+    }
+
+    /**
+     * @param  Builder<PrayerRequest>  $query
+     */
+    public function scopeCompleted(Builder $query): void
+    {
+        $query->whereNotNull('completed_at');
+    }
+
+    /**
+     * @param  Builder<PrayerRequest>  $query
+     */
+    public function scopeBulletin(Builder $query): void
+    {
+        $query->where('visibility', PrayerRequestVisibility::BULLETIN);
+    }
+}

--- a/app/Models/PrayerScheduleSettings.php
+++ b/app/Models/PrayerScheduleSettings.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\MembershipStatus;
+use App\Enums\PrayerScheduleGrouping;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int $cycle_weeks
+ * @property PrayerScheduleGrouping $group_by
+ * @property array<int, string> $include_statuses
+ * @property Carbon $anchor_date
+ */
+#[Fillable([
+    'cycle_weeks',
+    'group_by',
+    'include_statuses',
+    'anchor_date',
+])]
+class PrayerScheduleSettings extends Model
+{
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'cycle_weeks' => 'integer',
+            'group_by' => PrayerScheduleGrouping::class,
+            'include_statuses' => 'array',
+            'anchor_date' => 'date',
+        ];
+    }
+
+    /**
+     * The single application-wide settings row, created with defaults if missing.
+     */
+    public static function current(): self
+    {
+        return static::query()->firstOrCreate([], [
+            'cycle_weeks' => 8,
+            'group_by' => PrayerScheduleGrouping::ALPHA,
+            'include_statuses' => [
+                MembershipStatus::MEMBER->value,
+                MembershipStatus::CATECHUMEN->value,
+            ],
+            'anchor_date' => Carbon::now()->startOfWeek(Carbon::MONDAY)->toDateString(),
+        ]);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -81,6 +81,17 @@ class User extends Authenticatable implements CanComment
             ->exists();
     }
 
+    /**
+     * Whether the user may view pastoral-care surfaces (the Pastoral Care page,
+     * pastoral notes, and the prayer schedule).
+     */
+    public function canAccessPastoralCare(): bool
+    {
+        return $this->hasAccessRole(AccessRole::PASTORAL_CARE_USER)
+            || $this->hasAccessRole(AccessRole::PASTORAL_CARE_ADMIN)
+            || $this->hasAccessRole(AccessRole::ADMIN);
+    }
+
     public function grantAccessRole(AccessRole $role): void
     {
         DB::table('user_access_roles')->insertOrIgnore([

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,7 +2,6 @@
 
 namespace App\Models;
 
-// use Illuminate\Contracts\Auth\MustVerifyEmail;
 use App\Enums\AccessRole;
 use App\Enums\DigestFrequency;
 use App\Enums\GroupMembershipStatus;
@@ -87,9 +86,14 @@ class User extends Authenticatable implements CanComment
      */
     public function canAccessPastoralCare(): bool
     {
-        return $this->hasAccessRole(AccessRole::PASTORAL_CARE_USER)
-            || $this->hasAccessRole(AccessRole::PASTORAL_CARE_ADMIN)
-            || $this->hasAccessRole(AccessRole::ADMIN);
+        return DB::table('user_access_roles')
+            ->where('user_id', $this->id)
+            ->whereIn('role', [
+                AccessRole::PASTORAL_CARE_USER->value,
+                AccessRole::PASTORAL_CARE_ADMIN->value,
+                AccessRole::ADMIN->value,
+            ])
+            ->exists();
     }
 
     public function grantAccessRole(AccessRole $role): void

--- a/app/Policies/PastoralNotePolicy.php
+++ b/app/Policies/PastoralNotePolicy.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Policies;
+
+use App\Enums\AccessRole;
+use App\Models\PastoralNote;
+use App\Models\User;
+
+class PastoralNotePolicy
+{
+    public function viewAny(User $user): bool
+    {
+        return $user->canAccessPastoralCare();
+    }
+
+    public function view(User $user, PastoralNote $pastoralNote): bool
+    {
+        return $user->canAccessPastoralCare();
+    }
+
+    public function create(User $user): bool
+    {
+        return $user->canAccessPastoralCare();
+    }
+
+    public function update(User $user, PastoralNote $pastoralNote): bool
+    {
+        return $this->isAuthorOrAdmin($user, $pastoralNote);
+    }
+
+    public function delete(User $user, PastoralNote $pastoralNote): bool
+    {
+        return $this->isAuthorOrAdmin($user, $pastoralNote);
+    }
+
+    private function isAuthorOrAdmin(User $user, PastoralNote $pastoralNote): bool
+    {
+        return $pastoralNote->author_id === $user->id
+            || $user->hasAccessRole(AccessRole::PASTORAL_CARE_ADMIN)
+            || $user->hasAccessRole(AccessRole::ADMIN);
+    }
+}

--- a/app/Services/PrayerScheduleService.php
+++ b/app/Services/PrayerScheduleService.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace App\Services;
+
+use App\Enums\MembershipStatus;
+use App\Enums\PrayerScheduleGrouping;
+use App\Models\Person;
+use App\Models\PrayerScheduleSettings;
+use Carbon\CarbonInterface;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
+
+class PrayerScheduleService
+{
+    /**
+     * The prayer rotation, as an ordered collection of `cycle_weeks` weeks.
+     * Each week is a collection of People. Households are never split across
+     * weeks — every member of a household shares a week.
+     *
+     * @param  array<int, string|MembershipStatus>|null  $statusOverride
+     * @return Collection<int, Collection<int, Person>>
+     */
+    public function buckets(PrayerScheduleSettings $settings, ?array $statusOverride = null): Collection
+    {
+        $weeks = max(1, $settings->cycle_weeks);
+        $units = $this->units($this->resolveStatuses($settings, $statusOverride));
+
+        $grouping = $settings->group_by;
+
+        /** @var array<int, array<int, Person>> $bucketArrays */
+        $bucketArrays = $grouping === PrayerScheduleGrouping::HOUSEHOLD
+            ? $this->packBalanced($units, $weeks)
+            : $this->chunkSequential($units, $weeks);
+
+        return collect($bucketArrays)->map(
+            fn (array $people): Collection => collect($people),
+        );
+    }
+
+    /**
+     * The people scheduled for a single week.
+     *
+     * @param  array<int, string|MembershipStatus>|null  $statusOverride
+     * @return Collection<int, Person>
+     */
+    public function peopleForWeek(PrayerScheduleSettings $settings, int $weekIndex, ?array $statusOverride = null): Collection
+    {
+        return $this->buckets($settings, $statusOverride)->get($weekIndex) ?? collect();
+    }
+
+    /**
+     * The zero-based index of the current week within the cycle, derived from
+     * the anchor date so it is reproducible without any stored "current week".
+     */
+    public function currentWeekIndex(PrayerScheduleSettings $settings, ?CarbonInterface $now = null): int
+    {
+        $weeks = max(1, $settings->cycle_weeks);
+
+        $anchorMonday = $settings->anchor_date->copy()->startOfWeek(Carbon::MONDAY);
+        $nowMonday = Carbon::instance($now ?? Carbon::now())->startOfWeek(Carbon::MONDAY);
+
+        $weeksSince = (int) floor($anchorMonday->diffInDays($nowMonday, false) / 7);
+        $index = $weeksSince % $weeks;
+
+        return $index < 0 ? $index + $weeks : $index;
+    }
+
+    /**
+     * Summary figures for the schedule header.
+     *
+     * @param  array<int, string|MembershipStatus>|null  $statusOverride
+     * @return array{total: int, weeks: int, perWeek: int, currentWeekIndex: int}
+     */
+    public function stats(PrayerScheduleSettings $settings, ?array $statusOverride = null, ?CarbonInterface $now = null): array
+    {
+        $weeks = max(1, $settings->cycle_weeks);
+        $total = $this->eligiblePeople($this->resolveStatuses($settings, $statusOverride))->count();
+
+        return [
+            'total' => $total,
+            'weeks' => $weeks,
+            'perWeek' => (int) round($total / $weeks),
+            'currentWeekIndex' => $this->currentWeekIndex($settings, $now),
+        ];
+    }
+
+    /**
+     * Eligible people, sorted by a stable key (surname, first name, id) so the
+     * rotation is deterministic across requests.
+     *
+     * @param  array<int, string>  $statuses
+     * @return Collection<int, Person>
+     */
+    public function eligiblePeople(array $statuses): Collection
+    {
+        if ($statuses === []) {
+            return collect();
+        }
+
+        return Person::query()
+            ->whereIn('membership_status', $statuses)
+            ->with('household')
+            ->get()
+            ->sortBy([
+                ['last_name', 'asc'],
+                ['first_name', 'asc'],
+                ['id', 'asc'],
+            ])
+            ->values();
+    }
+
+    /**
+     * Eligible people grouped into household units (a person with no household
+     * is a singleton unit), preserving surname order of each unit's first member.
+     *
+     * @param  array<int, string>  $statuses
+     * @return Collection<int, Collection<int, Person>>
+     */
+    public function units(array $statuses): Collection
+    {
+        return $this->eligiblePeople($statuses)
+            ->groupBy(fn (Person $person): string => $person->household_id !== null
+                ? 'h'.$person->household_id
+                : 'p'.$person->id)
+            ->values();
+    }
+
+    /**
+     * Alphabetical distribution: fill week 1, then week 2, … keeping each
+     * household together so each week holds a contiguous run of households.
+     *
+     * @param  Collection<int, Collection<int, Person>>  $units
+     * @return array<int, array<int, Person>>
+     */
+    private function chunkSequential(Collection $units, int $weeks): array
+    {
+        $buckets = array_fill(0, $weeks, []);
+        $total = $units->sum(fn (Collection $unit): int => $unit->count());
+        $target = (int) ceil($total / $weeks);
+
+        $week = 0;
+        foreach ($units as $unit) {
+            $members = $unit->all();
+
+            if ($buckets[$week] !== []
+                && (count($buckets[$week]) + count($members)) > $target
+                && $week < $weeks - 1) {
+                $week++;
+            }
+
+            $buckets[$week] = array_merge($buckets[$week], $members);
+        }
+
+        return $buckets;
+    }
+
+    /**
+     * By-household distribution: greedily assign each household to the week with
+     * the smallest current headcount, evening out per-week counts.
+     *
+     * @param  Collection<int, Collection<int, Person>>  $units
+     * @return array<int, array<int, Person>>
+     */
+    private function packBalanced(Collection $units, int $weeks): array
+    {
+        $buckets = array_fill(0, $weeks, []);
+
+        foreach ($units as $unit) {
+            $smallest = 0;
+            for ($i = 1; $i < $weeks; $i++) {
+                if (count($buckets[$i]) < count($buckets[$smallest])) {
+                    $smallest = $i;
+                }
+            }
+
+            $buckets[$smallest] = array_merge($buckets[$smallest], $unit->all());
+        }
+
+        return $buckets;
+    }
+
+    /**
+     * Normalise the status set to string values, never including Terminated.
+     *
+     * @param  array<int, string|MembershipStatus>|null  $statusOverride
+     * @return array<int, string>
+     */
+    private function resolveStatuses(PrayerScheduleSettings $settings, ?array $statusOverride): array
+    {
+        $statuses = $statusOverride ?? $settings->include_statuses;
+
+        return collect($statuses)
+            ->map(fn (string|MembershipStatus $status): string => $status instanceof MembershipStatus
+                ? $status->value
+                : $status)
+            ->reject(fn (string $status): bool => $status === MembershipStatus::TERMINATED->value)
+            ->unique()
+            ->values()
+            ->all();
+    }
+}

--- a/app/Services/PrayerScheduleService.php
+++ b/app/Services/PrayerScheduleService.php
@@ -100,9 +100,8 @@ class PrayerScheduleService
         $nowMonday = ($now ? Carbon::instance($now) : Carbon::now())->startOfWeek(Carbon::MONDAY);
 
         $weeksSince = (int) floor($anchorMonday->diffInDays($nowMonday, false) / 7);
-        $index = $weeksSince % $weeks;
 
-        return $index < 0 ? $index + $weeks : $index;
+        return (($weeksSince % $weeks) + $weeks) % $weeks;
     }
 
     /**
@@ -114,11 +113,11 @@ class PrayerScheduleService
         $current = $this->currentWeekIndex($settings, $now);
         $reference = $now ? Carbon::instance($now) : Carbon::now();
         $monday = $reference->copy()->startOfWeek(Carbon::MONDAY)->addWeeks($weekIndex - $current);
-        $end = $monday->copy()->addDays(6);
+        $sunday = $monday->copy()->addDays(6);
 
-        return $monday->format('M j').' – '.($monday->month === $end->month
-            ? $end->format('j')
-            : $end->format('M j'));
+        $endFormat = $monday->month === $sunday->month ? 'j' : 'M j';
+
+        return $monday->format('M j').' – '.$sunday->format($endFormat);
     }
 
     /**
@@ -246,9 +245,7 @@ class PrayerScheduleService
         $statuses = $statusOverride ?? $settings->include_statuses;
 
         return collect($statuses)
-            ->map(fn (string|MembershipStatus $status): string => $status instanceof MembershipStatus
-                ? $status->value
-                : $status)
+            ->map(fn (string|MembershipStatus $status): string => $status instanceof MembershipStatus ? $status->value : $status)
             ->reject(fn (string $status): bool => $status === MembershipStatus::TERMINATED->value)
             ->unique()
             ->values()

--- a/app/Services/PrayerScheduleService.php
+++ b/app/Services/PrayerScheduleService.php
@@ -5,6 +5,7 @@ namespace App\Services;
 use App\Enums\MembershipStatus;
 use App\Enums\PrayerScheduleGrouping;
 use App\Models\Person;
+use App\Models\PrayerRequest;
 use App\Models\PrayerScheduleSettings;
 use Carbon\CarbonInterface;
 use Illuminate\Support\Carbon;
@@ -46,6 +47,45 @@ class PrayerScheduleService
     public function peopleForWeek(PrayerScheduleSettings $settings, int $weekIndex, ?array $statusOverride = null): Collection
     {
         return $this->buckets($settings, $statusOverride)->get($weekIndex) ?? collect();
+    }
+
+    /**
+     * The prayer-email payload for a week: each scheduled person with ONLY their
+     * open, bulletin-visibility requests. Private requests and pastoral notes are
+     * never included — this is the confidentiality boundary for the Monday email.
+     *
+     * @param  array<int, string|MembershipStatus>|null  $statusOverride
+     * @return array<int, array{name: string, household: ?string, status: string, requests: array<int, string>}>
+     */
+    public function bulletinDigestForWeek(PrayerScheduleSettings $settings, int $weekIndex, ?array $statusOverride = null): array
+    {
+        $ids = $this->peopleForWeek($settings, $weekIndex, $statusOverride)->pluck('id');
+
+        if ($ids->isEmpty()) {
+            return [];
+        }
+
+        $requestsByPerson = PrayerRequest::query()
+            ->open()
+            ->bulletin()
+            ->whereIn('person_id', $ids)
+            ->orderBy('created_at')
+            ->get()
+            ->groupBy('person_id');
+
+        return Person::query()
+            ->whereIn('id', $ids)
+            ->with('household')
+            ->orderBy('last_name')
+            ->orderBy('first_name')
+            ->get()
+            ->map(fn (Person $person): array => [
+                'name' => $person->full_name,
+                'household' => $person->household?->name,
+                'status' => $person->membership_status->label(),
+                'requests' => ($requestsByPerson->get($person->id) ?? collect())->pluck('body')->all(),
+            ])
+            ->all();
     }
 
     /**

--- a/app/Services/PrayerScheduleService.php
+++ b/app/Services/PrayerScheduleService.php
@@ -57,12 +57,28 @@ class PrayerScheduleService
         $weeks = max(1, $settings->cycle_weeks);
 
         $anchorMonday = $settings->anchor_date->copy()->startOfWeek(Carbon::MONDAY);
-        $nowMonday = Carbon::instance($now ?? Carbon::now())->startOfWeek(Carbon::MONDAY);
+        $nowMonday = ($now ? Carbon::instance($now) : Carbon::now())->startOfWeek(Carbon::MONDAY);
 
         $weeksSince = (int) floor($anchorMonday->diffInDays($nowMonday, false) / 7);
         $index = $weeksSince % $weeks;
 
         return $index < 0 ? $index + $weeks : $index;
+    }
+
+    /**
+     * A human label for a week's calendar range relative to the current week,
+     * e.g. "Jun 15 – 21".
+     */
+    public function weekRange(PrayerScheduleSettings $settings, int $weekIndex, ?CarbonInterface $now = null): string
+    {
+        $current = $this->currentWeekIndex($settings, $now);
+        $reference = $now ? Carbon::instance($now) : Carbon::now();
+        $monday = $reference->copy()->startOfWeek(Carbon::MONDAY)->addWeeks($weekIndex - $current);
+        $end = $monday->copy()->addDays(6);
+
+        return $monday->format('M j').' – '.($monday->month === $end->month
+            ? $end->format('j')
+            : $end->format('M j'));
     }
 
     /**

--- a/database/factories/PastoralNoteFactory.php
+++ b/database/factories/PastoralNoteFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\PastoralNote;
+use App\Models\Person;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<PastoralNote>
+ */
+class PastoralNoteFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'person_id' => Person::factory(),
+            'author_id' => User::factory(),
+            'body' => fake()->paragraph(),
+        ];
+    }
+}

--- a/database/factories/PrayerRequestFactory.php
+++ b/database/factories/PrayerRequestFactory.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\PrayerRequestVisibility;
+use App\Models\Person;
+use App\Models\PrayerRequest;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<PrayerRequest>
+ */
+class PrayerRequestFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'person_id' => Person::factory(),
+            'body' => fake()->sentence(),
+            'visibility' => fake()->randomElement(PrayerRequestVisibility::cases()),
+            'created_by_user_id' => User::factory(),
+            'completed_at' => null,
+        ];
+    }
+
+    public function bulletin(): self
+    {
+        return $this->state(['visibility' => PrayerRequestVisibility::BULLETIN]);
+    }
+
+    public function private(): self
+    {
+        return $this->state(['visibility' => PrayerRequestVisibility::PRIVATE]);
+    }
+
+    public function open(): self
+    {
+        return $this->state(['completed_at' => null]);
+    }
+
+    public function completed(?string $when = null): self
+    {
+        return $this->state([
+            'completed_at' => $when ? new \DateTimeImmutable($when) : fake()->dateTimeBetween('-30 days', 'now'),
+        ]);
+    }
+}

--- a/database/factories/PrayerRequestFactory.php
+++ b/database/factories/PrayerRequestFactory.php
@@ -7,6 +7,7 @@ use App\Models\Person;
 use App\Models\PrayerRequest;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Carbon;
 
 /**
  * @extends Factory<PrayerRequest>
@@ -45,7 +46,7 @@ class PrayerRequestFactory extends Factory
     public function completed(?string $when = null): self
     {
         return $this->state([
-            'completed_at' => $when ? new \DateTimeImmutable($when) : fake()->dateTimeBetween('-30 days', 'now'),
+            'completed_at' => $when ? Carbon::parse($when) : fake()->dateTimeBetween('-30 days', 'now'),
         ]);
     }
 }

--- a/database/migrations/2026_06_19_003844_create_prayer_requests_table.php
+++ b/database/migrations/2026_06_19_003844_create_prayer_requests_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('prayer_requests', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('person_id')->constrained('people')->cascadeOnDelete();
+            $table->text('body');
+            $table->string('visibility')->default('bulletin');
+            $table->foreignId('created_by_user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamp('completed_at')->nullable();
+            $table->timestamps();
+
+            $table->index(['person_id', 'completed_at']);
+            $table->index(['visibility', 'completed_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('prayer_requests');
+    }
+};

--- a/database/migrations/2026_06_19_004051_create_pastoral_notes_table.php
+++ b/database/migrations/2026_06_19_004051_create_pastoral_notes_table.php
@@ -11,11 +11,9 @@ return new class() extends Migration
         Schema::create('pastoral_notes', function (Blueprint $table): void {
             $table->id();
             $table->foreignId('person_id')->constrained('people')->cascadeOnDelete();
-            $table->foreignId('author_id')->constrained('users')->cascadeOnDelete();
+            $table->foreignId('author_id')->nullable()->constrained('users')->nullOnDelete();
             $table->text('body');
             $table->timestamps();
-
-            $table->index('person_id');
         });
     }
 

--- a/database/migrations/2026_06_19_004051_create_pastoral_notes_table.php
+++ b/database/migrations/2026_06_19_004051_create_pastoral_notes_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('pastoral_notes', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('person_id')->constrained('people')->cascadeOnDelete();
+            $table->foreignId('author_id')->constrained('users')->cascadeOnDelete();
+            $table->text('body');
+            $table->timestamps();
+
+            $table->index('person_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('pastoral_notes');
+    }
+};

--- a/database/migrations/2026_06_19_004312_create_prayer_schedule_settings_table.php
+++ b/database/migrations/2026_06_19_004312_create_prayer_schedule_settings_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('prayer_schedule_settings', function (Blueprint $table): void {
+            $table->id();
+            $table->unsignedTinyInteger('cycle_weeks')->default(8);
+            $table->string('group_by')->default('alpha');
+            $table->json('include_statuses');
+            $table->date('anchor_date');
+            $table->timestamps();
+        });
+
+        // Seed the single settings row so the rotation always has defaults to read.
+        DB::table('prayer_schedule_settings')->insert([
+            'cycle_weeks' => 8,
+            'group_by' => 'alpha',
+            'include_statuses' => json_encode(['member', 'catechumen']),
+            'anchor_date' => Carbon::now()->startOfWeek(Carbon::MONDAY)->toDateString(),
+            'created_at' => Carbon::now(),
+            'updated_at' => Carbon::now(),
+        ]);
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('prayer_schedule_settings');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -23,5 +23,6 @@ class DatabaseSeeder extends Seeder
         $this->call(ServicesTableSeeder::class);
         $this->call(LiturgyElementsTableSeeder::class);
         $this->call(GroupSeeder::class);
+        $this->call(PrayerRequestSeeder::class);
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,8 +2,6 @@
 
 namespace Database\Seeders;
 
-use App\Models\User;
-// use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
 class DatabaseSeeder extends Seeder
@@ -13,16 +11,16 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // User::factory(10)->create();
-
-        $this->call(PeopleTableSeeder::class);
-        $this->call(UsersTableSeeder::class);
-        $this->call(SongsTableSeeder::class);
-        $this->call(ReadingsTableSeeder::class);
-        $this->call(TemplatesTableSeeder::class);
-        $this->call(ServicesTableSeeder::class);
-        $this->call(LiturgyElementsTableSeeder::class);
-        $this->call(GroupSeeder::class);
-        $this->call(PrayerRequestSeeder::class);
+        $this->call([
+            PeopleTableSeeder::class,
+            UsersTableSeeder::class,
+            SongsTableSeeder::class,
+            ReadingsTableSeeder::class,
+            TemplatesTableSeeder::class,
+            ServicesTableSeeder::class,
+            LiturgyElementsTableSeeder::class,
+            GroupSeeder::class,
+            PrayerRequestSeeder::class,
+        ]);
     }
 }

--- a/database/seeders/PrayerRequestSeeder.php
+++ b/database/seeders/PrayerRequestSeeder.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Enums\MembershipStatus;
+use App\Enums\PrayerRequestVisibility;
+use App\Models\Person;
+use App\Models\PrayerRequest;
+use App\Models\User;
+use Illuminate\Database\Seeder;
+
+class PrayerRequestSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $author = User::query()->first();
+
+        // Bias toward members and catechumens — the people most likely to be in the rota.
+        $people = Person::query()
+            ->whereIn('membership_status', [
+                MembershipStatus::MEMBER,
+                MembershipStatus::CATECHUMEN,
+            ])
+            ->inRandomOrder()
+            ->limit(20)
+            ->get();
+
+        foreach ($people as $person) {
+            $count = fake()->numberBetween(0, 3);
+
+            for ($i = 0; $i < $count; $i++) {
+                $completed = fake()->boolean(30);
+
+                PrayerRequest::factory()
+                    ->for($person)
+                    ->state([
+                        'created_by_user_id' => $author?->id,
+                        'visibility' => fake()->boolean(80)
+                            ? PrayerRequestVisibility::BULLETIN
+                            : PrayerRequestVisibility::PRIVATE,
+                        'completed_at' => $completed ? fake()->dateTimeBetween('-21 days', 'now') : null,
+                    ])
+                    ->create();
+            }
+        }
+    }
+}

--- a/database/seeders/PrayerRequestSeeder.php
+++ b/database/seeders/PrayerRequestSeeder.php
@@ -28,20 +28,21 @@ class PrayerRequestSeeder extends Seeder
         foreach ($people as $person) {
             $count = fake()->numberBetween(0, 3);
 
-            for ($i = 0; $i < $count; $i++) {
-                $completed = fake()->boolean(30);
-
-                PrayerRequest::factory()
-                    ->for($person)
-                    ->state([
-                        'created_by_user_id' => $author?->id,
-                        'visibility' => fake()->boolean(80)
-                            ? PrayerRequestVisibility::BULLETIN
-                            : PrayerRequestVisibility::PRIVATE,
-                        'completed_at' => $completed ? fake()->dateTimeBetween('-21 days', 'now') : null,
-                    ])
-                    ->create();
+            if ($count === 0) {
+                continue;
             }
+
+            PrayerRequest::factory()
+                ->count($count)
+                ->for($person)
+                ->state(fn () => [
+                    'created_by_user_id' => $author?->id,
+                    'visibility' => fake()->boolean(80)
+                        ? PrayerRequestVisibility::BULLETIN
+                        : PrayerRequestVisibility::PRIVATE,
+                    'completed_at' => fake()->boolean(30) ? fake()->dateTimeBetween('-21 days', 'now') : null,
+                ])
+                ->create();
         }
     }
 }

--- a/resources/views/components/layouts/app/sidebar.blade.php
+++ b/resources/views/components/layouts/app/sidebar.blade.php
@@ -29,7 +29,9 @@
                     <flux:sidebar.item icon="user-group" :href="route('groups.index')" :current="request()->routeIs('groups.*')" wire:navigate>{{ __('Groups') }}</flux:sidebar.item>
                     <flux:sidebar.item icon="home-modern" :href="route('households.index')" :current="request()->routeIs('households.*')" wire:navigate>{{ __('Households') }}</flux:sidebar.item>
                     <livewire:sidebar.messages />
-                    <flux:sidebar.item icon="calendar-date-range" wire:navigate>{{ __('Prayer Schedule') }}</flux:sidebar.item>
+                    @if (auth()->user()?->canAccessPastoralCare())
+                        <flux:sidebar.item icon="calendar-date-range" :href="route('prayer-schedule.index')" :current="request()->routeIs('prayer-schedule.*')" wire:navigate>{{ __('Prayer Schedule') }}</flux:sidebar.item>
+                    @endif
                 </flux:sidebar.group>
             </flux:sidebar.nav>
 

--- a/resources/views/components/layouts/app/sidebar.blade.php
+++ b/resources/views/components/layouts/app/sidebar.blade.php
@@ -23,6 +23,9 @@
 
                 <flux:sidebar.group expandable icon="church" :heading="__('Congregation')">
                     <flux:sidebar.item icon="users" :href="route('people.index')" :current="request()->routeIs('people.*')" wire:navigate>{{ __('People') }}</flux:sidebar.item>
+                    @if (auth()->user()?->canAccessPastoralCare())
+                        <flux:sidebar.item icon="heart" :href="route('pastoral-care.index')" :current="request()->routeIs('pastoral-care.*')" wire:navigate>{{ __('Pastoral Care') }}</flux:sidebar.item>
+                    @endif
                     <flux:sidebar.item icon="user-group" :href="route('groups.index')" :current="request()->routeIs('groups.*')" wire:navigate>{{ __('Groups') }}</flux:sidebar.item>
                     <flux:sidebar.item icon="home-modern" :href="route('households.index')" :current="request()->routeIs('households.*')" wire:navigate>{{ __('Households') }}</flux:sidebar.item>
                     <livewire:sidebar.messages />

--- a/resources/views/components/profile-row.blade.php
+++ b/resources/views/components/profile-row.blade.php
@@ -1,0 +1,6 @@
+@props(['label'])
+
+<div class="flex gap-3 border-t border-zinc-100 py-2 dark:border-zinc-700/60">
+    <dt class="w-24 shrink-0 text-xs text-zinc-500 dark:text-zinc-400">{{ $label }}</dt>
+    <dd class="min-w-0 flex-1 text-[13px] font-medium break-words">{{ $slot }}</dd>
+</div>

--- a/resources/views/livewire/people/drawer.blade.php
+++ b/resources/views/livewire/people/drawer.blade.php
@@ -287,6 +287,9 @@ new class extends Component
                             @endforeach
                         </div>
                     </div>
+                    <flux:button :href="route('people.show', $person)" wire:navigate size="sm" variant="ghost" icon="heart" data-test="drawer-pastoral-care">
+                        Open pastoral care
+                    </flux:button>
                 </div>
             </div>
 

--- a/resources/views/livewire/people/messages-panel.blade.php
+++ b/resources/views/livewire/people/messages-panel.blade.php
@@ -154,7 +154,7 @@ new class extends Component
 
             @foreach ($dayMessages as $comment)
                 @php($author = $comment->commentator)
-                @php($isMine = $author instanceof App\Models\User && $author->id === $this->user()->id)
+                @php($isMine = $author instanceof User && $author->id === $this->user()->id)
 
                 <div @class(['flex flex-col gap-1', 'items-end' => $isMine, 'items-start' => ! $isMine]) wire:key="msg-{{ $comment->id }}" data-test="message">
                     <div @class([
@@ -189,13 +189,16 @@ new class extends Component
 
     @script
     <script>
-        window.addEventListener('stave:notification', (event) => {
+        const handler = (event) => {
             const detail = event.detail ?? {};
 
             if (detail.is_direct || detail.conversation_id) {
                 $wire.handleIncoming(detail.conversation_id ?? null);
             }
-        });
+        };
+
+        window.addEventListener('stave:notification', handler);
+        $cleanup(() => window.removeEventListener('stave:notification', handler));
     </script>
     @endscript
 </flux:card>

--- a/resources/views/livewire/people/messages-panel.blade.php
+++ b/resources/views/livewire/people/messages-panel.blade.php
@@ -1,0 +1,201 @@
+<?php
+
+use App\Models\Comment;
+use App\Models\Conversation;
+use App\Models\Group;
+use App\Models\Person;
+use App\Models\User;
+use App\Services\ScriptureLinker;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Auth;
+use Livewire\Attributes\Computed;
+use Livewire\Component;
+
+new class extends Component
+{
+    public Person $person;
+
+    public string $reply = '';
+
+    public function mount(): void
+    {
+        $conversation = $this->conversation;
+
+        if ($conversation !== null) {
+            $conversation->markReadFor($this->user());
+        }
+    }
+
+    private function user(): User
+    {
+        /** @var User $user */
+        $user = Auth::user();
+
+        return $user;
+    }
+
+    /**
+     * The 1:1 conversation between the current user and this person, looked up
+     * read-only. Returns null until the first message creates it, so simply
+     * viewing the panel never writes a phantom conversation.
+     */
+    #[Computed]
+    public function conversation(): ?Conversation
+    {
+        $other = $this->person->user;
+
+        if ($other === null) {
+            return null;
+        }
+
+        $key = Group::directKeyFor([$this->user()->id, $other->id]);
+
+        return Group::query()->direct()->where('direct_key', $key)->first()
+            ?->directConversation()->first();
+    }
+
+    /** @return EloquentCollection<int, Comment> */
+    #[Computed]
+    public function messages(): EloquentCollection
+    {
+        $conversation = $this->conversation;
+
+        if ($conversation === null) {
+            /** @var EloquentCollection<int, Comment> */
+            return new EloquentCollection();
+        }
+
+        /** @var EloquentCollection<int, Comment> */
+        return $conversation->comments()
+            ->with('commentator')
+            ->orderBy('created_at')
+            ->get();
+    }
+
+    /** @return Collection<string, EloquentCollection<int, Comment>> */
+    #[Computed]
+    public function groupedMessages(): Collection
+    {
+        return $this->messages->groupBy(fn (Comment $comment): string => $comment->created_at->toDateString());
+    }
+
+    public function dayLabel(string $dateString): string
+    {
+        $date = Carbon::parse($dateString);
+
+        return match (true) {
+            $date->isToday() => 'Today',
+            $date->isYesterday() => 'Yesterday',
+            $date->isCurrentYear() => $date->format('M j'),
+            default => $date->format('M j, Y'),
+        };
+    }
+
+    public function send(): void
+    {
+        $other = $this->person->user;
+
+        if ($other === null) {
+            return;
+        }
+
+        if (trim(strip_tags($this->reply)) === '') {
+            $this->addError('reply', 'Write a message.');
+
+            return;
+        }
+
+        $user = $this->user();
+        $group = Group::findOrCreateDirect($user, [$other->id]);
+
+        /** @var Conversation $conversation */
+        $conversation = $group->directConversation()->firstOrFail();
+
+        $this->authorize('comment', $conversation);
+
+        $conversation->postComment(trim($this->reply), $user);
+        $conversation->markReadFor($user);
+
+        $this->reply = '';
+        unset($this->conversation, $this->messages, $this->groupedMessages);
+        $this->dispatch('messages-unread-updated');
+    }
+
+    public function handleIncoming(?int $conversationId = null): void
+    {
+        $conversation = $this->conversation;
+
+        if ($conversation === null) {
+            return;
+        }
+
+        if ($conversationId !== null && $conversationId !== $conversation->id) {
+            return;
+        }
+
+        $conversation->markReadFor($this->user());
+        unset($this->conversation, $this->messages, $this->groupedMessages);
+        $this->dispatch('messages-unread-updated');
+    }
+}; ?>
+
+<flux:card class="overflow-hidden !p-0">
+    <div class="flex items-center gap-3 border-b border-zinc-200 px-5 py-4 dark:border-zinc-700">
+        <flux:icon icon="chat-bubble-left-right" class="size-5 text-emerald-600 dark:text-emerald-400" />
+        <flux:heading size="lg">Messages</flux:heading>
+        <flux:text size="sm" class="text-zinc-500">Direct conversation with {{ $person->first_name }}</flux:text>
+    </div>
+
+    <div class="max-h-[340px] space-y-4 overflow-y-auto bg-zinc-50 px-5 py-4 dark:bg-zinc-800/50" data-test="person-dm-thread">
+        @forelse ($this->groupedMessages as $dateString => $dayMessages)
+            <x-conversation.day-divider :label="$this->dayLabel($dateString)" />
+
+            @foreach ($dayMessages as $comment)
+                @php($author = $comment->commentator)
+                @php($isMine = $author instanceof App\Models\User && $author->id === $this->user()->id)
+
+                <div @class(['flex flex-col gap-1', 'items-end' => $isMine, 'items-start' => ! $isMine]) wire:key="msg-{{ $comment->id }}" data-test="message">
+                    <div @class([
+                        'max-w-[80%] break-words rounded-xl px-3.5 py-2.5 text-[13px] leading-relaxed',
+                        'rounded-tr-sm bg-accent text-white' => $isMine,
+                        'rounded-tl-sm border border-zinc-200 bg-white text-zinc-900 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100' => ! $isMine,
+                    ])>
+                        <div class="**:[a]:underline **:[strong]:font-semibold **:[em]:italic **:[ul]:ml-5 **:[ul]:list-disc **:[ol]:ml-5 **:[ol]:list-decimal **:[p]:not-first:mt-2">
+                            {!! app(ScriptureLinker::class)->linkify($comment->text) !!}
+                        </div>
+                    </div>
+                    <span @class(['text-[10px] text-zinc-400', 'text-right' => $isMine, 'text-left' => ! $isMine])>{{ $comment->created_at->format('g:i A') }}</span>
+                </div>
+            @endforeach
+        @empty
+            <div class="py-6 text-center text-[13px] text-zinc-500 dark:text-zinc-400" data-test="person-dm-empty">
+                No messages yet. Start the conversation below.
+            </div>
+        @endforelse
+    </div>
+
+    <div class="border-t border-zinc-200 px-5 pb-4 pt-3 dark:border-zinc-700">
+        <x-conversation-composer
+            editor-model="reply"
+            submit-action="send"
+            submit-label="Send"
+            :allow-prayer="false"
+            :allow-mentions="false"
+            test-prefix="person-dm"
+        />
+    </div>
+
+    @script
+    <script>
+        window.addEventListener('stave:notification', (event) => {
+            const detail = event.detail ?? {};
+
+            if (detail.is_direct || detail.conversation_id) {
+                $wire.handleIncoming(detail.conversation_id ?? null);
+            }
+        });
+    </script>
+    @endscript
+</flux:card>

--- a/resources/views/livewire/people/row.blade.php
+++ b/resources/views/livewire/people/row.blade.php
@@ -59,6 +59,21 @@ new class extends Component
     </flux:table.cell>
 
     <flux:table.cell align="end">
-        <flux:icon name="chevron-right" class="size-4 text-zinc-400" />
+        <div class="inline-flex items-center gap-1.5">
+            <flux:tooltip content="Open pastoral care">
+                <flux:button
+                    :href="route('people.show', $person)"
+                    wire:navigate
+                    size="xs"
+                    variant="ghost"
+                    icon="heart"
+                    class="text-emerald-600 dark:text-emerald-400"
+                    x-on:click.stop
+                    aria-label="Open pastoral care"
+                    data-test="open-pastoral-care"
+                />
+            </flux:tooltip>
+            <flux:icon name="chevron-right" class="size-4 text-zinc-400" />
+        </div>
     </flux:table.cell>
 </flux:table.row>

--- a/resources/views/mail/prayer-schedule-digest.blade.php
+++ b/resources/views/mail/prayer-schedule-digest.blade.php
@@ -1,0 +1,30 @@
+@php
+    use Illuminate\Support\Str;
+@endphp
+
+<x-mail::message>
+# Prayer for the week
+
+Good morning, elders.
+
+Here are the {{ count($people) }} {{ Str::plural('person', count($people)) }} to hold in prayer this week (Week {{ $weekNumber }} of {{ $totalWeeks }}, {{ $weekRange }}). Please pray for them and their households by name.
+
+@foreach ($people as $person)
+## {{ $person['name'] }}@if ($person['household']) · {{ $person['household'] }} household @endif
+
+@if (count($person['requests']) > 0)
+@foreach ($person['requests'] as $request)
+- {{ $request }}
+@endforeach
+@else
+_Pray for them and their household by name — no specific requests this week._
+@endif
+
+@endforeach
+<x-mail::panel>
+Private notes and requests marked confidential are never included in this email. Only requests shared for the bulletin appear above.
+</x-mail::panel>
+
+In Christ,<br>
+The Stave prayer rota · {{ config('app.name') }}
+</x-mail::message>

--- a/resources/views/pages/pastoral-care/index.blade.php
+++ b/resources/views/pages/pastoral-care/index.blade.php
@@ -1,0 +1,197 @@
+<?php
+
+use App\Models\Person;
+use App\Models\PrayerRequest;
+use App\Models\PrayerScheduleSettings;
+use App\Models\User;
+use App\Services\PrayerScheduleService;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\Auth;
+use Livewire\Attributes\Computed;
+use Livewire\Component;
+
+new class extends Component
+{
+    /** @var 'mine'|'all' */
+    public string $scope = 'mine';
+
+    public function mount(): void
+    {
+        abort_unless($this->user()->canAccessPastoralCare(), 403);
+    }
+
+    private function user(): User
+    {
+        /** @var User $user */
+        $user = Auth::user();
+
+        return $user;
+    }
+
+    /** @return Builder<Person> */
+    private function baseQuery(): Builder
+    {
+        $personId = $this->user()->person_id;
+
+        return Person::query()->when($this->scope === 'mine', fn (Builder $query) => $query
+            ->where('pastoral_care_elder_id', $personId)
+            ->where('id', '!=', $personId));
+    }
+
+    /** @return array<int, int> */
+    #[Computed]
+    public function currentWeekPersonIds(): array
+    {
+        $settings = PrayerScheduleSettings::current();
+        $service = app(PrayerScheduleService::class);
+
+        return $service->peopleForWeek($settings, $service->currentWeekIndex($settings))
+            ->pluck('id')
+            ->all();
+    }
+
+    public function currentWeekLabel(): string
+    {
+        $settings = PrayerScheduleSettings::current();
+        $service = app(PrayerScheduleService::class);
+        $index = $service->currentWeekIndex($settings);
+
+        return 'Week '.($index + 1).' · '.$service->weekRange($settings, $index);
+    }
+
+    /** @return array{count: int, openRequests: int, awaitingBaptism: int, inRota: int} */
+    #[Computed]
+    public function stats(): array
+    {
+        $ids = $this->baseQuery()->pluck('id');
+
+        return [
+            'count' => $ids->count(),
+            'openRequests' => PrayerRequest::query()->open()->whereIn('person_id', $ids)->count(),
+            'awaitingBaptism' => $this->baseQuery()->where('baptized', false)->count(),
+            'inRota' => count(array_intersect($this->currentWeekPersonIds, $ids->all())),
+        ];
+    }
+
+    /** @return Collection<int, Person> */
+    #[Computed]
+    public function people(): Collection
+    {
+        return $this->baseQuery()
+            ->with(['household', 'pastoralCareElder'])
+            ->withCount(['prayerRequests as open_requests_count' => fn (Builder $query) => $query->whereNull('completed_at')])
+            ->withMax('pastoralNotes as last_note_at', 'created_at')
+            ->orderBy('last_name')
+            ->orderBy('first_name')
+            ->get();
+    }
+}; ?>
+
+<section class="mx-auto w-full max-w-6xl">
+    {{-- Header --}}
+    <div class="mb-6 flex flex-wrap items-end justify-between gap-4">
+        <div>
+            <flux:heading size="xl" level="1">Pastoral Care</flux:heading>
+            <flux:subheading>
+                {{ $scope === 'mine'
+                    ? $this->stats['count'].' people under your care'
+                    : $this->stats['count'].' people across the congregation' }}
+            </flux:subheading>
+        </div>
+        <flux:radio.group variant="segmented" size="sm" wire:model.live="scope" data-test="scope-toggle">
+            <flux:radio value="mine">My Assignees</flux:radio>
+            <flux:radio value="all">All Congregation</flux:radio>
+        </flux:radio.group>
+    </div>
+
+    {{-- Stat cards --}}
+    <div class="mb-6 grid grid-cols-2 gap-3.5 lg:grid-cols-4">
+        <flux:card class="!p-4">
+            <p class="text-xs font-semibold text-zinc-500">{{ $scope === 'mine' ? 'Under your care' : 'In the congregation' }}</p>
+            <div class="mt-2 flex items-baseline gap-2">
+                <span class="text-3xl font-bold tracking-tight">{{ $this->stats['count'] }}</span>
+                <span class="text-xs text-zinc-400">people</span>
+            </div>
+        </flux:card>
+        <flux:card class="!p-4">
+            <p class="text-xs font-semibold text-zinc-500">Open prayer requests</p>
+            <div class="mt-2 flex items-baseline gap-2">
+                <span class="text-3xl font-bold tracking-tight text-emerald-700 dark:text-emerald-400">{{ $this->stats['openRequests'] }}</span>
+                <span class="text-xs text-zinc-400">active</span>
+            </div>
+        </flux:card>
+        <flux:card class="!p-4">
+            <p class="text-xs font-semibold text-zinc-500">Awaiting baptism</p>
+            <div class="mt-2 flex items-baseline gap-2">
+                <span class="text-3xl font-bold tracking-tight text-amber-700 dark:text-amber-500">{{ $this->stats['awaitingBaptism'] }}</span>
+                <span class="text-xs text-zinc-400">people</span>
+            </div>
+        </flux:card>
+        <flux:card class="!p-4">
+            <p class="text-xs font-semibold text-zinc-500">In this week's rota</p>
+            <div class="mt-2 flex items-baseline gap-2">
+                <span class="text-3xl font-bold tracking-tight">{{ $this->stats['inRota'] }}</span>
+                <span class="text-xs text-zinc-400">to pray for</span>
+            </div>
+        </flux:card>
+    </div>
+
+    {{-- Section heading --}}
+    <div class="mb-3 flex items-center justify-between gap-3">
+        <flux:heading size="lg">{{ $scope === 'mine' ? 'People under your care' : 'All congregation' }}</flux:heading>
+        <flux:badge color="emerald" icon="calendar-date-range">This week: {{ $this->currentWeekLabel() }}</flux:badge>
+    </div>
+
+    {{-- People grid --}}
+    @if ($this->people->isEmpty())
+        <flux:card class="py-12 text-center">
+            <flux:icon icon="heart" class="mx-auto size-8 text-zinc-300" />
+            <flux:heading class="mt-3">{{ $scope === 'mine' ? 'No one is assigned to your care yet' : 'No people yet' }}</flux:heading>
+            <flux:subheading>{{ $scope === 'mine' ? 'People you shepherd will appear here.' : 'Add people to your congregation to get started.' }}</flux:subheading>
+        </flux:card>
+    @else
+        <div class="grid grid-cols-1 gap-3 md:grid-cols-2">
+            @foreach ($this->people as $person)
+                <a
+                    href="{{ route('people.show', $person) }}"
+                    wire:navigate
+                    wire:key="care-{{ $person->id }}"
+                    class="flex flex-col gap-3 rounded-xl border border-zinc-200 bg-white p-4 transition hover:border-zinc-300 hover:shadow-sm dark:border-zinc-700 dark:bg-zinc-800 dark:hover:border-zinc-600"
+                    data-test="person-card"
+                >
+                    <div class="flex items-center gap-3">
+                        <x-person-avatar :person="$person" size="lg" />
+                        <div class="min-w-0 flex-1">
+                            <p class="truncate text-sm font-semibold">{{ $person->full_name }}</p>
+                            <p class="truncate text-xs text-zinc-500">
+                                {{ $person->household?->name ? $person->household->name.' household' : 'No household' }}@if ($scope === 'all' && $person->pastoralCareElder) · {{ $person->pastoralCareElder->full_name }}@endif
+                            </p>
+                        </div>
+                        <x-membership-badge :status="$person->membership_status" />
+                        @if (in_array($person->id, $this->currentWeekPersonIds, true))
+                            <flux:badge size="sm" color="emerald">This week</flux:badge>
+                        @endif
+                    </div>
+                    <div class="flex items-center gap-4 border-t border-zinc-100 pt-2.5 text-xs text-zinc-500 dark:border-zinc-700/60">
+                        <span class="inline-flex items-center gap-1.5">
+                            @if ($person->baptized && $person->baptism_date)
+                                <flux:icon icon="waves" class="size-3.5 text-emerald-600 dark:text-emerald-400" />
+                                {{ $person->baptism_date->format('M j, Y') }}
+                            @else
+                                <span class="text-zinc-400">Not yet baptized</span>
+                            @endif
+                        </span>
+                        <span @class(['inline-flex items-center gap-1.5', 'font-semibold text-emerald-700 dark:text-emerald-400' => $person->open_requests_count > 0])>
+                            <flux:icon icon="hand-raised" class="size-3.5" />
+                            {{ $person->open_requests_count > 0 ? $person->open_requests_count.' '.\Illuminate\Support\Str::plural('request', $person->open_requests_count) : 'No open requests' }}
+                        </span>
+                        <span class="ms-auto text-zinc-400">
+                            {{ $person->last_note_at ? 'Last note '.\Illuminate\Support\Carbon::parse($person->last_note_at)->format('M j') : 'No notes' }}
+                        </span>
+                    </div>
+                </a>
+            @endforeach
+        </div>
+    @endif
+</section>

--- a/resources/views/pages/pastoral-care/index.blade.php
+++ b/resources/views/pages/pastoral-care/index.blade.php
@@ -7,7 +7,9 @@ use App\Models\User;
 use App\Services\PrayerScheduleService;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Str;
 use Livewire\Attributes\Computed;
 use Livewire\Component;
 
@@ -184,10 +186,10 @@ new class extends Component
                         </span>
                         <span @class(['inline-flex items-center gap-1.5', 'font-semibold text-emerald-700 dark:text-emerald-400' => $person->open_requests_count > 0])>
                             <flux:icon icon="hand-raised" class="size-3.5" />
-                            {{ $person->open_requests_count > 0 ? $person->open_requests_count.' '.\Illuminate\Support\Str::plural('request', $person->open_requests_count) : 'No open requests' }}
+                            {{ $person->open_requests_count > 0 ? $person->open_requests_count.' '.Str::plural('request', $person->open_requests_count) : 'No open requests' }}
                         </span>
                         <span class="ms-auto text-zinc-400">
-                            {{ $person->last_note_at ? 'Last note '.\Illuminate\Support\Carbon::parse($person->last_note_at)->format('M j') : 'No notes' }}
+                            {{ $person->last_note_at ? 'Last note '.Carbon::parse($person->last_note_at)->format('M j') : 'No notes' }}
                         </span>
                     </div>
                 </a>

--- a/resources/views/pages/people/show.blade.php
+++ b/resources/views/pages/people/show.blade.php
@@ -1,12 +1,12 @@
 <?php
 
 use App\Enums\PrayerRequestVisibility;
+use App\Models\PastoralNote;
 use App\Models\Person;
 use App\Models\PrayerRequest;
 use App\Models\PrayerScheduleSettings;
 use App\Models\User;
 use App\Services\PrayerScheduleService;
-use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Str;
@@ -118,7 +118,7 @@ new class extends Component
 
     /* -------------------------- pastoral notes ---------------------- */
 
-    /** @return Collection<int, \App\Models\PastoralNote> */
+    /** @return Collection<int, PastoralNote> */
     #[Computed]
     public function notes(): Collection
     {

--- a/resources/views/pages/people/show.blade.php
+++ b/resources/views/pages/people/show.blade.php
@@ -1,0 +1,450 @@
+<?php
+
+use App\Enums\PrayerRequestVisibility;
+use App\Models\Person;
+use App\Models\PrayerRequest;
+use App\Models\PrayerScheduleSettings;
+use App\Models\User;
+use App\Services\PrayerScheduleService;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Str;
+use Livewire\Attributes\Computed;
+use Livewire\Attributes\On;
+use Livewire\Component;
+
+new class extends Component
+{
+    public Person $person;
+
+    public bool $showCompleted = false;
+
+    public string $newRequestBody = '';
+
+    public string $newRequestVisibility = 'bulletin';
+
+    public string $newNote = '';
+
+    public function mount(Person $person): void
+    {
+        $this->person = $person->load(['user', 'household', 'pastoralCareElder', 'offices']);
+    }
+
+    private function user(): User
+    {
+        /** @var User $user */
+        $user = Auth::user();
+
+        return $user;
+    }
+
+    #[Computed]
+    public function canAccessPastoralCare(): bool
+    {
+        return $this->user()->canAccessPastoralCare();
+    }
+
+    /* ----------------------- prayer requests ----------------------- */
+
+    /** @return Collection<int, PrayerRequest> */
+    #[Computed]
+    public function prayerRequests(): Collection
+    {
+        $all = $this->person->prayerRequests()->orderByDesc('created_at')->get();
+
+        $open = $all->whereNull('completed_at')->values();
+        $completed = $all->whereNotNull('completed_at');
+
+        if (! $this->showCompleted) {
+            $cutoff = now()->subDays(7);
+            $completed = $completed->filter(fn (PrayerRequest $request): bool => $request->completed_at->greaterThanOrEqualTo($cutoff));
+        }
+
+        return $open->concat($completed->sortByDesc('completed_at')->values());
+    }
+
+    #[Computed]
+    public function openRequestCount(): int
+    {
+        return $this->person->prayerRequests()->open()->count();
+    }
+
+    #[Computed]
+    public function hiddenCompletedCount(): int
+    {
+        if ($this->showCompleted) {
+            return 0;
+        }
+
+        return $this->person->prayerRequests()
+            ->completed()
+            ->where('completed_at', '<', now()->subDays(7))
+            ->count();
+    }
+
+    public function addPrayerRequest(): void
+    {
+        $body = trim($this->newRequestBody);
+
+        if ($body === '') {
+            $this->addError('newRequestBody', 'Enter a prayer request.');
+
+            return;
+        }
+
+        $this->person->prayerRequests()->create([
+            'body' => $body,
+            'visibility' => PrayerRequestVisibility::tryFrom($this->newRequestVisibility) ?? PrayerRequestVisibility::BULLETIN,
+            'created_by_user_id' => $this->user()->id,
+        ]);
+
+        $this->newRequestBody = '';
+        $this->newRequestVisibility = 'bulletin';
+        unset($this->prayerRequests, $this->openRequestCount, $this->hiddenCompletedCount);
+    }
+
+    public function toggleComplete(int $requestId): void
+    {
+        $request = $this->person->prayerRequests()->whereKey($requestId)->first();
+
+        if ($request === null) {
+            return;
+        }
+
+        $request->update(['completed_at' => $request->completed_at ? null : now()]);
+        unset($this->prayerRequests, $this->openRequestCount, $this->hiddenCompletedCount);
+    }
+
+    /* -------------------------- pastoral notes ---------------------- */
+
+    /** @return Collection<int, \App\Models\PastoralNote> */
+    #[Computed]
+    public function notes(): Collection
+    {
+        if (! $this->canAccessPastoralCare) {
+            return collect();
+        }
+
+        return $this->person->pastoralNotes()->with('author')->latest()->get();
+    }
+
+    public function addNote(): void
+    {
+        abort_unless($this->canAccessPastoralCare, 403);
+
+        $body = trim($this->newNote);
+
+        if ($body === '') {
+            $this->addError('newNote', 'Write a note.');
+
+            return;
+        }
+
+        $this->person->pastoralNotes()->create([
+            'author_id' => $this->user()->id,
+            'body' => $body,
+        ]);
+
+        $this->newNote = '';
+        unset($this->notes);
+    }
+
+    /* ----------------------------- rota ----------------------------- */
+
+    /** @return array{label?: string, excluded?: string} */
+    #[Computed]
+    public function rota(): array
+    {
+        $settings = PrayerScheduleSettings::current();
+
+        if (! in_array($this->person->membership_status->value, $settings->include_statuses, true)) {
+            return ['excluded' => Str::plural($this->person->membership_status->label()).' are not in this rotation'];
+        }
+
+        $service = app(PrayerScheduleService::class);
+
+        foreach ($service->buckets($settings) as $index => $week) {
+            if ($week->contains('id', $this->person->id)) {
+                return ['label' => 'Week '.($index + 1).' · '.$service->weekRange($settings, $index)];
+            }
+        }
+
+        return ['excluded' => 'Not currently scheduled'];
+    }
+
+    #[On('person-saved')]
+    public function refreshPerson(): void
+    {
+        $this->person->refresh()->load(['user', 'household', 'pastoralCareElder', 'offices']);
+        unset($this->prayerRequests, $this->openRequestCount, $this->hiddenCompletedCount, $this->notes, $this->rota);
+    }
+
+    #[On('person-deleted')]
+    public function onPersonDeleted(): void
+    {
+        $this->redirectRoute('people.index', navigate: true);
+    }
+}; ?>
+
+<section class="mx-auto w-full max-w-6xl">
+    <flux:button :href="route('people.index')" wire:navigate variant="ghost" size="sm" icon="arrow-left" class="mb-4">
+        People
+    </flux:button>
+
+    {{-- Header --}}
+    <div class="mb-6 flex flex-wrap items-start justify-between gap-4">
+        <div class="flex items-center gap-4">
+            <x-person-avatar :person="$person" size="xl" />
+            <div>
+                <flux:heading size="xl" level="1">{{ $person->full_name }}</flux:heading>
+                <div class="mt-1.5 flex flex-wrap items-center gap-x-2.5 gap-y-1.5">
+                    <x-membership-badge :status="$person->membership_status" :reason="$person->termination_reason" />
+                    @foreach ($person->offices as $office)
+                        <x-office-chip :kind="$office->kind" />
+                    @endforeach
+                    @if ($person->household)
+                        <flux:text size="sm" class="text-zinc-500">{{ $person->household->name }} household</flux:text>
+                    @endif
+                    @if ($person->pastoralCareElder)
+                        <span class="text-zinc-300 dark:text-zinc-600">·</span>
+                        <flux:text size="sm" class="text-zinc-500">Shepherded by {{ $person->pastoralCareElder->full_name }}</flux:text>
+                    @endif
+                </div>
+            </div>
+        </div>
+        <flux:button variant="outline" size="sm" icon="pencil-square" wire:click="$dispatch('open-person-drawer', { personId: {{ $person->id }} })" data-test="edit-profile">
+            Edit profile
+        </flux:button>
+    </div>
+
+    <div class="grid grid-cols-1 items-start gap-6 lg:grid-cols-[1fr_340px]">
+        {{-- LEFT --}}
+        <div class="space-y-6">
+            {{-- Prayer Requests --}}
+            <flux:card class="overflow-hidden !p-0" data-test="prayer-requests">
+                <div class="flex items-center gap-3 border-b border-zinc-200 px-5 py-4 dark:border-zinc-700">
+                    <flux:icon icon="hand-raised" class="size-5 text-emerald-600 dark:text-emerald-400" />
+                    <flux:heading size="lg">Prayer Requests</flux:heading>
+                    <flux:badge size="sm" color="zinc">{{ $this->openRequestCount }} open</flux:badge>
+                    <flux:spacer />
+                    <flux:field variant="inline">
+                        <flux:label class="!text-xs text-zinc-500">Show completed</flux:label>
+                        <flux:switch wire:model.live="showCompleted" data-test="show-completed" />
+                    </flux:field>
+                </div>
+
+                <div>
+                    @forelse ($this->prayerRequests as $request)
+                        @php($done = $request->completed_at !== null)
+                        <div class="flex items-start gap-3 border-b border-zinc-100 px-5 py-3.5 dark:border-zinc-700/60" wire:key="req-{{ $request->id }}" data-test="prayer-request">
+                            <button
+                                type="button"
+                                wire:click="toggleComplete({{ $request->id }})"
+                                @class([
+                                    'mt-0.5 grid size-5 shrink-0 place-items-center rounded-md border transition',
+                                    'border-transparent bg-accent text-white' => $done,
+                                    'border-zinc-300 hover:border-zinc-400 dark:border-zinc-600' => ! $done,
+                                ])
+                                aria-label="{{ $done ? 'Mark as open' : 'Mark as completed' }}"
+                            >
+                                @if ($done)
+                                    <flux:icon icon="check" variant="micro" class="size-3.5" />
+                                @endif
+                            </button>
+                            <div class="min-w-0 flex-1">
+                                <p @class(['text-sm leading-relaxed', 'text-zinc-400 line-through' => $done])>{{ $request->body }}</p>
+                                <div class="mt-1 flex flex-wrap items-center gap-2">
+                                    <span class="text-xs text-zinc-500">
+                                        {{ $done ? 'Completed '.$request->completed_at->format('M j') : 'Added '.$request->created_at->format('M j') }}
+                                    </span>
+                                    <flux:badge size="sm" :color="$request->visibility->color()" :icon="$request->visibility->icon()">{{ $request->visibility->label() }}</flux:badge>
+                                </div>
+                            </div>
+                        </div>
+                    @empty
+                        <div class="px-5 py-6 text-center text-sm text-zinc-500">No prayer requests yet.</div>
+                    @endforelse
+
+                    @if ($this->hiddenCompletedCount > 0)
+                        <div class="border-b border-zinc-100 px-5 py-2.5 text-xs text-zinc-500 dark:border-zinc-700/60" data-test="hidden-completed">
+                            {{ $this->hiddenCompletedCount }} completed {{ Str::plural('request', $this->hiddenCompletedCount) }} hidden — turn on “Show completed” to view
+                        </div>
+                    @endif
+
+                    <div class="flex items-center gap-2 bg-zinc-50 px-5 py-3.5 dark:bg-zinc-800/50">
+                        <flux:input wire:model="newRequestBody" placeholder="Add a prayer request…" size="sm" class="flex-1" wire:keydown.enter.prevent="addPrayerRequest" />
+                        <flux:radio.group variant="segmented" size="sm" wire:model="newRequestVisibility">
+                            <flux:radio value="bulletin">Bulletin</flux:radio>
+                            <flux:radio value="private">Private</flux:radio>
+                        </flux:radio.group>
+                        <flux:button variant="primary" size="sm" wire:click="addPrayerRequest">Add</flux:button>
+                    </div>
+                </div>
+            </flux:card>
+
+            {{-- Pastoral Notes --}}
+            @if ($this->canAccessPastoralCare)
+                <flux:card class="overflow-hidden !p-0" data-test="pastoral-notes">
+                    <div class="flex items-center gap-3 border-b border-zinc-200 px-5 py-4 dark:border-zinc-700">
+                        <flux:icon icon="lock-closed" class="size-5 text-amber-600 dark:text-amber-400" />
+                        <flux:heading size="lg">Pastoral Notes</flux:heading>
+                        <flux:badge size="sm" color="amber" icon="lock-closed">Visible to elders only</flux:badge>
+                    </div>
+
+                    <div class="divide-y divide-zinc-100 px-5 dark:divide-zinc-700/60">
+                        @forelse ($this->notes as $note)
+                            <div class="py-3.5" wire:key="note-{{ $note->id }}">
+                                <div class="mb-1.5 flex items-center gap-2">
+                                    @if ($note->author)
+                                        <flux:avatar size="xs" :name="$note->author->name" :src="$note->author->gravatar" color="auto" />
+                                    @else
+                                        <flux:avatar size="xs" name="—" color="auto" />
+                                    @endif
+                                    <span class="text-xs font-semibold">{{ $note->author?->name ?? 'Former user' }}</span>
+                                    <span class="text-xs text-zinc-400">{{ $note->created_at->diffForHumans() }}</span>
+                                </div>
+                                <p class="text-sm leading-relaxed">{{ $note->body }}</p>
+                            </div>
+                        @empty
+                            <div class="py-6 text-center text-sm text-zinc-500">No notes yet.</div>
+                        @endforelse
+                    </div>
+
+                    <div class="border-t border-zinc-200 bg-zinc-50 px-5 py-4 dark:border-zinc-700 dark:bg-zinc-800/50">
+                        <flux:textarea wire:model="newNote" rows="3" placeholder="Add a private note for the eldership…" />
+                        <flux:error name="newNote" />
+                        <div class="mt-2 flex justify-end">
+                            <flux:button variant="primary" size="sm" wire:click="addNote">Save Note</flux:button>
+                        </div>
+                    </div>
+                </flux:card>
+            @endif
+
+            {{-- Messages --}}
+            @if ($person->user)
+                <livewire:people.messages-panel :person="$person" :key="'dm-'.$person->id" />
+            @endif
+        </div>
+
+        {{-- RIGHT: read-only profile --}}
+        <flux:card class="overflow-hidden !p-0 lg:sticky lg:top-6" data-test="profile">
+            <div class="flex items-center gap-3 border-b border-zinc-200 px-5 py-4 dark:border-zinc-700">
+                <flux:icon icon="identification" class="size-5 text-zinc-500" />
+                <flux:heading size="lg">Profile</flux:heading>
+            </div>
+
+            <div class="space-y-5 px-5 py-4">
+                {{-- Contact --}}
+                <div>
+                    <p class="mb-1 text-[11px] font-semibold uppercase tracking-wider text-zinc-500">Contact</p>
+                    <dl>
+                        <x-profile-row label="Email">
+                            @if ($person->email)
+                                <a href="mailto:{{ $person->email }}" class="text-emerald-700 underline underline-offset-2 dark:text-emerald-300">{{ $person->email }}</a>
+                            @else
+                                <span class="text-zinc-400">—</span>
+                            @endif
+                        </x-profile-row>
+                        <x-profile-row label="Phone">{{ $person->phone ?: '—' }}</x-profile-row>
+                        <x-profile-row label="Address">
+                            @if ($person->address_line1 || $person->address_city)
+                                <span class="block leading-relaxed">
+                                    @if ($person->address_line1){{ $person->address_line1 }}<br>@endif
+                                    {{ collect([$person->address_city, $person->address_state])->filter()->join(', ') }} {{ $person->address_zip }}
+                                </span>
+                            @else
+                                <span class="text-zinc-400">—</span>
+                            @endif
+                        </x-profile-row>
+                    </dl>
+                </div>
+
+                {{-- Personal --}}
+                <div>
+                    <p class="mb-1 text-[11px] font-semibold uppercase tracking-wider text-zinc-500">Personal</p>
+                    <dl>
+                        <x-profile-row label="Birthday">{{ $person->birth_date?->format('M j, Y') ?? '—' }}</x-profile-row>
+                        <x-profile-row label="Gender">{{ $person->gender?->label() ?? '—' }}</x-profile-row>
+                        <x-profile-row label="Baptized">
+                            @if ($person->baptized)
+                                <span class="inline-flex items-center gap-1.5 text-emerald-700 dark:text-emerald-300">
+                                    <flux:icon icon="waves" class="size-4" />
+                                    {{ $person->baptism_date?->format('M j, Y') ?? 'Yes' }}
+                                </span>
+                            @else
+                                <span class="text-zinc-400">Not yet</span>
+                            @endif
+                        </x-profile-row>
+                    </dl>
+                </div>
+
+                {{-- Household --}}
+                <div>
+                    <p class="mb-1 text-[11px] font-semibold uppercase tracking-wider text-zinc-500">Household</p>
+                    <dl>
+                        <x-profile-row label="Household">{{ $person->household?->name ?? '—' }}</x-profile-row>
+                        <x-profile-row label="Role">{{ $person->household_role?->label() ?? '—' }}</x-profile-row>
+                    </dl>
+                </div>
+
+                {{-- Membership --}}
+                <div>
+                    <p class="mb-1 text-[11px] font-semibold uppercase tracking-wider text-zinc-500">Membership</p>
+                    <dl>
+                        <x-profile-row label="Status">
+                            <x-membership-badge :status="$person->membership_status" :reason="$person->termination_reason" />
+                        </x-profile-row>
+                        <x-profile-row label="Since">{{ $person->membership_since?->format('Y') ?? '—' }}</x-profile-row>
+                    </dl>
+                </div>
+
+                {{-- Office --}}
+                <div>
+                    <p class="mb-1 text-[11px] font-semibold uppercase tracking-wider text-zinc-500">Office</p>
+                    <dl>
+                        <x-profile-row label="Office">
+                            @if ($person->offices->isNotEmpty())
+                                <span class="inline-flex flex-wrap gap-1.5">
+                                    @foreach ($person->offices as $office)
+                                        <x-office-chip :kind="$office->kind" />
+                                    @endforeach
+                                </span>
+                            @else
+                                <span class="text-zinc-400">None held</span>
+                            @endif
+                        </x-profile-row>
+                    </dl>
+                </div>
+
+                {{-- Pastoral care --}}
+                @if ($this->canAccessPastoralCare)
+                    <div>
+                        <p class="mb-1 text-[11px] font-semibold uppercase tracking-wider text-zinc-500">Pastoral care</p>
+                        <dl>
+                            <x-profile-row label="Shepherd">
+                                @if ($person->pastoralCareElder)
+                                    <span class="inline-flex items-center gap-2">
+                                        <x-person-avatar :person="$person->pastoralCareElder" size="xs" />
+                                        {{ $person->pastoralCareElder->full_name }}
+                                    </span>
+                                @else
+                                    <span class="text-zinc-400">Unassigned</span>
+                                @endif
+                            </x-profile-row>
+                            <x-profile-row label="Prayer rota">
+                                @if (isset($this->rota['label']))
+                                    {{ $this->rota['label'] }}
+                                @else
+                                    <span class="text-zinc-400">{{ $this->rota['excluded'] }}</span>
+                                @endif
+                            </x-profile-row>
+                        </dl>
+                    </div>
+                @endif
+            </div>
+        </flux:card>
+    </div>
+
+    <livewire:people.drawer />
+</section>

--- a/resources/views/pages/prayer-schedule/index.blade.php
+++ b/resources/views/pages/prayer-schedule/index.blade.php
@@ -1,10 +1,12 @@
 <?php
 
 use App\Enums\MembershipStatus;
+use App\Mail\PrayerScheduleDigestMail;
 use App\Models\PrayerRequest;
 use App\Models\PrayerScheduleSettings;
 use App\Models\User;
 use App\Services\PrayerScheduleService;
+use Flux\Flux;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
 use Livewire\Attributes\Computed;
@@ -21,6 +23,10 @@ new class extends Component
     public int $cycleWeeks = 8;
 
     public string $groupBy = 'alpha';
+
+    public ?string $previewHtml = null;
+
+    public int $previewWeek = 0;
 
     public function mount(): void
     {
@@ -82,6 +88,25 @@ new class extends Component
     public function updatedGroupBy(): void
     {
         $this->persist();
+    }
+
+    public function previewEmail(?int $week = null): void
+    {
+        $week ??= $this->currentWeekIndex();
+        $this->previewWeek = $week;
+
+        $settings = $this->settings;
+        $people = $this->service()->bulletinDigestForWeek($settings, $week, $this->includeStatuses);
+
+        $this->previewHtml = (new PrayerScheduleDigestMail(
+            recipient: $this->user(),
+            people: $people,
+            weekNumber: $week + 1,
+            totalWeeks: $settings->cycle_weeks,
+            weekRange: $this->service()->weekRange($settings, $week),
+        ))->render();
+
+        Flux::modal('email-preview')->show();
     }
 
     #[Computed]
@@ -209,6 +234,10 @@ new class extends Component
                 <flux:radio value="roster">Roster</flux:radio>
             </flux:radio.group>
         </div>
+
+        <flux:button class="ms-auto" size="sm" variant="primary" icon="envelope" wire:click="previewEmail" data-test="preview-email">
+            Preview Monday email
+        </flux:button>
     </flux:card>
 
     <p class="mb-5 text-sm text-zinc-500" data-test="stat-line">{{ $this->statLine() }}</p>
@@ -236,6 +265,7 @@ new class extends Component
                             </div>
                             <p class="mt-0.5 text-xs text-zinc-500">{{ $this->service()->weekRange($this->settings, $weekIndex) }} · {{ $week->count() }} people</p>
                         </div>
+                        <flux:button size="xs" variant="ghost" icon="envelope" wire:click="previewEmail({{ $weekIndex }})" aria-label="Preview email for this week" />
                     </div>
                     <div class="px-4 py-2">
                         @forelse ($week as $person)
@@ -287,4 +317,19 @@ new class extends Component
             </flux:table>
         </div>
     @endif
+
+    <flux:modal name="email-preview" class="w-full max-w-2xl">
+        <div class="space-y-3">
+            <flux:heading size="lg">Monday email · Week {{ $previewWeek + 1 }}</flux:heading>
+            @if ($previewHtml !== null)
+                <iframe srcdoc="{{ $previewHtml }}" class="h-[60vh] w-full rounded-lg border border-zinc-200 dark:border-zinc-700" title="Monday email preview"></iframe>
+            @endif
+            <div class="flex items-center justify-between gap-3">
+                <flux:text size="sm" class="text-zinc-500">Sends automatically every Monday at 6:00 AM to all elders.</flux:text>
+                <flux:modal.close>
+                    <flux:button variant="ghost">Close</flux:button>
+                </flux:modal.close>
+            </div>
+        </div>
+    </flux:modal>
 </section>

--- a/resources/views/pages/prayer-schedule/index.blade.php
+++ b/resources/views/pages/prayer-schedule/index.blade.php
@@ -2,6 +2,7 @@
 
 use App\Enums\MembershipStatus;
 use App\Mail\PrayerScheduleDigestMail;
+use App\Models\Person;
 use App\Models\PrayerRequest;
 use App\Models\PrayerScheduleSettings;
 use App\Models\User;
@@ -115,7 +116,7 @@ new class extends Component
         return PrayerScheduleSettings::current();
     }
 
-    /** @return Collection<int, Collection<int, \App\Models\Person>> */
+    /** @return Collection<int, Collection<int, Person>> */
     #[Computed]
     public function buckets(): Collection
     {
@@ -134,7 +135,7 @@ new class extends Component
         return $this->service()->stats($this->settings, $this->includeStatuses);
     }
 
-    /** @return Collection<int, array{person: \App\Models\Person, week: int}> */
+    /** @return Collection<int, array{person: Person, week: int}> */
     #[Computed]
     public function roster(): Collection
     {

--- a/resources/views/pages/prayer-schedule/index.blade.php
+++ b/resources/views/pages/prayer-schedule/index.blade.php
@@ -1,0 +1,290 @@
+<?php
+
+use App\Enums\MembershipStatus;
+use App\Models\PrayerRequest;
+use App\Models\PrayerScheduleSettings;
+use App\Models\User;
+use App\Services\PrayerScheduleService;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Auth;
+use Livewire\Attributes\Computed;
+use Livewire\Component;
+
+new class extends Component
+{
+    /** @var 'weeks'|'roster' */
+    public string $view = 'weeks';
+
+    /** @var array<int, string> */
+    public array $includeStatuses = [];
+
+    public int $cycleWeeks = 8;
+
+    public string $groupBy = 'alpha';
+
+    public function mount(): void
+    {
+        abort_unless($this->user()->canAccessPastoralCare(), 403);
+
+        $settings = PrayerScheduleSettings::current();
+        $this->includeStatuses = $settings->include_statuses;
+        $this->cycleWeeks = $settings->cycle_weeks;
+        $this->groupBy = $settings->group_by->value;
+    }
+
+    private function user(): User
+    {
+        /** @var User $user */
+        $user = Auth::user();
+
+        return $user;
+    }
+
+    private function service(): PrayerScheduleService
+    {
+        return app(PrayerScheduleService::class);
+    }
+
+    private function persist(): void
+    {
+        PrayerScheduleSettings::current()->update([
+            'cycle_weeks' => $this->cycleWeeks,
+            'group_by' => $this->groupBy,
+            'include_statuses' => array_values($this->includeStatuses),
+        ]);
+
+        unset($this->settings, $this->buckets, $this->stats, $this->roster, $this->peopleWithOpenBulletinRequests);
+    }
+
+    public function toggleStatus(string $status): void
+    {
+        if (in_array($status, $this->includeStatuses, true)) {
+            $this->includeStatuses = array_values(array_diff($this->includeStatuses, [$status]));
+        } else {
+            $this->includeStatuses[] = $status;
+        }
+
+        $this->persist();
+    }
+
+    public function incrementWeeks(): void
+    {
+        $this->cycleWeeks = min(13, $this->cycleWeeks + 1);
+        $this->persist();
+    }
+
+    public function decrementWeeks(): void
+    {
+        $this->cycleWeeks = max(4, $this->cycleWeeks - 1);
+        $this->persist();
+    }
+
+    public function updatedGroupBy(): void
+    {
+        $this->persist();
+    }
+
+    #[Computed]
+    public function settings(): PrayerScheduleSettings
+    {
+        return PrayerScheduleSettings::current();
+    }
+
+    /** @return Collection<int, Collection<int, \App\Models\Person>> */
+    #[Computed]
+    public function buckets(): Collection
+    {
+        return $this->service()->buckets($this->settings, $this->includeStatuses);
+    }
+
+    public function currentWeekIndex(): int
+    {
+        return $this->service()->currentWeekIndex($this->settings);
+    }
+
+    /** @return array{total: int, weeks: int, perWeek: int, currentWeekIndex: int} */
+    #[Computed]
+    public function stats(): array
+    {
+        return $this->service()->stats($this->settings, $this->includeStatuses);
+    }
+
+    /** @return Collection<int, array{person: \App\Models\Person, week: int}> */
+    #[Computed]
+    public function roster(): Collection
+    {
+        return $this->buckets
+            ->flatMap(fn (Collection $people, int $week): Collection => $people->map(fn ($person): array => [
+                'person' => $person,
+                'week' => $week,
+            ]))
+            ->sortBy([
+                ['person.last_name', 'asc'],
+                ['person.first_name', 'asc'],
+            ])
+            ->values();
+    }
+
+    /** @return array<int, int> */
+    #[Computed]
+    public function peopleWithOpenBulletinRequests(): array
+    {
+        return PrayerRequest::query()->open()->bulletin()->distinct()->pluck('person_id')->all();
+    }
+
+    public function statLine(): string
+    {
+        $stats = $this->stats;
+        $range = $this->service()->weekRange($this->settings, $stats['currentWeekIndex']);
+
+        return $stats['total'].' people across '.$stats['weeks'].' weeks · about '.$stats['perWeek']
+            .' per week · This week: Week '.($stats['currentWeekIndex'] + 1).' ('.$range.')';
+    }
+
+    public function dotClass(MembershipStatus $status): string
+    {
+        return match ($status->color()) {
+            'emerald' => 'bg-emerald-500',
+            'amber' => 'bg-amber-500',
+            'sky' => 'bg-sky-500',
+            default => 'bg-zinc-400',
+        };
+    }
+}; ?>
+
+<section class="mx-auto w-full max-w-6xl">
+    <div class="mb-4">
+        <flux:heading size="xl" level="1">Prayer Schedule</flux:heading>
+        <flux:subheading>Pray through the congregation over a {{ $cycleWeeks }}-week cycle.</flux:subheading>
+    </div>
+
+    {{-- Controls --}}
+    <flux:card class="mb-3 flex flex-wrap items-center gap-x-6 gap-y-4 !p-4">
+        <div class="flex items-center gap-2.5">
+            <span class="text-xs font-semibold text-zinc-500">Cycle length</span>
+            <div class="inline-flex items-center overflow-hidden rounded-lg border border-zinc-200 dark:border-zinc-700">
+                <flux:button size="xs" variant="subtle" icon="minus" wire:click="decrementWeeks" aria-label="Fewer weeks" />
+                <span class="min-w-16 text-center text-sm font-semibold">{{ $cycleWeeks }} weeks</span>
+                <flux:button size="xs" variant="subtle" icon="plus" wire:click="incrementWeeks" aria-label="More weeks" />
+            </div>
+        </div>
+
+        <div class="flex items-center gap-2.5">
+            <span class="text-xs font-semibold text-zinc-500">Include</span>
+            <div class="flex flex-wrap gap-1.5" data-test="status-chips">
+                @foreach ([MembershipStatus::MEMBER, MembershipStatus::CATECHUMEN, MembershipStatus::ADHERENT, MembershipStatus::VISITOR] as $status)
+                    @php($on = in_array($status->value, $includeStatuses, true))
+                    <button
+                        type="button"
+                        wire:click="toggleStatus('{{ $status->value }}')"
+                        @class([
+                            'inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-semibold transition',
+                            'border-emerald-600 bg-emerald-50 text-emerald-700 dark:border-emerald-500 dark:bg-emerald-950/50 dark:text-emerald-300' => $on,
+                            'border-zinc-200 text-zinc-500 hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800' => ! $on,
+                        ])
+                        data-test="status-chip-{{ $status->value }}"
+                        @if ($on) data-on="true" @endif
+                    >
+                        @if ($on)
+                            <flux:icon icon="check" variant="micro" class="size-3.5" />
+                        @endif
+                        {{ $status->label() }}
+                    </button>
+                @endforeach
+            </div>
+        </div>
+
+        <div class="flex items-center gap-2.5">
+            <span class="text-xs font-semibold text-zinc-500">Group by</span>
+            <flux:radio.group variant="segmented" size="sm" wire:model.live="groupBy">
+                <flux:radio value="alpha">Alphabetical</flux:radio>
+                <flux:radio value="household">By household</flux:radio>
+            </flux:radio.group>
+        </div>
+
+        <div class="flex items-center gap-2.5">
+            <span class="text-xs font-semibold text-zinc-500">View</span>
+            <flux:radio.group variant="segmented" size="sm" wire:model.live="view">
+                <flux:radio value="weeks">Weeks</flux:radio>
+                <flux:radio value="roster">Roster</flux:radio>
+            </flux:radio.group>
+        </div>
+    </flux:card>
+
+    <p class="mb-5 text-sm text-zinc-500" data-test="stat-line">{{ $this->statLine() }}</p>
+
+    @if ($view === 'weeks')
+        <div class="grid grid-cols-1 gap-3.5 sm:grid-cols-2 lg:grid-cols-3" data-test="weeks-view">
+            @foreach ($this->buckets as $weekIndex => $week)
+                @php($isCurrent = $weekIndex === $this->currentWeekIndex())
+                <div @class([
+                    'overflow-hidden rounded-xl border bg-white dark:bg-zinc-800',
+                    'border-emerald-400 dark:border-emerald-500' => $isCurrent,
+                    'border-zinc-200 dark:border-zinc-700' => ! $isCurrent,
+                ]) wire:key="week-{{ $weekIndex }}">
+                    <div @class([
+                        'flex items-center gap-2 border-b px-4 py-3',
+                        'border-zinc-100 bg-emerald-50 dark:border-zinc-700 dark:bg-emerald-950/40' => $isCurrent,
+                        'border-zinc-100 bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800/60' => ! $isCurrent,
+                    ])>
+                        <div class="flex-1">
+                            <div class="flex items-center gap-2">
+                                <span class="text-sm font-bold">Week {{ $weekIndex + 1 }}</span>
+                                @if ($isCurrent)
+                                    <flux:badge size="sm" color="emerald">This week</flux:badge>
+                                @endif
+                            </div>
+                            <p class="mt-0.5 text-xs text-zinc-500">{{ $this->service()->weekRange($this->settings, $weekIndex) }} · {{ $week->count() }} people</p>
+                        </div>
+                    </div>
+                    <div class="px-4 py-2">
+                        @forelse ($week as $person)
+                            <div class="flex items-center gap-2.5 border-b border-zinc-100 py-1.5 last:border-0 dark:border-zinc-700/60" wire:key="week-{{ $weekIndex }}-person-{{ $person->id }}">
+                                <x-person-avatar :person="$person" size="xs" />
+                                <span class="flex-1 truncate text-[13px] font-medium">{{ $person->full_name }}</span>
+                                <span class="size-1.5 rounded-full {{ $this->dotClass($person->membership_status) }}"></span>
+                                @if (in_array($person->id, $this->peopleWithOpenBulletinRequests, true))
+                                    <flux:icon icon="hand-raised" class="size-3.5 text-emerald-600 dark:text-emerald-400" />
+                                @endif
+                            </div>
+                        @empty
+                            <p class="py-3 text-center text-xs text-zinc-400">No one this week</p>
+                        @endforelse
+                    </div>
+                </div>
+            @endforeach
+        </div>
+    @else
+        <div class="overflow-hidden rounded-xl border border-zinc-200 dark:border-zinc-700" data-test="roster-view">
+            <flux:table>
+                <flux:table.columns>
+                    <flux:table.column>Name</flux:table.column>
+                    <flux:table.column>Status</flux:table.column>
+                    <flux:table.column>Household</flux:table.column>
+                    <flux:table.column>Prayer week</flux:table.column>
+                </flux:table.columns>
+                <flux:table.rows>
+                    @foreach ($this->roster as $row)
+                        @php($person = $row['person'])
+                        @php($isCurrent = $row['week'] === $this->currentWeekIndex())
+                        <flux:table.row wire:key="roster-{{ $person->id }}">
+                            <flux:table.cell>
+                                <div class="flex items-center gap-2.5">
+                                    <x-person-avatar :person="$person" size="xs" />
+                                    <span class="font-medium">{{ $person->full_name }}</span>
+                                </div>
+                            </flux:table.cell>
+                            <flux:table.cell>
+                                <x-membership-badge :status="$person->membership_status" />
+                            </flux:table.cell>
+                            <flux:table.cell class="text-zinc-500">{{ $person->household?->name ?? '—' }}</flux:table.cell>
+                            <flux:table.cell>
+                                <span @class(['font-semibold', 'text-emerald-700 dark:text-emerald-400' => $isCurrent])>Week {{ $row['week'] + 1 }}</span>
+                            </flux:table.cell>
+                        </flux:table.row>
+                    @endforeach
+                </flux:table.rows>
+            </flux:table>
+        </div>
+    @endif
+</section>

--- a/routes/console.php
+++ b/routes/console.php
@@ -10,3 +10,5 @@ Artisan::command('inspire', function (): void {
 
 Schedule::command('stave:send-digests --frequency=daily')->dailyAt('07:00');
 Schedule::command('stave:send-digests --frequency=weekly')->weeklyOn(1, '07:00');
+
+Schedule::command('stave:send-prayer-schedule')->weeklyOn(1, '06:00');

--- a/routes/web.php
+++ b/routes/web.php
@@ -83,6 +83,8 @@ Route::middleware(['auth'])->group(function (): void {
 
     Route::livewire('/people', 'pages::people.index')->name('people.index');
 
+    Route::livewire('/people/{person}', 'pages::people.show')->name('people.show');
+
     Route::livewire('/households', 'pages::households.index')->name('households.index');
 
     Route::name('messages.')

--- a/routes/web.php
+++ b/routes/web.php
@@ -85,6 +85,8 @@ Route::middleware(['auth'])->group(function (): void {
 
     Route::livewire('/people/{person}', 'pages::people.show')->name('people.show');
 
+    Route::livewire('/pastoral-care', 'pages::pastoral-care.index')->name('pastoral-care.index');
+
     Route::livewire('/households', 'pages::households.index')->name('households.index');
 
     Route::name('messages.')

--- a/routes/web.php
+++ b/routes/web.php
@@ -87,6 +87,8 @@ Route::middleware(['auth'])->group(function (): void {
 
     Route::livewire('/pastoral-care', 'pages::pastoral-care.index')->name('pastoral-care.index');
 
+    Route::livewire('/prayer-schedule', 'pages::prayer-schedule.index')->name('prayer-schedule.index');
+
     Route::livewire('/households', 'pages::households.index')->name('households.index');
 
     Route::name('messages.')

--- a/tests/Feature/PastoralCare/IndexTest.php
+++ b/tests/Feature/PastoralCare/IndexTest.php
@@ -1,0 +1,91 @@
+<?php
+
+use App\Enums\AccessRole;
+use App\Models\Person;
+use App\Models\PrayerRequest;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+function careUser(): User
+{
+    $user = User::factory()->create();
+    $user->grantAccessRole(AccessRole::PASTORAL_CARE_USER);
+
+    return $user;
+}
+
+test('non pastoral-care users cannot access the page', function (): void {
+    $this->actingAs(User::factory()->create())
+        ->get(route('pastoral-care.index'))
+        ->assertForbidden();
+});
+
+test('pastoral-care users can view the page', function (): void {
+    $this->actingAs(careUser())
+        ->get(route('pastoral-care.index'))
+        ->assertOk()
+        ->assertSee('Pastoral Care');
+});
+
+test('mine scope shows only the elder\'s assignees and excludes self', function (): void {
+    $user = careUser();
+    $me = $user->person;
+    $assignee = Person::factory()->create(['pastoral_care_elder_id' => $me->id]);
+    $unrelated = Person::factory()->create();
+
+    $component = Livewire::actingAs($user)->test('pages::pastoral-care.index');
+
+    $ids = $component->instance()->people->pluck('id');
+    expect($ids)->toContain($assignee->id)
+        ->not->toContain($unrelated->id)
+        ->not->toContain($me->id);
+});
+
+test('all scope shows the whole congregation', function (): void {
+    $user = careUser();
+    $me = $user->person;
+    $shepherd = Person::factory()->create();
+    $someone = Person::factory()->create(['pastoral_care_elder_id' => $shepherd->id]);
+
+    $component = Livewire::actingAs($user)
+        ->test('pages::pastoral-care.index')
+        ->set('scope', 'all');
+
+    $ids = $component->instance()->people->pluck('id');
+    expect($ids)->toContain($someone->id)->toContain($me->id);
+});
+
+test('the first stat card label switches with scope', function (): void {
+    Livewire::actingAs(careUser())
+        ->test('pages::pastoral-care.index')
+        ->assertSee('Under your care')
+        ->set('scope', 'all')
+        ->assertSee('In the congregation');
+});
+
+test('stats count open requests and people awaiting baptism within the scope', function (): void {
+    $user = careUser();
+    $me = $user->person;
+    $assignee = Person::factory()->create(['pastoral_care_elder_id' => $me->id, 'baptized' => false]);
+    PrayerRequest::factory()->open()->for($assignee)->create();
+    PrayerRequest::factory()->completed()->for($assignee)->create();
+
+    $stats = Livewire::actingAs($user)->test('pages::pastoral-care.index')->instance()->stats;
+
+    expect($stats['count'])->toBe(1)
+        ->and($stats['openRequests'])->toBe(1)
+        ->and($stats['awaitingBaptism'])->toBe(1);
+});
+
+test('the sidebar links to pastoral care only for pastoral-care users', function (): void {
+    $this->actingAs(User::factory()->create())
+        ->get(route('people.index'))
+        ->assertDontSee('Pastoral Care');
+
+    $this->actingAs(careUser())
+        ->get(route('people.index'))
+        ->assertSee('Pastoral Care');
+});

--- a/tests/Feature/PastoralNotes/PastoralNotePolicyTest.php
+++ b/tests/Feature/PastoralNotes/PastoralNotePolicyTest.php
@@ -1,0 +1,78 @@
+<?php
+
+use App\Enums\AccessRole;
+use App\Models\PastoralNote;
+use App\Models\Person;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+function userWithRole(?AccessRole $role): User
+{
+    $user = User::factory()->create();
+
+    if ($role !== null) {
+        $user->grantAccessRole($role);
+    }
+
+    return $user;
+}
+
+test('a pastoral note belongs to a person and an author', function (): void {
+    $person = Person::factory()->create();
+    $author = User::factory()->create();
+    $note = PastoralNote::factory()->for($person)->state(['author_id' => $author->id])->create();
+
+    expect($note->person->is($person))->toBeTrue()
+        ->and($note->author->is($author))->toBeTrue();
+});
+
+test('a person has many pastoral notes', function (): void {
+    $person = Person::factory()->create();
+    PastoralNote::factory()->count(2)->for($person)->create();
+    PastoralNote::factory()->create();
+
+    expect($person->pastoralNotes)->toHaveCount(2);
+});
+
+test('pastoral-care users can view and create notes', function (): void {
+    $user = userWithRole(AccessRole::PASTORAL_CARE_USER);
+    $note = PastoralNote::factory()->create();
+
+    expect($user->can('viewAny', PastoralNote::class))->toBeTrue()
+        ->and($user->can('view', $note))->toBeTrue()
+        ->and($user->can('create', PastoralNote::class))->toBeTrue();
+});
+
+test('users without pastoral-care access cannot view or create notes', function (): void {
+    $user = userWithRole(AccessRole::LITURGY_USER);
+    $note = PastoralNote::factory()->create();
+
+    expect($user->can('viewAny', PastoralNote::class))->toBeFalse()
+        ->and($user->can('view', $note))->toBeFalse()
+        ->and($user->can('create', PastoralNote::class))->toBeFalse();
+});
+
+test('admins can access notes through the admin role', function (): void {
+    $user = userWithRole(AccessRole::ADMIN);
+    $note = PastoralNote::factory()->create();
+
+    expect($user->can('view', $note))->toBeTrue()
+        ->and($user->can('create', PastoralNote::class))->toBeTrue();
+});
+
+test('only the author or an admin can update or delete a note', function (): void {
+    $author = userWithRole(AccessRole::PASTORAL_CARE_USER);
+    $otherCareUser = userWithRole(AccessRole::PASTORAL_CARE_USER);
+    $careAdmin = userWithRole(AccessRole::PASTORAL_CARE_ADMIN);
+
+    $note = PastoralNote::factory()->state(['author_id' => $author->id])->create();
+
+    expect($author->can('update', $note))->toBeTrue()
+        ->and($author->can('delete', $note))->toBeTrue()
+        ->and($otherCareUser->can('update', $note))->toBeFalse()
+        ->and($otherCareUser->can('delete', $note))->toBeFalse()
+        ->and($careAdmin->can('update', $note))->toBeTrue()
+        ->and($careAdmin->can('delete', $note))->toBeTrue();
+});

--- a/tests/Feature/People/RowActionTest.php
+++ b/tests/Feature/People/RowActionTest.php
@@ -1,0 +1,20 @@
+<?php
+
+use App\Models\Person;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function (): void {
+    $this->actingAs(User::factory()->create());
+});
+
+test('the people list exposes a pastoral-care action linking to the person page', function (): void {
+    $person = Person::factory()->create();
+
+    $this->get('/people')
+        ->assertOk()
+        ->assertSeeHtml(route('people.show', $person))
+        ->assertSeeHtml('Open pastoral care');
+});

--- a/tests/Feature/People/ShowPageTest.php
+++ b/tests/Feature/People/ShowPageTest.php
@@ -1,0 +1,164 @@
+<?php
+
+use App\Enums\AccessRole;
+use App\Enums\PrayerRequestVisibility;
+use App\Models\Group;
+use App\Models\PastoralNote;
+use App\Models\Person;
+use App\Models\PrayerRequest;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+function actingCareUser(): User
+{
+    $user = User::factory()->create();
+    $user->grantAccessRole(AccessRole::PASTORAL_CARE_USER);
+
+    return $user;
+}
+
+test('renders the person page with profile and cards', function (): void {
+    $person = Person::factory()->create(['first_name' => 'Mark', 'last_name' => 'Aldridge']);
+
+    $this->actingAs(User::factory()->create())
+        ->get(route('people.show', $person))
+        ->assertOk()
+        ->assertSee('Mark Aldridge')
+        ->assertSee('Profile')
+        ->assertSee('Prayer Requests');
+});
+
+test('the edit profile button is wired to open the drawer', function (): void {
+    $person = Person::factory()->create();
+
+    $this->actingAs(User::factory()->create())
+        ->get(route('people.show', $person))
+        ->assertSeeHtml('open-person-drawer');
+});
+
+test('adds a prayer request attributed to the current user', function (): void {
+    $user = User::factory()->create();
+    $person = Person::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test('pages::people.show', ['person' => $person])
+        ->set('newRequestBody', 'Pray for safe travels')
+        ->set('newRequestVisibility', 'private')
+        ->call('addPrayerRequest')
+        ->assertHasNoErrors();
+
+    $request = PrayerRequest::query()->first();
+    expect($request->body)->toBe('Pray for safe travels')
+        ->and($request->visibility)->toBe(PrayerRequestVisibility::PRIVATE)
+        ->and($request->created_by_user_id)->toBe($user->id)
+        ->and($request->person_id)->toBe($person->id);
+});
+
+test('show completed toggle hides old completed requests', function (): void {
+    $person = Person::factory()->create();
+    PrayerRequest::factory()->open()->for($person)->create();
+    PrayerRequest::factory()->for($person)->state(['completed_at' => now()->subDays(2)])->create();
+    PrayerRequest::factory()->for($person)->state(['completed_at' => now()->subDays(30)])->create();
+
+    $component = Livewire::actingAs(User::factory()->create())
+        ->test('pages::people.show', ['person' => $person]);
+
+    expect($component->instance()->prayerRequests)->toHaveCount(2)
+        ->and($component->instance()->hiddenCompletedCount)->toBe(1);
+
+    $component->set('showCompleted', true);
+
+    expect($component->instance()->prayerRequests)->toHaveCount(3)
+        ->and($component->instance()->hiddenCompletedCount)->toBe(0);
+});
+
+test('toggling a request completes and reopens it', function (): void {
+    $person = Person::factory()->create();
+    $request = PrayerRequest::factory()->open()->for($person)->create();
+
+    $component = Livewire::actingAs(User::factory()->create())
+        ->test('pages::people.show', ['person' => $person])
+        ->call('toggleComplete', $request->id);
+
+    expect($request->refresh()->completed_at)->not->toBeNull();
+
+    $component->call('toggleComplete', $request->id);
+
+    expect($request->refresh()->completed_at)->toBeNull();
+});
+
+test('pastoral notes are hidden from users without pastoral-care access', function (): void {
+    $person = Person::factory()->create();
+
+    $this->actingAs(User::factory()->create())
+        ->get(route('people.show', $person))
+        ->assertDontSee('Pastoral Notes');
+});
+
+test('pastoral-care users can add a note', function (): void {
+    $user = actingCareUser();
+    $person = Person::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test('pages::people.show', ['person' => $person])
+        ->set('newNote', 'Met for coffee — encouraged.')
+        ->call('addNote')
+        ->assertHasNoErrors();
+
+    $note = PastoralNote::query()->first();
+    expect($note->body)->toBe('Met for coffee — encouraged.')
+        ->and($note->author_id)->toBe($user->id)
+        ->and($note->person_id)->toBe($person->id);
+});
+
+test('adding a note is forbidden without pastoral-care access', function (): void {
+    $person = Person::factory()->create();
+
+    Livewire::actingAs(User::factory()->create())
+        ->test('pages::people.show', ['person' => $person])
+        ->set('newNote', 'Should not save')
+        ->call('addNote')
+        ->assertForbidden();
+
+    expect(PastoralNote::count())->toBe(0);
+});
+
+test('the messages panel is hidden when the person has no user account', function (): void {
+    $person = Person::factory()->create();
+
+    $this->actingAs(User::factory()->create())
+        ->get(route('people.show', $person))
+        ->assertDontSee('Direct conversation with');
+});
+
+test('the messages panel shows when the person has a user account', function (): void {
+    $other = User::factory()->create();
+
+    $this->actingAs(User::factory()->create())
+        ->get(route('people.show', $other->person))
+        ->assertSee('Direct conversation with');
+});
+
+test('sending a message creates the direct conversation', function (): void {
+    $me = User::factory()->create();
+    $other = User::factory()->create();
+
+    // Merely rendering the panel must not create a conversation.
+    Livewire::actingAs($me)->test('people.messages-panel', ['person' => $other->person]);
+    expect(Group::query()->direct()->count())->toBe(0);
+
+    Livewire::actingAs($me)
+        ->test('people.messages-panel', ['person' => $other->person])
+        ->set('reply', '<p>Praying for you this week.</p>')
+        ->call('send')
+        ->assertHasNoErrors();
+
+    $key = Group::directKeyFor([$me->id, $other->id]);
+    $group = Group::query()->direct()->where('direct_key', $key)->first();
+
+    expect($group)->not->toBeNull()
+        ->and($group->directConversation->comments()->count())->toBe(1);
+});

--- a/tests/Feature/PrayerRequests/PrayerRequestModelTest.php
+++ b/tests/Feature/PrayerRequests/PrayerRequestModelTest.php
@@ -1,0 +1,67 @@
+<?php
+
+use App\Enums\PrayerRequestVisibility;
+use App\Models\Person;
+use App\Models\PrayerRequest;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+test('a person has many prayer requests', function (): void {
+    $person = Person::factory()->create();
+    PrayerRequest::factory()->count(3)->for($person)->create();
+    PrayerRequest::factory()->create();
+
+    expect($person->prayerRequests)->toHaveCount(3);
+});
+
+test('open scope returns only requests without a completion date', function (): void {
+    PrayerRequest::factory()->count(2)->open()->create();
+    PrayerRequest::factory()->completed()->create();
+
+    expect(PrayerRequest::open()->count())->toBe(2);
+});
+
+test('completed scope returns only requests with a completion date', function (): void {
+    PrayerRequest::factory()->count(2)->open()->create();
+    PrayerRequest::factory()->completed()->create();
+
+    expect(PrayerRequest::completed()->count())->toBe(1);
+});
+
+test('bulletin scope returns only bulletin-visibility requests', function (): void {
+    PrayerRequest::factory()->count(2)->bulletin()->create();
+    PrayerRequest::factory()->private()->create();
+
+    expect(PrayerRequest::bulletin()->count())->toBe(2);
+});
+
+test('visibility is cast to the enum and completed_at to a datetime', function (): void {
+    $request = PrayerRequest::factory()->private()->completed('2026-06-10 09:00:00')->create();
+
+    $request->refresh();
+
+    expect($request->visibility)->toBe(PrayerRequestVisibility::PRIVATE)
+        ->and($request->completed_at)->not->toBeNull()
+        ->and($request->isOpen())->toBeFalse();
+});
+
+test('open requests count can be eager loaded on a person', function (): void {
+    $person = Person::factory()->create();
+    PrayerRequest::factory()->count(2)->open()->for($person)->create();
+    PrayerRequest::factory()->completed()->for($person)->create();
+
+    $loaded = Person::query()
+        ->withCount(['prayerRequests as open_prayer_requests_count' => fn ($query) => $query->whereNull('completed_at')])
+        ->find($person->id);
+
+    expect($loaded->open_prayer_requests_count)->toBe(2);
+});
+
+test('a prayer request tracks the user who created it', function (): void {
+    $user = User::factory()->create();
+    $request = PrayerRequest::factory()->state(['created_by_user_id' => $user->id])->create();
+
+    expect($request->createdBy->is($user))->toBeTrue();
+});

--- a/tests/Feature/PrayerSchedule/IndexTest.php
+++ b/tests/Feature/PrayerSchedule/IndexTest.php
@@ -1,0 +1,86 @@
+<?php
+
+use App\Enums\AccessRole;
+use App\Models\Person;
+use App\Models\PrayerScheduleSettings;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+function schedulePlanner(): User
+{
+    $user = User::factory()->create();
+    $user->grantAccessRole(AccessRole::PASTORAL_CARE_USER);
+
+    return $user;
+}
+
+test('non pastoral-care users cannot access the schedule', function (): void {
+    $this->actingAs(User::factory()->create())
+        ->get(route('prayer-schedule.index'))
+        ->assertForbidden();
+});
+
+test('pastoral-care users can view the schedule', function (): void {
+    $this->actingAs(schedulePlanner())
+        ->get(route('prayer-schedule.index'))
+        ->assertOk()
+        ->assertSee('Prayer Schedule');
+});
+
+test('toggling a status chip updates and persists the included statuses', function (): void {
+    Livewire::actingAs(schedulePlanner())
+        ->test('pages::prayer-schedule.index')
+        ->assertSet('includeStatuses', ['member', 'catechumen'])
+        ->call('toggleStatus', 'catechumen')
+        ->assertSet('includeStatuses', ['member'])
+        ->call('toggleStatus', 'adherent')
+        ->assertSet('includeStatuses', ['member', 'adherent']);
+
+    expect(PrayerScheduleSettings::current()->include_statuses)->toBe(['member', 'adherent']);
+});
+
+test('changing the cycle length persists and clamps to 4-13 weeks', function (): void {
+    $component = Livewire::actingAs(schedulePlanner())
+        ->test('pages::prayer-schedule.index')
+        ->call('incrementWeeks');
+
+    expect(PrayerScheduleSettings::current()->cycle_weeks)->toBe(9);
+
+    foreach (range(1, 10) as $ignored) {
+        $component->call('decrementWeeks');
+    }
+
+    $component->assertSet('cycleWeeks', 4);
+    expect(PrayerScheduleSettings::current()->cycle_weeks)->toBe(4);
+});
+
+test('switching between weeks and roster views', function (): void {
+    Livewire::actingAs(schedulePlanner())
+        ->test('pages::prayer-schedule.index')
+        ->assertSet('view', 'weeks')
+        ->set('view', 'roster')
+        ->assertSet('view', 'roster')
+        ->assertSee('Prayer week');
+});
+
+test('the rotation only includes the selected statuses', function (): void {
+    $member = Person::factory()->member()->create(['last_name' => 'Aaa']);
+    $catechumen = Person::factory()->catechumen()->create(['last_name' => 'Bbb']);
+    $adherent = Person::factory()->adherent()->create(['last_name' => 'Ccc']);
+
+    $component = Livewire::actingAs(schedulePlanner())->test('pages::prayer-schedule.index');
+
+    $ids = $component->instance()->buckets->flatten(1)->pluck('id');
+
+    expect($ids)->toContain($member->id)
+        ->toContain($catechumen->id)
+        ->not->toContain($adherent->id);
+
+    $component->call('toggleStatus', 'adherent');
+    $ids = $component->instance()->buckets->flatten(1)->pluck('id');
+
+    expect($ids)->toContain($adherent->id);
+});

--- a/tests/Feature/PrayerSchedule/MondayEmailTest.php
+++ b/tests/Feature/PrayerSchedule/MondayEmailTest.php
@@ -1,0 +1,128 @@
+<?php
+
+use App\Enums\MembershipStatus;
+use App\Mail\PrayerScheduleDigestMail;
+use App\Models\PastoralNote;
+use App\Models\Person;
+use App\Models\PersonOffice;
+use App\Models\PrayerRequest;
+use App\Models\PrayerScheduleSettings;
+use App\Models\User;
+use App\Services\PrayerScheduleService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Mail;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Collapse the cycle to a single week so everyone is scheduled in the current
+ * week, making the command's output deterministic.
+ */
+function singleWeekSchedule(): void
+{
+    PrayerScheduleSettings::current()->update([
+        'cycle_weeks' => 1,
+        'anchor_date' => Carbon::now()->startOfWeek(Carbon::MONDAY),
+        'include_statuses' => [MembershipStatus::MEMBER->value, MembershipStatus::CATECHUMEN->value],
+    ]);
+}
+
+function makeElder(): User
+{
+    $person = Person::factory()->member()->create();
+    PersonOffice::factory()->elder()->for($person)->create();
+
+    return User::factory()->create(['person_id' => $person->id]);
+}
+
+test('the email is queued to elders with accounts but not to non-elders', function (): void {
+    Mail::fake();
+    singleWeekSchedule();
+
+    $elder = makeElder();
+    $nonElder = User::factory()->create();
+    Person::factory()->member()->create();
+
+    $this->artisan('stave:send-prayer-schedule')->assertSuccessful();
+
+    Mail::assertQueued(PrayerScheduleDigestMail::class, fn (PrayerScheduleDigestMail $mail): bool => $mail->hasTo($elder->email));
+    Mail::assertNotQueued(PrayerScheduleDigestMail::class, fn (PrayerScheduleDigestMail $mail): bool => $mail->hasTo($nonElder->email));
+});
+
+test('the email contains only open bulletin requests', function (): void {
+    Mail::fake();
+    singleWeekSchedule();
+    makeElder();
+
+    $subject = Person::factory()->member()->create();
+    PrayerRequest::factory()->open()->bulletin()->for($subject)->create(['body' => 'Open bulletin request']);
+    PrayerRequest::factory()->open()->private()->for($subject)->create(['body' => 'Secret private request']);
+    PrayerRequest::factory()->bulletin()->completed()->for($subject)->create(['body' => 'Already answered request']);
+    PastoralNote::factory()->for($subject)->create(['body' => 'Confidential pastoral note']);
+
+    $this->artisan('stave:send-prayer-schedule')->assertSuccessful();
+
+    Mail::assertQueued(PrayerScheduleDigestMail::class, function (PrayerScheduleDigestMail $mail): bool {
+        $bodies = collect($mail->people)->flatMap(fn (array $person): array => $person['requests']);
+
+        return $bodies->contains('Open bulletin request')
+            && ! $bodies->contains('Secret private request')
+            && ! $bodies->contains('Already answered request')
+            && ! $bodies->contains('Confidential pastoral note');
+    });
+});
+
+test('the rendered email never leaks private content', function (): void {
+    singleWeekSchedule();
+    $elder = makeElder();
+
+    $subject = Person::factory()->member()->create();
+    PrayerRequest::factory()->open()->bulletin()->for($subject)->create(['body' => 'Pray for the bulletin item']);
+    PrayerRequest::factory()->open()->private()->for($subject)->create(['body' => 'Hidden private item']);
+
+    $service = app(PrayerScheduleService::class);
+    $settings = PrayerScheduleSettings::current();
+    $mail = new PrayerScheduleDigestMail(
+        recipient: $elder,
+        people: $service->bulletinDigestForWeek($settings, 0),
+        weekNumber: 1,
+        totalWeeks: 1,
+        weekRange: $service->weekRange($settings, 0),
+    );
+
+    $rendered = $mail->render();
+
+    expect($rendered)->toContain('Pray for the bulletin item')
+        ->and($rendered)->not->toContain('Hidden private item');
+});
+
+test('elders without a user account are skipped', function (): void {
+    Mail::fake();
+    singleWeekSchedule();
+
+    makeElder();
+    $accountlessElder = Person::factory()->member()->create();
+    PersonOffice::factory()->elder()->for($accountlessElder)->create();
+
+    $this->artisan('stave:send-prayer-schedule')
+        ->expectsOutputToContain('1 elder(s) have no user account')
+        ->assertSuccessful();
+
+    Mail::assertQueuedCount(1);
+});
+
+test('nothing is sent when no one is scheduled for the week', function (): void {
+    Mail::fake();
+    singleWeekSchedule();
+    makeElder();
+
+    // Exclude every status so the rotation is empty.
+    PrayerScheduleSettings::current()->update(['include_statuses' => []]);
+
+    $this->artisan('stave:send-prayer-schedule')
+        ->expectsOutputToContain('nothing to send')
+        ->assertSuccessful();
+
+    Mail::assertNothingQueued();
+});

--- a/tests/Feature/PrayerSchedule/RotationServiceTest.php
+++ b/tests/Feature/PrayerSchedule/RotationServiceTest.php
@@ -1,0 +1,190 @@
+<?php
+
+use App\Enums\HouseholdRole;
+use App\Enums\MembershipStatus;
+use App\Enums\PrayerScheduleGrouping;
+use App\Models\Household;
+use App\Models\Person;
+use App\Models\PrayerScheduleSettings;
+use App\Services\PrayerScheduleService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Map each person id to the week index it was placed in.
+ *
+ * @param  Collection<int, Collection<int, Person>>  $buckets
+ * @return array<int, int>
+ */
+function personWeekMap(Collection $buckets): array
+{
+    $map = [];
+    $buckets->each(function (Collection $week, int $index) use (&$map): void {
+        $week->each(function (Person $person) use (&$map, $index): void {
+            $map[$person->id] = $index;
+        });
+    });
+
+    return $map;
+}
+
+function buildCongregation(): void
+{
+    // Three multi-person households plus a couple of lone people, all members.
+    foreach (['Aldridge', 'Bellamy', 'Castellano'] as $surname) {
+        $household = Household::factory()->create(['name' => "{$surname} Household"]);
+        Person::factory()
+            ->count(3)
+            ->member()
+            ->inHousehold($household, HouseholdRole::OTHER)
+            ->create(['last_name' => $surname]);
+    }
+
+    Person::factory()->member()->create(['last_name' => 'Devereux', 'household_id' => null]);
+    Person::factory()->member()->create(['last_name' => 'Everett', 'household_id' => null]);
+}
+
+function settings(int $weeks, PrayerScheduleGrouping $groupBy): PrayerScheduleSettings
+{
+    $settings = PrayerScheduleSettings::current();
+    $settings->update([
+        'cycle_weeks' => $weeks,
+        'group_by' => $groupBy,
+        'include_statuses' => [MembershipStatus::MEMBER->value, MembershipStatus::CATECHUMEN->value],
+        'anchor_date' => '2026-01-05', // a Monday
+    ]);
+
+    return $settings->refresh();
+}
+
+test('the rotation is deterministic across calls', function (): void {
+    buildCongregation();
+    $service = new PrayerScheduleService();
+    $settings = settings(4, PrayerScheduleGrouping::ALPHA);
+
+    $first = $service->buckets($settings)->map(fn (Collection $w) => $w->pluck('id')->all())->all();
+    $second = $service->buckets($settings)->map(fn (Collection $w) => $w->pluck('id')->all())->all();
+
+    expect($first)->toBe($second);
+});
+
+test('no household is split across weeks in alphabetical mode', function (): void {
+    buildCongregation();
+    $service = new PrayerScheduleService();
+    $buckets = $service->buckets(settings(4, PrayerScheduleGrouping::ALPHA));
+
+    assertHouseholdsIntact($buckets);
+});
+
+test('no household is split across weeks in by-household mode', function (): void {
+    buildCongregation();
+    $service = new PrayerScheduleService();
+    $buckets = $service->buckets(settings(4, PrayerScheduleGrouping::HOUSEHOLD));
+
+    assertHouseholdsIntact($buckets);
+});
+
+function assertHouseholdsIntact(Collection $buckets): void
+{
+    $weekFor = personWeekMap($buckets);
+
+    Household::query()->with('people')->get()->each(function (Household $household) use ($weekFor): void {
+        $weeks = $household->people->pluck('id')->map(fn (int $id): int => $weekFor[$id])->unique();
+        expect($weeks)->toHaveCount(1, "Household {$household->name} was split across weeks");
+    });
+}
+
+test('alphabetical mode lays households out in contiguous surname order', function (): void {
+    buildCongregation();
+    $service = new PrayerScheduleService();
+    $buckets = $service->buckets(settings(4, PrayerScheduleGrouping::ALPHA));
+
+    $orderedSurnames = $buckets
+        ->flatMap(fn (Collection $week) => $week->pluck('last_name'))
+        ->values();
+
+    $sorted = $orderedSurnames->sort()->values();
+
+    expect($orderedSurnames->all())->toBe($sorted->all());
+});
+
+test('by-household mode balances per-week headcounts', function (): void {
+    buildCongregation();
+    $service = new PrayerScheduleService();
+    $buckets = $service->buckets(settings(4, PrayerScheduleGrouping::HOUSEHOLD));
+
+    $counts = $buckets->map(fn (Collection $week): int => $week->count());
+
+    // 11 people across 4 weeks: the spread should stay within one household's size.
+    expect($counts->max() - $counts->min())->toBeLessThanOrEqual(3)
+        ->and($counts->sum())->toBe(11);
+});
+
+test('terminated people are never scheduled', function (): void {
+    buildCongregation();
+    Person::factory()->create(['membership_status' => MembershipStatus::TERMINATED, 'last_name' => 'Zephyr']);
+
+    $service = new PrayerScheduleService();
+    // Even if a caller passes terminated explicitly, it is excluded.
+    $buckets = $service->buckets(settings(4, PrayerScheduleGrouping::ALPHA), [
+        MembershipStatus::MEMBER->value,
+        MembershipStatus::TERMINATED->value,
+    ]);
+
+    $names = $buckets->flatMap(fn (Collection $week) => $week->pluck('last_name'));
+
+    expect($names)->not->toContain('Zephyr');
+});
+
+test('status override changes who is included', function (): void {
+    buildCongregation();
+    Person::factory()->adherent()->create(['last_name' => 'Quint', 'household_id' => null]);
+
+    $service = new PrayerScheduleService();
+    $settings = settings(4, PrayerScheduleGrouping::ALPHA);
+
+    $withoutAdherents = $service->buckets($settings)->flatMap(fn (Collection $w) => $w->pluck('last_name'));
+    expect($withoutAdherents)->not->toContain('Quint');
+
+    $withAdherents = $service->buckets($settings, [
+        MembershipStatus::MEMBER->value,
+        MembershipStatus::ADHERENT->value,
+    ])->flatMap(fn (Collection $w) => $w->pluck('last_name'));
+    expect($withAdherents)->toContain('Quint');
+});
+
+test('current week index advances and wraps around the cycle', function (): void {
+    $settings = settings(8, PrayerScheduleGrouping::ALPHA); // anchor 2026-01-05 (Mon)
+    $service = new PrayerScheduleService();
+
+    Carbon::setTestNow('2026-01-07'); // same week as anchor
+    expect($service->currentWeekIndex($settings))->toBe(0);
+
+    Carbon::setTestNow('2026-01-26'); // 3 weeks later
+    expect($service->currentWeekIndex($settings))->toBe(3);
+
+    Carbon::setTestNow('2026-03-02'); // 8 weeks later -> wraps to 0
+    expect($service->currentWeekIndex($settings))->toBe(0);
+
+    Carbon::setTestNow('2026-03-16'); // 10 weeks later -> 2
+    expect($service->currentWeekIndex($settings))->toBe(2);
+
+    Carbon::setTestNow();
+});
+
+test('stats summarise the rotation', function (): void {
+    buildCongregation();
+    $service = new PrayerScheduleService();
+
+    Carbon::setTestNow('2026-01-05');
+    $stats = $service->stats(settings(4, PrayerScheduleGrouping::ALPHA));
+    Carbon::setTestNow();
+
+    expect($stats['total'])->toBe(11)
+        ->and($stats['weeks'])->toBe(4)
+        ->and($stats['perWeek'])->toBe(3)
+        ->and($stats['currentWeekIndex'])->toBe(0);
+});


### PR DESCRIPTION
## Summary

- Adds prayer requests and pastoral notes domains with models, factories, migrations, and policies
- Builds a prayer schedule rotation engine that distributes the congregation across configurable weekly cycles, keeping households together
- Adds person detail page with prayer requests, pastoral notes, and direct messaging panels
- Adds pastoral care overview page showing assignees, open requests, and baptism stats with mine/all scoping
- Adds prayer schedule page with week/roster views, status filtering, and email preview
- Sends a weekly Monday digest email to elders with the current week's prayer rota (bulletin-visibility requests only)
- Gates pastoral care surfaces behind access roles; prayer requests are accessible to all authenticated users

## Test plan

- [x] PrayerRequest model scopes and relationships
- [x] PastoralNote policy (view/create/update/delete by role)
- [x] Rotation service determinism, household integrity, week wrapping, status filtering
- [x] Monday email sends to elders only, excludes private requests and pastoral notes
- [x] Pastoral care index authorization, scope toggling, stat accuracy
- [x] Prayer schedule index controls, status chip persistence, view switching
- [x] Person show page: add/toggle requests, add notes, authorization, messaging

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Prayer request submission and tracking with public/private visibility options
  * Automated weekly prayer schedule digest emails for elders
  * Pastoral care dashboard displaying statistics, assignments, and congregational overview
  * Pastoral notes management for authorized users
  * Prayer schedule configuration interface for cycle weeks and grouping methods
  * Direct messaging capabilities for pastoral care access
  * Enhanced person profiles with integrated prayer requests, pastoral notes, and messages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->