### PR TITLE
Equalize dashboard widget heights within each row

### DIFF
--- a/resources/views/components/dashboard/widget-skeleton.blade.php
+++ b/resources/views/components/dashboard/widget-skeleton.blade.php
@@ -1,6 +1,6 @@
 @props(['rows' => 3, 'title' => null, 'icon' => null, 'chip' => 'zinc'])
 
-<flux:card class="!px-4.5 !py-4">
+<flux:card class="!px-4.5 !py-4 h-full">
     <div class="mb-2 flex items-center gap-2">
         @if ($title)
             <div @class([

--- a/resources/views/components/dashboard/widget.blade.php
+++ b/resources/views/components/dashboard/widget.blade.php
@@ -8,7 +8,7 @@
     'emptyMessage' => null,
 ])
 
-<flux:card class="!px-4.5 !py-4 hover:shadow-sm transition-shadow" {{ $attributes }}>
+<flux:card class="!px-4.5 !py-4 hover:shadow-sm transition-shadow h-full" {{ $attributes }}>
     <div class="mb-2 flex items-center gap-2">
         <div @class([
             'flex size-7 items-center justify-center rounded-lg',

--- a/resources/views/pages/dashboard/index.blade.php
+++ b/resources/views/pages/dashboard/index.blade.php
@@ -256,7 +256,7 @@ new #[Title('Dashboard')] class extends Component
         <flux:subheading>{{ now()->format('l, F j, Y') }}</flux:subheading>
     </div>
 
-    <div class="grid gap-4 md:grid-cols-3 items-start">
+    <div class="grid gap-4 md:grid-cols-3 items-stretch">
         {{-- Quick Actions --}}
         <flux:card class="md:col-span-3 !py-3.5 !px-4.5">
             <div class="flex flex-wrap items-center gap-3">


### PR DESCRIPTION
The dashboard grid used `items-start`, which overrode CSS Grid's default stretch and let each widget card size to its own content, so widgets in the same row rendered at different heights. This switches the grid container to `items-stretch` and adds `h-full` to the shared widget and skeleton card components so every widget—and its loading placeholder—fills its row's height, with content staying top-aligned. Only layout utility classes changed; all 78 dashboard feature tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dashboard widgets and loading skeletons now stretch to fill the available height more consistently.
  * Adjusted dashboard layout alignment so cards and content match row height better, improving visual balance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->