### PR TITLE
Sort household members by role priority

### DIFF
--- a/app/Enums/HouseholdRole.php
+++ b/app/Enums/HouseholdRole.php
@@ -20,4 +20,15 @@ enum HouseholdRole: string
             self::OTHER => 'Other',
         };
     }
+
+    public function sortOrder(): int
+    {
+        return match ($this) {
+            self::HEAD_OF_HOUSEHOLD => 1,
+            self::SPOUSE => 2,
+            self::DEPENDENT => 3,
+            self::CHILD => 4,
+            self::OTHER => 5,
+        };
+    }
 }

--- a/resources/views/pages/households/index.blade.php
+++ b/resources/views/pages/households/index.blade.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\Household;
+use App\Models\Person;
 use Flux\Flux;
 use Illuminate\Database\Eloquent\Collection;
 use Livewire\Attributes\Computed;
@@ -25,7 +26,13 @@ new class extends Component
     {
         return Household::with(['people' => fn ($q) => $q->orderBy('last_name')->orderBy('first_name')])
             ->orderBy('name')
-            ->get();
+            ->get()
+            ->each(fn (Household $household) => $household->setRelation(
+                'people',
+                $household->people
+                    ->sortBy(fn (Person $person) => $person->household_role?->sortOrder() ?? PHP_INT_MAX)
+                    ->values()
+            ));
     }
 
     public function openNew(): void

--- a/tests/Feature/Households/IndexTest.php
+++ b/tests/Feature/Households/IndexTest.php
@@ -24,6 +24,34 @@ test('renders the households index', function (): void {
         ->assertSee('Child');
 });
 
+test('lists members ordered by household role then alphabetically', function (): void {
+    $household = Household::factory()->create();
+
+    Person::factory()->inHousehold($household, HouseholdRole::OTHER)->create(['first_name' => 'Olive', 'last_name' => 'Zane']);
+    Person::factory()->inHousehold($household, HouseholdRole::CHILD)->create(['first_name' => 'Cara', 'last_name' => 'Young']);
+    Person::factory()->inHousehold($household, HouseholdRole::CHILD)->create(['first_name' => 'Adam', 'last_name' => 'Adams']);
+    Person::factory()->inHousehold($household, HouseholdRole::DEPENDENT)->create(['first_name' => 'Dana', 'last_name' => 'Doe']);
+    Person::factory()->inHousehold($household, HouseholdRole::SPOUSE)->create(['first_name' => 'Sam', 'last_name' => 'Smith']);
+    Person::factory()->inHousehold($household, HouseholdRole::HEAD_OF_HOUSEHOLD)->create(['first_name' => 'Hana', 'last_name' => 'Hill']);
+    Person::factory()->create(['household_id' => $household->id, 'household_role' => null, 'first_name' => 'Nora', 'last_name' => 'Null']);
+
+    $households = Livewire::test('pages::households.index')->instance()->households;
+
+    $roles = $households->firstWhere('id', $household->id)->people
+        ->map(fn (Person $person) => [$person->household_role?->value, $person->full_name])
+        ->all();
+
+    expect($roles)->toBe([
+        ['head_of_household', 'Hana Hill'],
+        ['spouse', 'Sam Smith'],
+        ['dependent', 'Dana Doe'],
+        ['child', 'Adam Adams'],
+        ['child', 'Cara Young'],
+        ['other', 'Olive Zane'],
+        [null, 'Nora Null'],
+    ]);
+});
+
 test('shows empty state when no households exist', function (): void {
     $this->get('/households')->assertOk()->assertSee('No households yet');
 });


### PR DESCRIPTION
## Summary
- Adds a `sortOrder()` method to the `HouseholdRole` enum to define role priority (head of household > spouse > dependent > child > other)
- Sorts household members by role on the index page, with null roles appearing last and alphabetical order preserved within the same role
- Adds a test verifying the full ordering behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Household member lists now appear in a consistent, role-based order.
  * Members are grouped by household role, then sorted alphabetically within each role.

* **Tests**
  * Added coverage to verify the household index displays members in the expected order, including entries without a role.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->