### PR TITLE
Add public bulletin view for follow-along worship services

### DIFF
--- a/app/Models/Reading.php
+++ b/app/Models/Reading.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Mews\Purifier\Casts\CleanHtmlInput;
 
 /**
  * @property ReadingType $type
@@ -31,6 +32,7 @@ class Reading extends Model
         return [
             'type' => ReadingType::class,
             'last_used_date' => 'date',
+            'text' => CleanHtmlInput::class.':rich_text',
         ];
     }
 

--- a/app/Models/Service.php
+++ b/app/Models/Service.php
@@ -5,6 +5,8 @@ namespace App\Models;
 use App\Enums\LiturgyElementType;
 use Database\Factories\ServiceFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\Scope;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -32,6 +34,29 @@ class Service extends Model
         return [
             'date' => 'date',
         ];
+    }
+
+    /**
+     * Services on or after today, soonest first.
+     *
+     * @param  Builder<Service>  $query
+     * @return Builder<Service>
+     */
+    #[Scope]
+    protected function upcoming(Builder $query): Builder
+    {
+        return $query->whereDate('date', '>=', today())
+            ->orderBy('date')
+            ->orderBy('id');
+    }
+
+    /**
+     * The service a congregant is most likely following right now:
+     * the soonest service on or after today.
+     */
+    public static function current(): ?self
+    {
+        return static::query()->upcoming()->first();
     }
 
     /** @return BelongsTo<Template, $this> */

--- a/app/Models/Song.php
+++ b/app/Models/Song.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Mews\Purifier\Casts\CleanHtmlInput;
 
 #[Fillable(['name', 'authors', 'ccli_number', 'copyright', 'lyrics'])]
 class Song extends Model
@@ -26,6 +27,7 @@ class Song extends Model
     {
         return [
             'last_used_date' => 'date',
+            'lyrics' => CleanHtmlInput::class.':rich_text',
         ];
     }
 

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -377,6 +377,35 @@ a.mention:hover {
     @apply bg-accent/10 text-accent-content;
 }
 
+/* ----------------------------------------------------------
+   Public bulletin (follow-along) body text. The wrapper's
+   font-size carries the A− / A+ reader scale; everything
+   inside is em-relative so arbitrary editor HTML scales too.
+   ---------------------------------------------------------- */
+.bulletin-body {
+    font-size: calc(var(--reader-scale, 1) * 1.0625rem);
+    line-height: 1.65;
+}
+
+@media (width >= 48rem) {
+    .bulletin-body {
+        font-size: calc(var(--reader-scale, 1) * 1.1875rem);
+    }
+}
+
+.bulletin-body :where(h1, h2, h3) {
+    font-size: 1em;
+    font-weight: 700;
+}
+
+.bulletin-body :where(p + p, p + h1, p + h2, p + h3) {
+    margin-top: 1em;
+}
+
+.bulletin-body :where(h1 + p, h2 + p, h3 + p) {
+    margin-top: 0.35em;
+}
+
 .mention-suggestions__avatar {
     @apply size-5 shrink-0 rounded-full object-cover;
 }

--- a/resources/views/components/layouts/public.blade.php
+++ b/resources/views/components/layouts/public.blade.php
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+        <meta name="csrf-token" content="{{ csrf_token() }}" />
+        <meta name="robots" content="noindex" />
+
+        <title>{{ $title ?? config('app.name') }}</title>
+
+        <link rel="icon" href="/favicon.ico" sizes="any">
+        <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+        <link rel="apple-touch-icon" href="/apple-touch-icon.png">
+
+        <link rel="preconnect" href="https://fonts.bunny.net">
+        <link href="https://fonts.bunny.net/css?family=manrope:200,400,600,800" rel="stylesheet" />
+
+        @vite(['resources/css/app.css', 'resources/js/app.js'])
+    </head>
+    <body class="min-h-screen bg-white antialiased">
+        {{ $slot }}
+        @fluxScripts
+    </body>
+</html>

--- a/resources/views/pages/bulletin/show.blade.php
+++ b/resources/views/pages/bulletin/show.blade.php
@@ -1,0 +1,346 @@
+<?php
+
+use App\Enums\LiturgyElementType;
+use App\Models\Service;
+use Livewire\Attributes\Computed;
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+
+new #[Layout('components.layouts.public')] class extends Component {
+    public ?Service $service = null;
+
+    public function mount(?Service $service = null): void
+    {
+        $this->service = $service ?? Service::current();
+        $this->service?->load(['liturgyElements.content', 'liturgyElements.assignee']);
+    }
+
+    /**
+     * The service shaped for the follow-along view: `panels` are the
+     * navigable elements (sections excluded), `sections` the movements
+     * that hold them. Each panel knows its section, and the first panel
+     * of a movement carries that section's "Entering" intro.
+     *
+     * @return array{
+     *     panels: array<int, array<string, mixed>>,
+     *     sections: array<int, array{name: string, description: ?string, firstIndex: int}>
+     * }
+     */
+    #[Computed]
+    public function bulletin(): array
+    {
+        $panels = [];
+        $sections = [];
+        $entering = null;
+
+        if (! $this->service) {
+            return ['panels' => $panels, 'sections' => $sections];
+        }
+
+        foreach ($this->service->liturgyElements as $element) {
+            if ($element->type === LiturgyElementType::SECTION) {
+                $entering = ['name' => $element->name, 'description' => $element->description];
+
+                continue;
+            }
+
+            if ($entering) {
+                $sections[] = [...$entering, 'firstIndex' => count($panels)];
+            }
+
+            $body = $element->hasContent() ? $element->getContentText() : null;
+            $preacher = $element->type === LiturgyElementType::SERMON ? $element->assignee?->name : null;
+
+            $panels[] = [
+                'kindLabel' => $element->isReading() && $element->reading_type ? $element->reading_type->label() : $element->type->label(),
+                'title' => $element->getDisplayTitle(),
+                'description' => $element->description,
+                'body' => $body,
+                'isEmpty' => ! $body && ! $element->description && ! $preacher,
+                'preacher' => $preacher,
+                'song' => $element->isSong() && $element->hasContent() ? $element->content : null,
+                'sectionIndex' => count($sections) - 1,
+                'entering' => $entering,
+            ];
+
+            $entering = null;
+        }
+
+        return ['panels' => $panels, 'sections' => $sections];
+    }
+};
+?>
+
+@php
+    $churchName = 'Reforming Truth Church';
+    $panels = $this->bulletin['panels'];
+    $sections = $this->bulletin['sections'];
+@endphp
+
+<div>
+    @if (! $service)
+        <div class="flex min-h-dvh flex-col items-center justify-center gap-5 bg-white p-8 text-center text-zinc-900">
+            <span class="text-accent-content *:h-14 *:w-auto"><x-app-logo-icon /></span>
+            <div>
+                <h1 class="text-lg font-bold">{{ $churchName }}</h1>
+                <p class="mt-2 text-sm text-zinc-500">No upcoming service is scheduled. Check back soon.</p>
+            </div>
+        </div>
+    @else
+        <div
+            id="follow-along"
+            x-data="{
+                idx: 0,
+                total: @js(count($panels)),
+                sectionStarts: @js(array_column($sections, 'firstIndex')),
+                panelSection: @js(array_column($panels, 'sectionIndex')),
+                scale: 1,
+                dim: false,
+                copied: false,
+                startX: null,
+
+                init() {
+                    try {
+                        const stored = localStorage.getItem('bulletin.dim');
+                        this.dim = stored !== null ? stored === 'true' : window.matchMedia('(prefers-color-scheme: dark)').matches;
+                    } catch { }
+                    this.$watch('idx', () => {
+                        this.centerStep();
+                        this.$refs.content?.scrollTo(0, 0);
+                    });
+                    this.$nextTick(() => this.centerStep());
+                },
+                go(n) {
+                    if (this.total) this.idx = Math.max(0, Math.min(this.total - 1, n));
+                },
+                next() { this.go(this.idx + 1) },
+                prev() { this.go(this.idx - 1) },
+                jump(s) { this.go(this.sectionStarts[s]) },
+                bump(d) { this.scale = Math.min(1.5, Math.max(0.82, Math.round((this.scale + d) * 100) / 100)) },
+                toggleDim() {
+                    this.dim = ! this.dim;
+                    try { localStorage.setItem('bulletin.dim', this.dim); } catch { }
+                },
+                copyLink() {
+                    navigator.clipboard?.writeText(window.location.href).then(() => {
+                        this.copied = true;
+                        clearTimeout(this._toast);
+                        this._toast = setTimeout(() => this.copied = false, 1600);
+                    });
+                },
+                pointerDown(e) { this.startX = e.clientX },
+                pointerUp(e) {
+                    if (this.startX === null) return;
+                    const dx = e.clientX - this.startX;
+                    this.startX = null;
+                    if (dx < -45) this.next();
+                    else if (dx > 45) this.prev();
+                },
+                centerStep() {
+                    const stepper = this.$refs.stepper;
+                    const s = this.panelSection[this.idx];
+                    if (! stepper || s === undefined || s < 0) return;
+                    const step = stepper.children[s];
+                    if (! step) return;
+                    const target = step.offsetLeft - (stepper.clientWidth - step.offsetWidth) / 2;
+                    stepper.scrollTo({
+                        left: Math.max(0, Math.min(target, stepper.scrollWidth - stepper.clientWidth)),
+                        behavior: 'instant',
+                    });
+                },
+            }"
+            :class="dim && 'dark'"
+            :style="'--reader-scale: ' + scale"
+            @keydown.arrow-right.window.prevent="next()"
+            @keydown.arrow-left.window.prevent="prev()"
+            class="flex h-dvh flex-col bg-white text-zinc-900 transition-colors duration-[350ms] dark:bg-zinc-950 dark:text-zinc-100"
+        >
+            {{-- Header --}}
+            <header class="flex-none border-b border-zinc-200 bg-zinc-50 transition-colors duration-[350ms] dark:border-zinc-800 dark:bg-zinc-900">
+                <div class="flex items-center justify-between gap-3 px-4.5 pt-4 pb-2.5 md:px-10">
+                    <div class="flex min-w-0 items-center gap-2.5">
+                        <span class="flex-none text-accent-content *:h-7 *:w-auto md:*:h-8"><x-app-logo-icon /></span>
+                        <div class="min-w-0 leading-tight">
+                            <div class="truncate text-[11.5px] font-bold md:text-[13px]">{{ $churchName }}</div>
+                            <div class="truncate text-[11px] text-zinc-500 dark:text-zinc-400">{{ $service->date->format('D, M j, Y') }}</div>
+                        </div>
+                    </div>
+                    <div class="relative flex flex-none items-center gap-1.5">
+                        <button
+                            type="button"
+                            @click="bump(-0.12)"
+                            :disabled="scale <= 0.82"
+                            aria-label="Smaller text"
+                            class="size-[30px] rounded-lg border border-zinc-200 text-[11px] font-bold text-zinc-500 disabled:opacity-40 dark:border-zinc-700 dark:text-zinc-400"
+                        >A−</button>
+                        <button
+                            type="button"
+                            @click="bump(0.12)"
+                            :disabled="scale >= 1.5"
+                            aria-label="Larger text"
+                            class="size-[30px] rounded-lg border border-zinc-200 text-[14px] font-bold text-zinc-500 disabled:opacity-40 dark:border-zinc-700 dark:text-zinc-400"
+                        >A+</button>
+                        <button
+                            type="button"
+                            @click="toggleDim()"
+                            aria-label="Toggle dim mode"
+                            class="flex size-[30px] items-center justify-center rounded-lg border border-zinc-200 text-zinc-500 dark:border-zinc-700 dark:text-zinc-400"
+                        >
+                            <flux:icon.sun x-show="dim" style="display: none" class="size-4" />
+                            <flux:icon.moon x-show="! dim" class="size-4" />
+                        </button>
+                        <button
+                            type="button"
+                            @click="copyLink()"
+                            aria-label="Copy link"
+                            class="flex size-[30px] items-center justify-center rounded-lg border border-zinc-200 text-zinc-500 dark:border-zinc-700 dark:text-zinc-400"
+                        >
+                            <flux:icon.link class="size-4" />
+                        </button>
+                        <div
+                            x-show="copied"
+                            x-transition.opacity
+                            style="display: none"
+                            class="absolute top-[38px] right-0 z-20 rounded-md bg-zinc-900 px-2.5 py-1.5 text-[11px] font-semibold whitespace-nowrap text-white dark:bg-zinc-100 dark:text-zinc-900"
+                        >Link copied</div>
+                    </div>
+                </div>
+
+                @if (count($sections))
+                    <div class="relative">
+                        <div x-ref="stepper" class="flex overflow-x-auto px-3 [scrollbar-width:none] md:px-7 [&::-webkit-scrollbar]:hidden">
+                            @foreach ($sections as $s => $section)
+                                <button
+                                    type="button"
+                                    @click="jump({{ $s }})"
+                                    wire:key="section-step-{{ $s }}"
+                                    class="min-w-[84px] flex-1 cursor-pointer px-1.5 pt-1 md:min-w-[120px]"
+                                >
+                                    <div
+                                        class="truncate pb-1.5 text-center text-[11px] font-bold tracking-[.02em]"
+                                        :class="panelSection[idx] === {{ $s }} ? 'text-accent-content' : ({{ $s }} < panelSection[idx] ? 'text-zinc-900 dark:text-zinc-100' : 'text-zinc-500 dark:text-zinc-400')"
+                                    >{{ $section['name'] }}</div>
+                                    <div
+                                        class="h-[3px] rounded-full"
+                                        :class="panelSection[idx] === {{ $s }} ? 'bg-accent' : ({{ $s }} < panelSection[idx] ? 'bg-emerald-300 dark:bg-emerald-500/50' : 'bg-zinc-200 dark:bg-zinc-700')"
+                                    ></div>
+                                </button>
+                            @endforeach
+                        </div>
+                        <div class="pointer-events-none absolute inset-y-0 left-0 w-5 bg-gradient-to-r from-zinc-50 to-transparent dark:from-zinc-900"></div>
+                        <div class="pointer-events-none absolute inset-y-0 right-0 w-5 bg-gradient-to-l from-zinc-50 to-transparent dark:from-zinc-900"></div>
+                    </div>
+                @endif
+            </header>
+
+            {{-- Content --}}
+            <main class="relative min-h-0 flex-1 touch-pan-y" @pointerdown="pointerDown" @pointerup="pointerUp">
+                @if (count($panels))
+                    <button
+                        type="button"
+                        @click="prev()"
+                        aria-label="Previous element"
+                        :class="idx === 0 && 'pointer-events-none'"
+                        class="group absolute inset-y-0 left-0 z-10 flex w-14 items-center justify-start pl-3 md:w-[18%]"
+                    >
+                        <flux:icon.chevron-left class="hidden size-8 text-zinc-400 opacity-0 transition-opacity duration-150 group-hover:opacity-50 md:block" />
+                    </button>
+                    <button
+                        type="button"
+                        @click="next()"
+                        aria-label="Next element"
+                        :class="idx >= total - 1 && 'pointer-events-none'"
+                        class="group absolute inset-y-0 right-0 z-10 flex w-14 items-center justify-end pr-3 md:w-[18%]"
+                    >
+                        <flux:icon.chevron-right class="hidden size-8 text-zinc-400 opacity-0 transition-opacity duration-150 group-hover:opacity-50 md:block" />
+                    </button>
+                @endif
+
+                <div x-ref="content" class="absolute inset-0 overflow-y-auto px-7 py-6 md:px-14 md:py-11">
+                    <div class="mx-auto max-w-full md:max-w-[660px]">
+                        @forelse ($panels as $i => $panel)
+                            <article
+                                @class(['hidden' => $i !== 0])
+                                :class="{ hidden: idx !== {{ $i }} }"
+                                wire:key="panel-{{ $i }}"
+                            >
+                                @if ($panel['entering'] && $panel['entering']['description'])
+                                    <div class="mb-6.5 rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3.5 dark:border-emerald-500/30 dark:bg-emerald-500/10">
+                                        <div class="mb-1.5 text-[10.5px] font-bold tracking-[.12em] text-accent-content uppercase">Entering · {{ $panel['entering']['name'] }}</div>
+                                        <p class="text-sm leading-relaxed text-emerald-950 dark:text-zinc-300">{{ $panel['entering']['description'] }}</p>
+                                    </div>
+                                @endif
+
+                                <div class="mb-2 text-[11px] font-bold tracking-[.1em] text-zinc-500 uppercase dark:text-zinc-400">{{ $panel['kindLabel'] }}</div>
+                                <h2 class="text-[27px] leading-[1.12] font-extrabold tracking-tight md:text-[38px]">{{ $panel['title'] }}</h2>
+
+                                @if ($panel['body'])
+                                    <div class="bulletin-body mt-5">{!! $panel['body'] !!}</div>
+                                @elseif ($panel['description'])
+                                    <p class="bulletin-body mt-5">{{ $panel['description'] }}</p>
+                                @elseif ($panel['isEmpty'])
+                                    <div class="mt-6 rounded-xl border border-dashed border-zinc-300 p-6 text-center text-sm text-zinc-500 dark:border-zinc-700 dark:text-zinc-400">
+                                        No content was attached to this element yet.
+                                    </div>
+                                @endif
+
+                                @if ($panel['preacher'])
+                                    <div class="mt-4 inline-flex items-center gap-2 rounded-full border border-emerald-200 bg-emerald-50 px-4 py-2 dark:border-emerald-500/30 dark:bg-emerald-500/10">
+                                        <span class="text-[13px] text-zinc-500 dark:text-zinc-400">Preaching</span>
+                                        <span class="text-[13.5px] font-bold">{{ $panel['preacher'] }}</span>
+                                    </div>
+                                @endif
+
+                                @if ($panel['song'] && ($panel['song']->authors || $panel['song']->ccli_number || $panel['song']->copyright))
+                                    <div class="mt-6 border-t border-zinc-200 pt-4 text-xs leading-relaxed text-zinc-500 dark:border-zinc-800 dark:text-zinc-400">
+                                        @if ($panel['song']->authors)
+                                            <div>{{ $panel['song']->authors }}</div>
+                                        @endif
+                                        @if ($panel['song']->copyright || $panel['song']->ccli_number)
+                                            <div>{{ collect([$panel['song']->copyright, $panel['song']->ccli_number ? 'CCLI Song #'.$panel['song']->ccli_number : null])->filter()->implode(' · ') }}</div>
+                                        @endif
+                                    </div>
+                                @endif
+                            </article>
+                        @empty
+                            <div class="rounded-xl border border-dashed border-zinc-300 p-6 text-center text-sm text-zinc-500 dark:border-zinc-700 dark:text-zinc-400">
+                                This service doesn't have any elements yet.
+                            </div>
+                        @endforelse
+                    </div>
+                </div>
+            </main>
+
+            {{-- Footer --}}
+            @if (count($panels))
+                <footer class="flex flex-none items-center gap-3.5 border-t border-zinc-200 px-4.5 pt-3 pb-4 transition-colors duration-[350ms] md:px-10 dark:border-zinc-800">
+                    <button
+                        type="button"
+                        @click="prev()"
+                        :disabled="idx === 0"
+                        aria-label="Previous element"
+                        class="flex size-[46px] flex-none items-center justify-center rounded-full border border-zinc-200 disabled:text-zinc-300 dark:border-zinc-700 dark:disabled:text-zinc-600"
+                    >
+                        <flux:icon.chevron-left class="size-5" />
+                    </button>
+                    <div class="min-w-0 flex-1 text-center">
+                        <div class="text-[12.5px] font-bold"><span x-text="idx + 1">1</span> of {{ count($panels) }}</div>
+                        <div class="text-[10.5px] text-zinc-500 dark:text-zinc-400">
+                            <span class="md:hidden">swipe or tap sides</span>
+                            <span class="hidden md:inline">← → arrow keys, or click the sides</span>
+                        </div>
+                    </div>
+                    <button
+                        type="button"
+                        @click="next()"
+                        :disabled="idx >= total - 1"
+                        aria-label="Next element"
+                        class="flex size-[46px] flex-none items-center justify-center rounded-full bg-accent text-white disabled:bg-zinc-200 disabled:text-zinc-400 dark:disabled:bg-zinc-800 dark:disabled:text-zinc-500"
+                    >
+                        <flux:icon.chevron-right class="size-5" />
+                    </button>
+                </footer>
+            @endif
+        </div>
+    @endif
+</div>

--- a/resources/views/pages/bulletin/show.blade.php
+++ b/resources/views/pages/bulletin/show.blade.php
@@ -19,7 +19,10 @@ new #[Layout('components.layouts.public')] class extends Component {
      * The service shaped for the follow-along view: `panels` are the
      * navigable elements (sections excluded), `sections` the movements
      * that hold them. Each panel knows its section, and the first panel
-     * of a movement carries that section's "Entering" intro.
+     * of a movement carries that section's "Entering" intro. A section is
+     * recorded the moment it appears, so content-less sections (trailing or
+     * consecutive) still show in the stepper; their tab just jumps to the
+     * nearest panel since they own none.
      *
      * @return array{
      *     panels: array<int, array<string, mixed>>,
@@ -31,7 +34,8 @@ new #[Layout('components.layouts.public')] class extends Component {
     {
         $panels = [];
         $sections = [];
-        $entering = null;
+        $currentSection = null;
+        $pendingEntering = null;
 
         if (! $this->service) {
             return ['panels' => $panels, 'sections' => $sections];
@@ -39,13 +43,15 @@ new #[Layout('components.layouts.public')] class extends Component {
 
         foreach ($this->service->liturgyElements as $element) {
             if ($element->type === LiturgyElementType::SECTION) {
-                $entering = ['name' => $element->name, 'description' => $element->description];
+                $sections[] = [
+                    'name' => $element->name,
+                    'description' => $element->description,
+                    'firstIndex' => count($panels),
+                ];
+                $currentSection = count($sections) - 1;
+                $pendingEntering = ['name' => $element->name, 'description' => $element->description];
 
                 continue;
-            }
-
-            if ($entering) {
-                $sections[] = [...$entering, 'firstIndex' => count($panels)];
             }
 
             $body = $element->hasContent() ? $element->getContentText() : null;
@@ -59,11 +65,11 @@ new #[Layout('components.layouts.public')] class extends Component {
                 'isEmpty' => ! $body && ! $element->description && ! $preacher,
                 'preacher' => $preacher,
                 'song' => $element->isSong() && $element->hasContent() ? $element->content : null,
-                'sectionIndex' => count($sections) - 1,
-                'entering' => $entering,
+                'sectionIndex' => $currentSection ?? -1,
+                'entering' => $pendingEntering,
             ];
 
-            $entering = null;
+            $pendingEntering = null;
         }
 
         return ['panels' => $panels, 'sections' => $sections];

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,9 @@ use Illuminate\Support\Facades\Route;
 
 Route::get('/', fn () => view('welcome'))->name('home');
 
+Route::livewire('/bulletin', 'pages::bulletin.show')->name('bulletin.current');
+Route::livewire('/bulletin/{service}', 'pages::bulletin.show')->name('bulletin.show');
+
 Route::view('dashboard', 'dashboard')
     ->middleware(['auth', 'verified'])
     ->name('dashboard');

--- a/tests/Browser/PublicBulletinSmokeTest.php
+++ b/tests/Browser/PublicBulletinSmokeTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use App\Enums\LiturgyElementType;
+use App\Models\Service;
+use App\Models\Song;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+/** @group browser */
+it('renders the public bulletin for guests without smoke', function (): void {
+    $preacher = User::factory()->create(['name' => 'Rev. Smoke Tester']);
+
+    $song = Song::factory()->create([
+        'name' => 'Doxology',
+        'lyrics' => '<p>Praise God, from whom all blessings flow</p>',
+        'ccli_number' => '56204',
+    ]);
+
+    $service = Service::factory()->create(['title' => 'Sunday Morning Service', 'date' => now()]);
+    $service->liturgyElements()->createMany([
+        ['type' => LiturgyElementType::SECTION, 'name' => 'God', 'description' => 'We start with a proclamation of God.', 'order' => 1],
+        ['type' => LiturgyElementType::SONG, 'name' => 'Doxology', 'order' => 2, 'content_type' => Song::class, 'content_id' => $song->id],
+        ['type' => LiturgyElementType::SECTION, 'name' => 'Word', 'description' => 'God speaks to his people.', 'order' => 3],
+        ['type' => LiturgyElementType::SERMON, 'name' => 'The God Who Provides', 'order' => 4, 'assignee_id' => $preacher->id],
+    ]);
+
+    $page = visit(route('bulletin.show', $service));
+
+    $page->assertSee('Reforming Truth Church')
+        ->assertSee('Doxology')
+        ->assertSee('Praise God, from whom all blessings flow')
+        ->assertSee('1 of 2')
+        ->assertNoJavascriptErrors()
+        ->assertNoSmoke();
+});
+
+/** @group browser */
+it('advances to the next element with the arrow key', function (): void {
+    $service = Service::factory()->create(['date' => now()]);
+    $service->liturgyElements()->createMany([
+        ['type' => LiturgyElementType::READING, 'name' => 'Call to Worship', 'order' => 1],
+        ['type' => LiturgyElementType::SERMON, 'name' => 'The God Who Provides', 'order' => 2],
+    ]);
+
+    $page = visit(route('bulletin.show', $service));
+
+    $page->assertSee('Call to Worship')
+        ->keys('#follow-along', 'ArrowRight')
+        ->assertSee('The God Who Provides')
+        ->assertSee('2 of 2')
+        ->assertNoJavascriptErrors();
+});

--- a/tests/Feature/PublicBulletinTest.php
+++ b/tests/Feature/PublicBulletinTest.php
@@ -1,0 +1,219 @@
+<?php
+
+use App\Enums\LiturgyElementType;
+use App\Enums\ReadingType;
+use App\Models\Reading;
+use App\Models\Service;
+use App\Models\Song;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('lets guests view a service bulletin by id', function (): void {
+    $service = Service::factory()->create([
+        'title' => 'Sunday Morning Service',
+        'date' => '2026-05-03',
+    ]);
+
+    $service->liturgyElements()->create([
+        'type' => LiturgyElementType::PRAYER,
+        'name' => 'Prayer of Confession',
+        'order' => 1,
+    ]);
+
+    $this->get(route('bulletin.show', $service))
+        ->assertSuccessful()
+        ->assertSee('Prayer of Confession')
+        ->assertSee('Sun, May 3, 2026');
+});
+
+it('resolves the soonest upcoming service on /bulletin', function (): void {
+    Service::factory()->create(['date' => now()->subWeek()])
+        ->liturgyElements()->create(['type' => LiturgyElementType::SERMON, 'name' => 'Past Sermon', 'order' => 1]);
+
+    Service::factory()->create(['date' => now()])
+        ->liturgyElements()->create(['type' => LiturgyElementType::SERMON, 'name' => 'Todays Sermon', 'order' => 1]);
+
+    Service::factory()->create(['date' => now()->addWeek()])
+        ->liturgyElements()->create(['type' => LiturgyElementType::SERMON, 'name' => 'Future Sermon', 'order' => 1]);
+
+    $this->get(route('bulletin.current'))
+        ->assertSuccessful()
+        ->assertSee('Todays Sermon')
+        ->assertDontSee('Past Sermon')
+        ->assertDontSee('Future Sermon');
+});
+
+it('breaks same-date ties by id when resolving the current service', function (): void {
+    $first = Service::factory()->create(['date' => now()->addDay()]);
+    Service::factory()->create(['date' => now()->addDay()]);
+
+    expect(Service::current()->id)->toBe($first->id);
+});
+
+it('shows the empty state when only past services exist', function (): void {
+    Service::factory()->create(['date' => now()->subWeek()])
+        ->liturgyElements()->create(['type' => LiturgyElementType::SERMON, 'name' => 'Past Sermon', 'order' => 1]);
+
+    $this->get(route('bulletin.current'))
+        ->assertSuccessful()
+        ->assertSee('No upcoming service is scheduled')
+        ->assertDontSee('Past Sermon');
+});
+
+it('shows the empty state when no services exist', function (): void {
+    $this->get(route('bulletin.current'))
+        ->assertSuccessful()
+        ->assertSee('No upcoming service is scheduled');
+});
+
+it('returns 404 for an unknown service id', function (): void {
+    $this->get('/bulletin/999999')->assertNotFound();
+});
+
+it('shows song lyrics and CCLI details', function (): void {
+    $song = Song::factory()->create([
+        'name' => 'Doxology',
+        'lyrics' => '<p>Praise God, from whom all blessings flow</p>',
+        'authors' => 'Thomas Ken',
+        'copyright' => 'Public Domain',
+        'ccli_number' => '56204',
+    ]);
+
+    $service = Service::factory()->create(['date' => now()]);
+    $service->liturgyElements()->create([
+        'type' => LiturgyElementType::SONG,
+        'name' => 'Doxology',
+        'description' => null,
+        'order' => 1,
+        'content_type' => Song::class,
+        'content_id' => $song->id,
+    ]);
+
+    $this->get(route('bulletin.show', $service))
+        ->assertSuccessful()
+        ->assertSee('Praise God, from whom all blessings flow')
+        ->assertSee('Thomas Ken')
+        ->assertSee('Public Domain')
+        ->assertSee('CCLI Song #56204');
+});
+
+it('shows reading text with the reading type as the kind label', function (): void {
+    $reading = Reading::factory()->create([
+        'title' => 'Psalm 147',
+        'text' => '<p>Sing to the LORD with thanksgiving</p>',
+    ]);
+
+    $service = Service::factory()->create(['date' => now()]);
+    $service->liturgyElements()->create([
+        'type' => LiturgyElementType::READING,
+        'reading_type' => ReadingType::WORSHIP_CALL,
+        'name' => 'Call to Worship',
+        'order' => 1,
+        'content_type' => Reading::class,
+        'content_id' => $reading->id,
+    ]);
+
+    $this->get(route('bulletin.show', $service))
+        ->assertSuccessful()
+        ->assertSee('Sing to the LORD with thanksgiving')
+        ->assertSee('Call to Worship');
+});
+
+it('hides assignees on non-sermon elements', function (): void {
+    $user = User::factory()->create(['name' => 'Hidden Assignee Name']);
+
+    $service = Service::factory()->create(['date' => now()]);
+    $service->liturgyElements()->create([
+        'type' => LiturgyElementType::READING,
+        'name' => 'Call to Worship',
+        'order' => 1,
+        'assignee_id' => $user->id,
+    ]);
+
+    $this->get(route('bulletin.show', $service))
+        ->assertSuccessful()
+        ->assertDontSee('Hidden Assignee Name');
+});
+
+it('shows the preacher on the sermon element', function (): void {
+    $user = User::factory()->create(['name' => 'Rev. Joshua Pangborn']);
+
+    $service = Service::factory()->create(['date' => now()]);
+    $service->liturgyElements()->create([
+        'type' => LiturgyElementType::SERMON,
+        'name' => 'The God Who Provides',
+        'order' => 1,
+        'assignee_id' => $user->id,
+    ]);
+
+    $this->get(route('bulletin.show', $service))
+        ->assertSuccessful()
+        ->assertSee('Preaching')
+        ->assertSee('Rev. Joshua Pangborn');
+});
+
+it('never renders internal service notes', function (): void {
+    $service = Service::factory()->create([
+        'date' => now(),
+        'notes' => 'Internal planning notes for staff only',
+    ]);
+    $service->liturgyElements()->create(['type' => LiturgyElementType::SERMON, 'name' => 'Sermon', 'order' => 1]);
+
+    $this->get(route('bulletin.show', $service))
+        ->assertSuccessful()
+        ->assertDontSee('Internal planning notes for staff only');
+});
+
+it('excludes sections from the element count', function (): void {
+    $service = Service::factory()->create(['date' => now()]);
+
+    $service->liturgyElements()->createMany([
+        ['type' => LiturgyElementType::SECTION, 'name' => 'God', 'order' => 1],
+        ['type' => LiturgyElementType::READING, 'name' => 'Call to Worship', 'order' => 2],
+        ['type' => LiturgyElementType::SONG, 'name' => 'Doxology', 'order' => 3],
+        ['type' => LiturgyElementType::SECTION, 'name' => 'Word', 'order' => 4],
+        ['type' => LiturgyElementType::SERMON, 'name' => 'Sermon', 'order' => 5],
+    ]);
+
+    $this->get(route('bulletin.show', $service))
+        ->assertSuccessful()
+        ->assertSee('of 3');
+});
+
+it('shows a no-content card for a contentless song', function (): void {
+    $service = Service::factory()->create(['date' => now()]);
+    $service->liturgyElements()->create([
+        'type' => LiturgyElementType::SONG,
+        'name' => 'Doxology',
+        'description' => null,
+        'order' => 1,
+    ]);
+
+    $this->get(route('bulletin.show', $service))
+        ->assertSuccessful()
+        ->assertSee('No content was attached to this element yet.');
+});
+
+it('shows the entering card on the first element of a movement', function (): void {
+    $service = Service::factory()->create(['date' => now()]);
+
+    $service->liturgyElements()->createMany([
+        ['type' => LiturgyElementType::SECTION, 'name' => 'God', 'description' => 'We start with a proclamation of God.', 'order' => 1],
+        ['type' => LiturgyElementType::READING, 'name' => 'Call to Worship', 'order' => 2],
+    ]);
+
+    $this->get(route('bulletin.show', $service))
+        ->assertSuccessful()
+        ->assertSee('Entering · God')
+        ->assertSee('We start with a proclamation of God.');
+});
+
+it('renders a service with no elements without a counter', function (): void {
+    $service = Service::factory()->create(['date' => now()]);
+
+    $this->get(route('bulletin.show', $service))
+        ->assertSuccessful()
+        ->assertSee("This service doesn't have any elements yet.", false);
+});

--- a/tests/Feature/PublicBulletinTest.php
+++ b/tests/Feature/PublicBulletinTest.php
@@ -109,7 +109,7 @@ it('shows reading text with the reading type as the kind label', function (): vo
     $service->liturgyElements()->create([
         'type' => LiturgyElementType::READING,
         'reading_type' => ReadingType::WORSHIP_CALL,
-        'name' => 'Call to Worship',
+        'name' => 'Opening Reading',
         'order' => 1,
         'content_type' => Reading::class,
         'content_id' => $reading->id,
@@ -118,7 +118,54 @@ it('shows reading text with the reading type as the kind label', function (): vo
     $this->get(route('bulletin.show', $service))
         ->assertSuccessful()
         ->assertSee('Sing to the LORD with thanksgiving')
+        ->assertSee('Opening Reading')
         ->assertSee('Call to Worship');
+});
+
+it('strips dangerous html from song lyrics before the public page renders it', function (): void {
+    $song = Song::factory()->create([
+        'name' => 'Doxology',
+        'lyrics' => '<p>Praise God</p><script>alert(1)</script>',
+    ]);
+
+    expect($song->fresh()->lyrics)->not->toContain('script');
+
+    $service = Service::factory()->create(['date' => now()]);
+    $service->liturgyElements()->create([
+        'type' => LiturgyElementType::SONG,
+        'name' => 'Doxology',
+        'order' => 1,
+        'content_type' => Song::class,
+        'content_id' => $song->id,
+    ]);
+
+    $this->get(route('bulletin.show', $service))
+        ->assertSuccessful()
+        ->assertSee('Praise God')
+        ->assertDontSee('alert(1)');
+});
+
+it('strips dangerous html from reading text before the public page renders it', function (): void {
+    $reading = Reading::factory()->create([
+        'title' => 'Psalm 147',
+        'text' => '<p>Sing praises</p><script>alert(1)</script>',
+    ]);
+
+    expect($reading->fresh()->text)->not->toContain('script');
+
+    $service = Service::factory()->create(['date' => now()]);
+    $service->liturgyElements()->create([
+        'type' => LiturgyElementType::READING,
+        'name' => 'Opening Reading',
+        'order' => 1,
+        'content_type' => Reading::class,
+        'content_id' => $reading->id,
+    ]);
+
+    $this->get(route('bulletin.show', $service))
+        ->assertSuccessful()
+        ->assertSee('Sing praises')
+        ->assertDontSee('alert(1)');
 });
 
 it('hides assignees on non-sermon elements', function (): void {
@@ -208,6 +255,36 @@ it('shows the entering card on the first element of a movement', function (): vo
         ->assertSuccessful()
         ->assertSee('Entering · God')
         ->assertSee('We start with a proclamation of God.');
+});
+
+it('keeps a trailing section with no following element in the stepper', function (): void {
+    $service = Service::factory()->create(['date' => now()]);
+
+    $service->liturgyElements()->createMany([
+        ['type' => LiturgyElementType::SECTION, 'name' => 'God', 'order' => 1],
+        ['type' => LiturgyElementType::READING, 'name' => 'Call to Worship', 'order' => 2],
+        ['type' => LiturgyElementType::SECTION, 'name' => 'Sending', 'order' => 3],
+    ]);
+
+    $this->get(route('bulletin.show', $service))
+        ->assertSuccessful()
+        ->assertSee('God')
+        ->assertSee('Sending');
+});
+
+it('keeps consecutive sections in the stepper', function (): void {
+    $service = Service::factory()->create(['date' => now()]);
+
+    $service->liturgyElements()->createMany([
+        ['type' => LiturgyElementType::SECTION, 'name' => 'Adoration', 'order' => 1],
+        ['type' => LiturgyElementType::SECTION, 'name' => 'Confession', 'order' => 2],
+        ['type' => LiturgyElementType::SERMON, 'name' => 'The Sermon', 'order' => 3],
+    ]);
+
+    $this->get(route('bulletin.show', $service))
+        ->assertSuccessful()
+        ->assertSee('Adoration')
+        ->assertSee('Confession');
 });
 
 it('renders a service with no elements without a counter', function (): void {


### PR DESCRIPTION
Adds an unauthenticated `/bulletin` page that displays the current (or a specific) service as a swipeable, follow-along bulletin for congregants. Includes a public layout, dark mode toggle, text scaling (A−/A+), section stepper, and copy-link sharing. The `/bulletin` route auto-resolves to the soonest upcoming service via a new `Service::current()` method. Covered by 13 feature tests and 2 browser smoke tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public bulletin “follow-along” reader for upcoming services, with section stepping, dim mode, swipe/tap navigation, and keyboard controls.
  * Added routes for the current bulletin and service-specific bulletin pages.
  * Introduced a reusable public page layout for locale-aware HTML and asset loading.

* **Bug Fixes**
  * Improved empty-state behavior when there are no upcoming services or no liturgy content.
  * Hardened public rendering by sanitizing song lyrics and reading text to prevent unsafe HTML.

* **Tests**
  * Added browser and feature coverage for navigation, edge cases, routing, rendering, privacy rules, and pagination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->