### PR TITLE
Fix responsive layout on people and prayer schedule pages

### DIFF
--- a/resources/views/pages/people/show.blade.php
+++ b/resources/views/pages/people/show.blade.php
@@ -218,7 +218,7 @@ new class extends Component
         </flux:button>
     </div>
 
-    <div class="grid grid-cols-1 items-start gap-6 lg:grid-cols-[1fr_340px]">
+    <div class="grid grid-cols-1 items-start gap-6 md:grid-cols-[1fr_340px]">
         {{-- LEFT --}}
         <div class="space-y-6">
             {{-- Prayer Requests --}}
@@ -328,7 +328,7 @@ new class extends Component
         </div>
 
         {{-- RIGHT: read-only profile --}}
-        <flux:card class="overflow-hidden !p-0 lg:sticky lg:top-6" data-test="profile">
+        <flux:card class="overflow-hidden !p-0 md:sticky md:top-6" data-test="profile">
             <div class="flex items-center gap-3 border-b border-zinc-200 px-5 py-4 dark:border-zinc-700">
                 <flux:icon icon="identification" class="size-5 text-zinc-500" />
                 <flux:heading size="lg">Profile</flux:heading>

--- a/resources/views/pages/prayer-schedule/index.blade.php
+++ b/resources/views/pages/prayer-schedule/index.blade.php
@@ -185,60 +185,64 @@ new class extends Component
     </div>
 
     {{-- Controls --}}
-    <flux:card class="mb-3 flex flex-wrap items-center gap-x-6 gap-y-4 !p-4">
-        <div class="flex items-center gap-2.5">
-            <span class="text-xs font-semibold text-zinc-500">Cycle length</span>
-            <div class="inline-flex items-center overflow-hidden rounded-lg border border-zinc-200 dark:border-zinc-700">
-                <flux:button size="xs" variant="subtle" icon="minus" wire:click="decrementWeeks" aria-label="Fewer weeks" />
-                <span class="min-w-16 text-center text-sm font-semibold">{{ $cycleWeeks }} weeks</span>
-                <flux:button size="xs" variant="subtle" icon="plus" wire:click="incrementWeeks" aria-label="More weeks" />
+    <flux:card class="mb-3 flex flex-wrap items-start justify-between gap-4 !p-4">
+        <div class="flex flex-wrap items-center gap-x-6 gap-y-4">
+            <div class="flex items-center gap-2.5">
+                <span class="text-xs font-semibold text-zinc-500">Cycle length</span>
+                <div class="inline-flex items-center overflow-hidden rounded-lg border border-zinc-200 dark:border-zinc-700">
+                    <flux:button size="xs" variant="subtle" icon="minus" wire:click="decrementWeeks" aria-label="Fewer weeks" />
+                    <span class="min-w-16 text-center text-sm font-semibold">{{ $cycleWeeks }} weeks</span>
+                    <flux:button size="xs" variant="subtle" icon="plus" wire:click="incrementWeeks" aria-label="More weeks" />
+                </div>
+            </div>
+
+            <div class="flex items-center gap-2.5">
+                <span class="text-xs font-semibold text-zinc-500">Include</span>
+                <div class="flex flex-wrap gap-1.5" data-test="status-chips">
+                    @foreach ([MembershipStatus::MEMBER, MembershipStatus::CATECHUMEN, MembershipStatus::ADHERENT, MembershipStatus::VISITOR] as $status)
+                        @php($on = in_array($status->value, $includeStatuses, true))
+                        <button
+                            type="button"
+                            wire:click="toggleStatus('{{ $status->value }}')"
+                            @class([
+                                'inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-semibold transition',
+                                'border-emerald-600 bg-emerald-50 text-emerald-700 dark:border-emerald-500 dark:bg-emerald-950/50 dark:text-emerald-300' => $on,
+                                'border-zinc-200 text-zinc-500 hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800' => ! $on,
+                            ])
+                            data-test="status-chip-{{ $status->value }}"
+                            @if ($on) data-on="true" @endif
+                        >
+                            @if ($on)
+                                <flux:icon icon="check" variant="micro" class="size-3.5" />
+                            @endif
+                            {{ $status->label() }}
+                        </button>
+                    @endforeach
+                </div>
+            </div>
+
+            <div class="flex items-center gap-2.5">
+                <span class="text-xs font-semibold text-zinc-500">Group by</span>
+                <flux:radio.group variant="segmented" size="sm" wire:model.live="groupBy">
+                    <flux:radio value="alpha">Alphabetical</flux:radio>
+                    <flux:radio value="household">By household</flux:radio>
+                </flux:radio.group>
+            </div>
+
+            <div class="flex items-center gap-2.5">
+                <span class="text-xs font-semibold text-zinc-500">View</span>
+                <flux:radio.group variant="segmented" size="sm" wire:model.live="view">
+                    <flux:radio value="weeks">Weeks</flux:radio>
+                    <flux:radio value="roster">Roster</flux:radio>
+                </flux:radio.group>
             </div>
         </div>
 
-        <div class="flex items-center gap-2.5">
-            <span class="text-xs font-semibold text-zinc-500">Include</span>
-            <div class="flex flex-wrap gap-1.5" data-test="status-chips">
-                @foreach ([MembershipStatus::MEMBER, MembershipStatus::CATECHUMEN, MembershipStatus::ADHERENT, MembershipStatus::VISITOR] as $status)
-                    @php($on = in_array($status->value, $includeStatuses, true))
-                    <button
-                        type="button"
-                        wire:click="toggleStatus('{{ $status->value }}')"
-                        @class([
-                            'inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-semibold transition',
-                            'border-emerald-600 bg-emerald-50 text-emerald-700 dark:border-emerald-500 dark:bg-emerald-950/50 dark:text-emerald-300' => $on,
-                            'border-zinc-200 text-zinc-500 hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800' => ! $on,
-                        ])
-                        data-test="status-chip-{{ $status->value }}"
-                        @if ($on) data-on="true" @endif
-                    >
-                        @if ($on)
-                            <flux:icon icon="check" variant="micro" class="size-3.5" />
-                        @endif
-                        {{ $status->label() }}
-                    </button>
-                @endforeach
-            </div>
+        <div>
+            <flux:button size="sm" variant="primary" icon="envelope" wire:click="previewEmail" data-test="preview-email">
+                Preview Monday email
+            </flux:button>
         </div>
-
-        <div class="flex items-center gap-2.5">
-            <span class="text-xs font-semibold text-zinc-500">Group by</span>
-            <flux:radio.group variant="segmented" size="sm" wire:model.live="groupBy">
-                <flux:radio value="alpha">Alphabetical</flux:radio>
-                <flux:radio value="household">By household</flux:radio>
-            </flux:radio.group>
-        </div>
-
-        <div class="flex items-center gap-2.5">
-            <span class="text-xs font-semibold text-zinc-500">View</span>
-            <flux:radio.group variant="segmented" size="sm" wire:model.live="view">
-                <flux:radio value="weeks">Weeks</flux:radio>
-                <flux:radio value="roster">Roster</flux:radio>
-            </flux:radio.group>
-        </div>
-
-        <flux:button class="ms-auto" size="sm" variant="primary" icon="envelope" wire:click="previewEmail" data-test="preview-email">
-            Preview Monday email
-        </flux:button>
     </flux:card>
 
     <p class="mb-5 text-sm text-zinc-500" data-test="stat-line">{{ $this->statLine() }}</p>


### PR DESCRIPTION
## Summary

- **People show page:** Lower the two-column grid breakpoint from `lg` to `md` so the sidebar profile card appears alongside the main content on medium-width screens. The sticky behavior follows the same breakpoint.
- **Prayer schedule controls:** Restructure the controls card to separate filter controls from the action button using `justify-between`, improving layout when controls wrap on narrower viewports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined responsive design on the people profile page—layout elements now adapt at medium screen sizes instead of large, improving mobile and tablet viewing experience.
  * Reorganized the prayer schedule controls interface with improved spacing, padding, and button positioning for enhanced usability and visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->