### PR TITLE
Add multi-church tenancy with scoped data, invitations, and join links

### DIFF
--- a/app/Console/Commands/SendPrayerScheduleDigestCommand.php
+++ b/app/Console/Commands/SendPrayerScheduleDigestCommand.php
@@ -6,10 +6,12 @@ namespace App\Console\Commands;
 
 use App\Enums\Office;
 use App\Mail\PrayerScheduleDigestMail;
+use App\Models\Church;
 use App\Models\Person;
 use App\Models\PrayerScheduleSettings;
 use App\Models\User;
 use App\Services\PrayerScheduleService;
+use App\Support\CurrentChurch;
 use Illuminate\Console\Attributes\Description;
 use Illuminate\Console\Attributes\Signature;
 use Illuminate\Console\Command;
@@ -22,6 +24,18 @@ class SendPrayerScheduleDigestCommand extends Command
 {
     public function handle(PrayerScheduleService $service): int
     {
+        Church::query()->orderBy('id')->each(
+            fn (Church $church) => app(CurrentChurch::class)->runAs(
+                $church,
+                fn () => $this->sendForChurch($church, $service),
+            ),
+        );
+
+        return self::SUCCESS;
+    }
+
+    private function sendForChurch(Church $church, PrayerScheduleService $service): void
+    {
         $settings = PrayerScheduleSettings::current();
 
         $week = $this->option('week') !== null
@@ -31,9 +45,9 @@ class SendPrayerScheduleDigestCommand extends Command
         $people = $service->bulletinDigestForWeek($settings, $week);
 
         if ($people === []) {
-            $this->info('No one is scheduled for this week — nothing to send.');
+            $this->info("{$church->name}: no one is scheduled for this week — nothing to send.");
 
-            return self::SUCCESS;
+            return;
         }
 
         /** @var Collection<int, User> $elders */
@@ -57,12 +71,10 @@ class SendPrayerScheduleDigestCommand extends Command
         }
 
         $weekNumber = $week + 1;
-        $this->info("Sent the Week {$weekNumber} prayer rota to {$elders->count()} elders.");
+        $this->info("{$church->name}: sent the Week {$weekNumber} prayer rota to {$elders->count()} elders.");
 
         if ($eldersWithoutAccounts > 0) {
-            $this->warn("{$eldersWithoutAccounts} elder(s) have no user account and were not emailed.");
+            $this->warn("{$church->name}: {$eldersWithoutAccounts} elder(s) have no user account and were not emailed.");
         }
-
-        return self::SUCCESS;
     }
 }

--- a/app/Http/Middleware/EnsureCurrentChurch.php
+++ b/app/Http/Middleware/EnsureCurrentChurch.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\Church;
+use App\Models\User;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Guarantees every authenticated request has a valid current church:
+ * self-heals a stale current_church_id from the user's memberships and
+ * routes users without any church to onboarding.
+ */
+class EnsureCurrentChurch
+{
+    /**
+     * Routes a churchless user may still reach.
+     *
+     * @var array<int, string>
+     */
+    private array $allowedRoutes = [
+        'churches.create',
+        'churches.join',
+        'invitations.accept',
+        'logout',
+        'settings.profile',
+        'verification.notice',
+        'verification.verify',
+        'verification.send',
+    ];
+
+    public function handle(Request $request, Closure $next): Response
+    {
+        $user = $request->user();
+
+        if (! $user instanceof User) {
+            return $next($request);
+        }
+
+        if ($user->current_church_id !== null
+            && $user->churches()->whereKey($user->current_church_id)->exists()) {
+            return $next($request);
+        }
+
+        $fallback = $user->churches()->orderBy('churches.id')->first();
+
+        if ($fallback instanceof Church) {
+            $user->forceFill(['current_church_id' => $fallback->id])->save();
+
+            return $next($request);
+        }
+
+        if ($request->routeIs(...$this->allowedRoutes)) {
+            return $next($request);
+        }
+
+        return redirect()->route('churches.create');
+    }
+}

--- a/app/Mail/ChurchInvitationMail.php
+++ b/app/Mail/ChurchInvitationMail.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\ChurchInvitation;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class ChurchInvitationMail extends Mailable implements ShouldQueue
+{
+    use Queueable, SerializesModels;
+
+    public function __construct(
+        public ChurchInvitation $invitation,
+    ) {}
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: "You're invited to join {$this->invitation->church->name} on Stave",
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            markdown: 'mail.church-invitation',
+        );
+    }
+}

--- a/app/Models/Church.php
+++ b/app/Models/Church.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\AccessRole;
+use App\Support\CurrentChurch;
+use Database\Factories\ChurchFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+
+#[Fillable(['name', 'slug', 'timezone', 'email', 'phone', 'address', 'website', 'logo_path'])]
+class Church extends Model
+{
+    /** @use HasFactory<ChurchFactory> */
+    use HasFactory;
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return [
+            'join_token_rotated_at' => 'datetime',
+        ];
+    }
+
+    /** @return BelongsToMany<User, $this> */
+    public function users(): BelongsToMany
+    {
+        return $this->belongsToMany(User::class)->withTimestamps();
+    }
+
+    /** @return HasMany<Service, $this> */
+    public function services(): HasMany
+    {
+        return $this->hasMany(Service::class);
+    }
+
+    /** @return HasMany<Person, $this> */
+    public function people(): HasMany
+    {
+        return $this->hasMany(Person::class);
+    }
+
+    /** @return HasMany<ChurchInvitation, $this> */
+    public function invitations(): HasMany
+    {
+        return $this->hasMany(ChurchInvitation::class);
+    }
+
+    public function hasMember(User $user): bool
+    {
+        return $this->users()->whereKey($user->id)->exists();
+    }
+
+    /**
+     * Add a user to this church: creates (or finds) the church's Person
+     * record for them, links it on the membership pivot, grants the given
+     * roles, and makes this church current when the user has none.
+     *
+     * @param  array<int, AccessRole>  $roles
+     */
+    public function addMember(User $user, array $roles = []): void
+    {
+        $person = app(CurrentChurch::class)->runAs($this, function () use ($user): Person {
+            [$first, $last] = array_pad(preg_split('/\s+/', trim($user->name), 2), 2, '');
+
+            return Person::firstOrCreate([
+                'email' => Str::lower($user->email),
+            ], [
+                'first_name' => $first,
+                'last_name' => $last,
+            ]);
+        });
+
+        $this->users()->syncWithoutDetaching([$user->id => ['person_id' => $person->id]]);
+
+        if ($user->current_church_id === null) {
+            $user->forceFill(['current_church_id' => $this->id])->save();
+        }
+
+        foreach ($roles as $role) {
+            $user->grantAccessRole($role, $this);
+        }
+    }
+
+    /**
+     * Rotate the shareable join token, invalidating any previously
+     * distributed join links and QR codes.
+     */
+    public function regenerateJoinToken(): void
+    {
+        $this->forceFill([
+            'join_token' => Str::random(64),
+            'join_token_rotated_at' => now(),
+        ])->save();
+    }
+
+    public function disableJoinToken(): void
+    {
+        $this->forceFill([
+            'join_token' => null,
+            'join_token_rotated_at' => now(),
+        ])->save();
+    }
+
+    /**
+     * Generate a unique slug for a new church.
+     */
+    public static function uniqueSlugFor(string $name): string
+    {
+        $base = Str::slug($name) !== '' ? Str::slug($name) : 'church';
+        $slug = $base;
+        $suffix = 2;
+
+        while (self::query()->where('slug', $slug)->exists()) {
+            $slug = $base.'-'.$suffix++;
+        }
+
+        return $slug;
+    }
+
+    protected function logoUrl(): Attribute
+    {
+        return Attribute::get(fn (): ?string => $this->logo_path
+            ? Storage::disk('digital-ocean')->url($this->logo_path)
+            : null);
+    }
+}

--- a/app/Models/ChurchInvitation.php
+++ b/app/Models/ChurchInvitation.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\AccessRole;
+use Database\Factories\ChurchInvitationFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
+
+/**
+ * @property array<int, string> $roles
+ * @property Carbon $expires_at
+ * @property ?Carbon $accepted_at
+ */
+#[Fillable(['church_id', 'email', 'roles', 'invited_by', 'token', 'expires_at', 'accepted_at'])]
+class ChurchInvitation extends Model
+{
+    /** @use HasFactory<ChurchInvitationFactory> */
+    use HasFactory;
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return [
+            'roles' => 'array',
+            'expires_at' => 'datetime',
+            'accepted_at' => 'datetime',
+        ];
+    }
+
+    /** @return BelongsTo<Church, $this> */
+    public function church(): BelongsTo
+    {
+        return $this->belongsTo(Church::class);
+    }
+
+    /** @return BelongsTo<User, $this> */
+    public function invitedBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'invited_by');
+    }
+
+    /**
+     * Create (or refresh) the invitation for an email address in a church.
+     *
+     * @param  array<int, AccessRole>  $roles
+     */
+    public static function createFor(Church $church, string $email, array $roles, User $invitedBy): self
+    {
+        return self::query()->updateOrCreate([
+            'church_id' => $church->id,
+            'email' => Str::lower($email),
+        ], [
+            'roles' => array_map(fn (AccessRole $role): string => $role->value, $roles),
+            'invited_by' => $invitedBy->id,
+            'token' => Str::random(64),
+            'expires_at' => now()->addDays(14),
+            'accepted_at' => null,
+        ]);
+    }
+
+    public function isPending(): bool
+    {
+        return $this->accepted_at === null && ! $this->isExpired();
+    }
+
+    public function isExpired(): bool
+    {
+        return $this->expires_at->isPast();
+    }
+
+    /** @return array<int, AccessRole> */
+    public function accessRoles(): array
+    {
+        return collect($this->roles)
+            ->map(fn (string $value) => AccessRole::tryFrom($value))
+            ->filter()
+            ->values()
+            ->all();
+    }
+
+    public function acceptUrl(): string
+    {
+        return route('invitations.accept', $this->token);
+    }
+}

--- a/app/Models/Concerns/BelongsToChurch.php
+++ b/app/Models/Concerns/BelongsToChurch.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Models\Concerns;
+
+use App\Models\Church;
+use App\Models\Scopes\ChurchScope;
+use App\Support\CurrentChurch;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Scopes the model to the current church and stamps church_id on creation.
+ * Apply to every model that is the root of top-level queries; strictly
+ * parent-accessed children inherit their church through the parent.
+ *
+ * @property ?int $church_id
+ */
+trait BelongsToChurch
+{
+    public static function bootBelongsToChurch(): void
+    {
+        static::addGlobalScope(new ChurchScope());
+
+        static::creating(function (Model $model): void {
+            $model->setAttribute(
+                'church_id',
+                $model->getAttribute('church_id') ?? app(CurrentChurch::class)->id(),
+            );
+        });
+    }
+
+    /** @return BelongsTo<Church, $this> */
+    public function church(): BelongsTo
+    {
+        return $this->belongsTo(Church::class);
+    }
+}

--- a/app/Models/Group.php
+++ b/app/Models/Group.php
@@ -167,6 +167,13 @@ class Group extends Model
         // request context resolved one (queued jobs, tests).
         $churchId = app(CurrentChurch::class)->id() ?? $creator->current_church_id;
 
+        $churchMembers = DB::table('church_user')
+            ->where('church_id', $churchId)
+            ->whereIn('user_id', $allIds)
+            ->pluck('user_id');
+
+        abort_unless($churchMembers->count() === count($allIds), 403);
+
         return DB::transaction(function () use ($creator, $allIds, $directKey, $churchId): self {
             if ($directKey !== null) {
                 $existing = self::query()

--- a/app/Models/Group.php
+++ b/app/Models/Group.php
@@ -6,6 +6,8 @@ use App\Enums\GroupMembershipStatus;
 use App\Enums\GroupMessaging;
 use App\Enums\GroupRole;
 use App\Enums\GroupVisibility;
+use App\Models\Concerns\BelongsToChurch;
+use App\Support\CurrentChurch;
 use Database\Factories\GroupFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Builder;
@@ -31,7 +33,7 @@ use Mews\Purifier\Casts\CleanHtmlInput;
 class Group extends Model
 {
     /** @use HasFactory<GroupFactory> */
-    use HasFactory;
+    use BelongsToChurch, HasFactory;
 
     protected static function booted(): void
     {
@@ -161,9 +163,17 @@ class Group extends Model
         $isOneToOne = count($allIds) === 2;
         $directKey = $isOneToOne ? self::directKeyFor($allIds) : null;
 
-        return DB::transaction(function () use ($creator, $allIds, $directKey): self {
+        // Direct groups live in the creator's church regardless of whether a
+        // request context resolved one (queued jobs, tests).
+        $churchId = app(CurrentChurch::class)->id() ?? $creator->current_church_id;
+
+        return DB::transaction(function () use ($creator, $allIds, $directKey, $churchId): self {
             if ($directKey !== null) {
-                $existing = self::query()->direct()->where('direct_key', $directKey)->first();
+                $existing = self::query()
+                    ->direct()
+                    ->where('church_id', $churchId)
+                    ->where('direct_key', $directKey)
+                    ->first();
 
                 if ($existing instanceof self) {
                     return $existing;
@@ -171,16 +181,22 @@ class Group extends Model
             }
 
             try {
-                $group = self::create([
+                $group = new self([
                     'name' => null,
                     'visibility' => GroupVisibility::PRIVATE,
                     'messaging' => GroupMessaging::ALL_MEMBERS,
                     'is_direct' => true,
                     'direct_key' => $directKey,
                 ]);
+                $group->church_id = $churchId;
+                $group->save();
             } catch (QueryException $exception) {
                 if ($directKey !== null && in_array($exception->getCode(), ['23000', '23505'], true)) {
-                    $existing = self::query()->direct()->where('direct_key', $directKey)->first();
+                    $existing = self::query()
+                        ->direct()
+                        ->where('church_id', $churchId)
+                        ->where('direct_key', $directKey)
+                        ->first();
 
                     if ($existing instanceof self) {
                         return $existing;

--- a/app/Models/Household.php
+++ b/app/Models/Household.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\BelongsToChurch;
 use Database\Factories\HouseholdFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -12,7 +13,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 class Household extends Model
 {
     /** @use HasFactory<HouseholdFactory> */
-    use HasFactory;
+    use BelongsToChurch, HasFactory;
 
     protected static function booted(): void
     {

--- a/app/Models/LiturgyElement.php
+++ b/app/Models/LiturgyElement.php
@@ -42,10 +42,11 @@ class LiturgyElement extends Model
         // An element always belongs to its liturgy parent's church, even when
         // created outside a request context where no current church resolves.
         static::creating(function (LiturgyElement $element): void {
-            $element->setAttribute(
-                'church_id',
-                $element->getAttribute('church_id') ?? $element->liturgy?->getAttribute('church_id'),
-            );
+            $parentChurchId = $element->liturgy?->getAttribute('church_id');
+
+            if ($parentChurchId !== null) {
+                $element->setAttribute('church_id', $parentChurchId);
+            }
         });
     }
 

--- a/app/Models/LiturgyElement.php
+++ b/app/Models/LiturgyElement.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Enums\LiturgyElementType;
 use App\Enums\ReadingType;
+use App\Models\Concerns\BelongsToChurch;
 use App\Observers\LiturgyElementObserver;
 use App\Support\SectionTone;
 use Database\Factories\LiturgyElementFactory;
@@ -34,7 +35,19 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
 class LiturgyElement extends Model
 {
     /** @use HasFactory<LiturgyElementFactory> */
-    use HasFactory;
+    use BelongsToChurch, HasFactory;
+
+    protected static function booted(): void
+    {
+        // An element always belongs to its liturgy parent's church, even when
+        // created outside a request context where no current church resolves.
+        static::creating(function (LiturgyElement $element): void {
+            $element->setAttribute(
+                'church_id',
+                $element->getAttribute('church_id') ?? $element->liturgy?->getAttribute('church_id'),
+            );
+        });
+    }
 
     /**
      * Get the attributes that should be cast.

--- a/app/Models/PastoralNote.php
+++ b/app/Models/PastoralNote.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\BelongsToChurch;
 use Database\Factories\PastoralNoteFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -16,7 +17,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 class PastoralNote extends Model
 {
     /** @use HasFactory<PastoralNoteFactory> */
-    use HasFactory;
+    use BelongsToChurch, HasFactory;
 
     /** @return BelongsTo<Person, $this> */
     public function person(): BelongsTo

--- a/app/Models/Person.php
+++ b/app/Models/Person.php
@@ -6,6 +6,7 @@ use App\Enums\Gender;
 use App\Enums\HouseholdRole;
 use App\Enums\MembershipStatus;
 use App\Enums\TerminationReason;
+use App\Models\Concerns\BelongsToChurch;
 use App\Models\Traits\HasGravatar;
 use Database\Factories\PersonFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
@@ -56,7 +57,7 @@ use LogicException;
 class Person extends Model
 {
     /** @use HasFactory<PersonFactory> */
-    use HasFactory, HasGravatar;
+    use BelongsToChurch, HasFactory, HasGravatar;
 
     /**
      * @return array<string, string>

--- a/app/Models/PrayerRequest.php
+++ b/app/Models/PrayerRequest.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Enums\PrayerRequestVisibility;
+use App\Models\Concerns\BelongsToChurch;
 use Database\Factories\PrayerRequestFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Builder;
@@ -25,7 +26,7 @@ use Illuminate\Support\Carbon;
 class PrayerRequest extends Model
 {
     /** @use HasFactory<PrayerRequestFactory> */
-    use HasFactory;
+    use BelongsToChurch, HasFactory;
 
     /**
      * @return array<string, string>

--- a/app/Models/PrayerScheduleSettings.php
+++ b/app/Models/PrayerScheduleSettings.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Enums\MembershipStatus;
 use App\Enums\PrayerScheduleGrouping;
+use App\Models\Concerns\BelongsToChurch;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Carbon;
@@ -22,6 +23,8 @@ use Illuminate\Support\Carbon;
 ])]
 class PrayerScheduleSettings extends Model
 {
+    use BelongsToChurch;
+
     /**
      * @return array<string, string>
      */

--- a/app/Models/Reading.php
+++ b/app/Models/Reading.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Enums\ReadingType;
+use App\Models\Concerns\BelongsToChurch;
 use Database\Factories\ReadingFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Scope;
@@ -20,7 +21,7 @@ use Mews\Purifier\Casts\CleanHtmlInput;
 class Reading extends Model
 {
     /** @use HasFactory<ReadingFactory> */
-    use HasFactory;
+    use BelongsToChurch, HasFactory;
 
     /**
      * Get the attributes that should be cast.

--- a/app/Models/Scopes/ChurchScope.php
+++ b/app/Models/Scopes/ChurchScope.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models\Scopes;
+
+use App\Support\CurrentChurch;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Scope;
+
+/**
+ * Constrains queries to the current church. Deliberately a no-op when no
+ * current church resolves (migrations, seeders, queued model restoration).
+ */
+class ChurchScope implements Scope
+{
+    /**
+     * @param  Builder<covariant Model>  $builder
+     */
+    public function apply(Builder $builder, Model $model): void
+    {
+        $churchId = app(CurrentChurch::class)->id();
+
+        if ($churchId !== null) {
+            $builder->where($model->qualifyColumn('church_id'), $churchId);
+        }
+    }
+}

--- a/app/Models/Series.php
+++ b/app/Models/Series.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\BelongsToChurch;
 use Database\Factories\SeriesFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -12,7 +13,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 class Series extends Model
 {
     /** @use HasFactory<SeriesFactory> */
-    use HasFactory;
+    use BelongsToChurch, HasFactory;
 
     /** @return HasMany<Reading, $this> */
     public function readings(): HasMany

--- a/app/Models/Service.php
+++ b/app/Models/Service.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Enums\LiturgyElementType;
+use App\Models\Concerns\BelongsToChurch;
 use Database\Factories\ServiceFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Scope;
@@ -23,7 +24,7 @@ use Spatie\Comments\Models\Concerns\HasComments;
 class Service extends Model
 {
     /** @use HasFactory<ServiceFactory> */
-    use HasComments, HasFactory;
+    use BelongsToChurch, HasComments, HasFactory;
 
     /**
      * Get the attributes that should be cast.

--- a/app/Models/Song.php
+++ b/app/Models/Song.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\BelongsToChurch;
 use Database\Factories\SongFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Scope;
@@ -16,7 +17,7 @@ use Mews\Purifier\Casts\CleanHtmlInput;
 class Song extends Model
 {
     /** @use HasFactory<SongFactory> */
-    use HasFactory;
+    use BelongsToChurch, HasFactory;
 
     /**
      * Get the attributes that should be cast.

--- a/app/Models/Template.php
+++ b/app/Models/Template.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\BelongsToChurch;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -11,7 +12,7 @@ use Illuminate\Database\Eloquent\Relations\MorphMany;
 #[Fillable(['name', 'default'])]
 class Template extends Model
 {
-    use HasFactory;
+    use BelongsToChurch, HasFactory;
 
     /** @return MorphMany<LiturgyElement, $this> */
     public function liturgyElements(): MorphMany

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -192,8 +192,13 @@ class User extends Authenticatable implements CanComment
             ->where('church_id', $churchId)
             ->value('person_id');
 
-        if ($pivotPersonId !== null) {
-            return Person::query()->withoutGlobalScopes()->find($pivotPersonId);
+        if ($churchId !== null) {
+            return $pivotPersonId !== null
+                ? Person::query()
+                    ->withoutGlobalScopes()
+                    ->where('church_id', $churchId)
+                    ->find($pivotPersonId)
+                : null;
         }
 
         return $this->person;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -6,9 +6,11 @@ use App\Enums\AccessRole;
 use App\Enums\DigestFrequency;
 use App\Enums\GroupMembershipStatus;
 use App\Models\Traits\HasGravatar;
+use App\Support\CurrentChurch;
 use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
+use Illuminate\Database\Eloquent\Attributes\Scope;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -63,22 +65,46 @@ class User extends Authenticatable implements CanComment
             ->implode('');
     }
 
-    /** @return Collection<int, AccessRole> */
-    public function accessRoles(): Collection
+    /**
+     * Role sets already loaded this request, keyed by church id (0 = no
+     * church), so repeated capability checks cost a single query.
+     *
+     * @var array<int, Collection<int, AccessRole>>
+     */
+    private array $resolvedAccessRoles = [];
+
+    /**
+     * The user's access roles in the given church (defaults to the current
+     * church). Roles are church-scoped: a user can be an administrator in
+     * one church and a plain member in another.
+     *
+     * @return Collection<int, AccessRole>
+     */
+    public function accessRoles(?Church $church = null): Collection
     {
-        return DB::table('user_access_roles')
+        $churchId = $church->id ?? app(CurrentChurch::class)->id() ?? $this->current_church_id;
+
+        return $this->resolvedAccessRoles[$churchId ?? 0] ??= DB::table('user_access_roles')
             ->where('user_id', $this->id)
+            ->where('church_id', $churchId)
             ->pluck('role')
             ->map(fn (string $value) => AccessRole::tryFrom($value))
-            ->filter();
+            ->filter()
+            ->values();
     }
 
-    public function hasAccessRole(AccessRole $role): bool
+    public function hasAccessRole(AccessRole $role, ?Church $church = null): bool
     {
-        return DB::table('user_access_roles')
-            ->where('user_id', $this->id)
-            ->where('role', $role->value)
-            ->exists();
+        return $this->accessRoles($church)->containsStrict($role);
+    }
+
+    /**
+     * @param  array<int, AccessRole>  $roles
+     */
+    private function hasAnyAccessRole(array $roles): bool
+    {
+        return $this->accessRoles()
+            ->contains(fn (AccessRole $role): bool => in_array($role, $roles, true));
     }
 
     /**
@@ -87,14 +113,11 @@ class User extends Authenticatable implements CanComment
      */
     public function canAccessPastoralCare(): bool
     {
-        return DB::table('user_access_roles')
-            ->where('user_id', $this->id)
-            ->whereIn('role', [
-                AccessRole::PASTORAL_CARE_USER->value,
-                AccessRole::PASTORAL_CARE_ADMIN->value,
-                AccessRole::ADMIN->value,
-            ])
-            ->exists();
+        return $this->hasAnyAccessRole([
+            AccessRole::PASTORAL_CARE_USER,
+            AccessRole::PASTORAL_CARE_ADMIN,
+            AccessRole::ADMIN,
+        ]);
     }
 
     /**
@@ -103,14 +126,11 @@ class User extends Authenticatable implements CanComment
      */
     public function canAccessLiturgy(): bool
     {
-        return DB::table('user_access_roles')
-            ->where('user_id', $this->id)
-            ->whereIn('role', [
-                AccessRole::LITURGY_USER->value,
-                AccessRole::LITURGY_ADMIN->value,
-                AccessRole::ADMIN->value,
-            ])
-            ->exists();
+        return $this->hasAnyAccessRole([
+            AccessRole::LITURGY_USER,
+            AccessRole::LITURGY_ADMIN,
+            AccessRole::ADMIN,
+        ]);
     }
 
     /**
@@ -119,36 +139,107 @@ class User extends Authenticatable implements CanComment
      */
     public function canManageLiturgy(): bool
     {
-        return DB::table('user_access_roles')
-            ->where('user_id', $this->id)
-            ->whereIn('role', [
-                AccessRole::LITURGY_ADMIN->value,
-                AccessRole::ADMIN->value,
-            ])
-            ->exists();
-    }
-
-    public function grantAccessRole(AccessRole $role): void
-    {
-        DB::table('user_access_roles')->insertOrIgnore([
-            'user_id' => $this->id,
-            'role' => $role->value,
-            'created_at' => now(),
+        return $this->hasAnyAccessRole([
+            AccessRole::LITURGY_ADMIN,
+            AccessRole::ADMIN,
         ]);
     }
 
-    public function revokeAccessRole(AccessRole $role): void
+    public function grantAccessRole(AccessRole $role, ?Church $church = null): void
     {
+        $churchId = $church->id ?? app(CurrentChurch::class)->id() ?? $this->current_church_id;
+
+        DB::table('user_access_roles')->insertOrIgnore([
+            'user_id' => $this->id,
+            'church_id' => $churchId,
+            'role' => $role->value,
+            'created_at' => now(),
+        ]);
+
+        unset($this->resolvedAccessRoles[$churchId ?? 0]);
+    }
+
+    public function revokeAccessRole(AccessRole $role, ?Church $church = null): void
+    {
+        $churchId = $church->id ?? app(CurrentChurch::class)->id() ?? $this->current_church_id;
+
         DB::table('user_access_roles')
             ->where('user_id', $this->id)
+            ->where('church_id', $churchId)
             ->where('role', $role->value)
             ->delete();
+
+        unset($this->resolvedAccessRoles[$churchId ?? 0]);
     }
 
     /** @return BelongsTo<Person, $this> */
     public function person(): BelongsTo
     {
         return $this->belongsTo(Person::class);
+    }
+
+    /**
+     * The Person representing this user in the given church (defaults to the
+     * current church). Multi-church users have a distinct Person per church,
+     * tracked on the membership pivot; users.person_id is the fallback.
+     */
+    public function personFor(?Church $church = null): ?Person
+    {
+        $churchId = $church->id ?? app(CurrentChurch::class)->id() ?? $this->current_church_id;
+
+        $pivotPersonId = DB::table('church_user')
+            ->where('user_id', $this->id)
+            ->where('church_id', $churchId)
+            ->value('person_id');
+
+        if ($pivotPersonId !== null) {
+            return Person::query()->withoutGlobalScopes()->find($pivotPersonId);
+        }
+
+        return $this->person;
+    }
+
+    /** @return BelongsToMany<Church, $this> */
+    public function churches(): BelongsToMany
+    {
+        return $this->belongsToMany(Church::class)->withTimestamps();
+    }
+
+    /**
+     * Members of the current church — use for all user pickers so one
+     * church's members never appear in another church's UI.
+     *
+     * @param  Builder<User>  $query
+     * @return Builder<User>
+     */
+    #[Scope]
+    protected function inCurrentChurch(Builder $query): Builder
+    {
+        return $query->whereHas('churches', fn (Builder $inner) => $inner
+            ->whereKey(app(CurrentChurch::class)->id()));
+    }
+
+    /** @return BelongsTo<Church, $this> */
+    public function currentChurch(): BelongsTo
+    {
+        return $this->belongsTo(Church::class, 'current_church_id');
+    }
+
+    /**
+     * Switch the user's current church, refusing churches the user is not a
+     * member of.
+     */
+    public function switchChurch(Church $church): bool
+    {
+        if (! $this->churches()->whereKey($church->id)->exists()) {
+            return false;
+        }
+
+        $this->forceFill(['current_church_id' => $church->id])->save();
+        $this->setRelation('currentChurch', $church);
+        $this->resolvedAccessRoles = [];
+
+        return true;
     }
 
     /** @return BelongsToMany<Group, $this> */

--- a/app/Policies/ChurchPolicy.php
+++ b/app/Policies/ChurchPolicy.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Policies;
+
+use App\Enums\AccessRole;
+use App\Models\Church;
+use App\Models\User;
+
+class ChurchPolicy
+{
+    public function update(User $user, Church $church): bool
+    {
+        return $user->hasAccessRole(AccessRole::ADMIN, $church);
+    }
+
+    public function manageMembers(User $user, Church $church): bool
+    {
+        return $user->hasAccessRole(AccessRole::ADMIN, $church);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use App\Channels\DigestChannel;
+use App\Support\CurrentChurch;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\ServiceProvider;
@@ -17,7 +18,7 @@ class AppServiceProvider extends ServiceProvider
     #[\Override]
     public function register(): void
     {
-        //
+        $this->app->scoped(CurrentChurch::class);
     }
 
     /**

--- a/app/Support/CurrentChurch.php
+++ b/app/Support/CurrentChurch.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Support;
+
+use App\Models\Church;
+use App\Models\User;
+use Closure;
+use Illuminate\Support\Facades\Auth;
+
+/**
+ * Container-scoped resolver for the church the current request (or job,
+ * command, test) is operating on. Resolution order: an explicitly set church,
+ * then the authenticated user's current church, then null. When no church
+ * resolves, church scoping is a no-op so migrations, seeders, and queued
+ * model restoration keep working.
+ */
+class CurrentChurch
+{
+    private ?Church $church = null;
+
+    public function set(?Church $church): void
+    {
+        $this->church = $church;
+    }
+
+    public function get(): ?Church
+    {
+        if ($this->church instanceof Church) {
+            return $this->church;
+        }
+
+        $user = Auth::user();
+
+        return $user instanceof User ? $user->currentChurch : null;
+    }
+
+    public function id(): ?int
+    {
+        if ($this->church instanceof Church) {
+            return $this->church->id;
+        }
+
+        $user = Auth::user();
+
+        return $user instanceof User ? $user->current_church_id : null;
+    }
+
+    /**
+     * Run the callback with the given church as the current church, restoring
+     * the previous state afterwards. Use for console commands and queued jobs
+     * that query church-scoped models outside a request.
+     *
+     * @template TReturn
+     *
+     * @param  Closure(Church): TReturn  $callback
+     * @return TReturn
+     */
+    public function runAs(Church $church, Closure $callback): mixed
+    {
+        $previous = $this->church;
+        $this->set($church);
+
+        try {
+            return $callback($church);
+        } finally {
+            $this->set($previous);
+        }
+    }
+}

--- a/app/Support/QrCode.php
+++ b/app/Support/QrCode.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Support;
+
+use BaconQrCode\Renderer\Image\SvgImageBackEnd;
+use BaconQrCode\Renderer\ImageRenderer;
+use BaconQrCode\Renderer\RendererStyle\RendererStyle;
+use BaconQrCode\Writer;
+
+class QrCode
+{
+    /**
+     * Render the given URL as an inline SVG QR code.
+     */
+    public static function svg(string $url, int $size = 240): string
+    {
+        $renderer = new ImageRenderer(
+            new RendererStyle($size, 1),
+            new SvgImageBackEnd(),
+        );
+
+        return (new Writer($renderer))->writeString($url);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Middleware\EnsureCurrentChurch;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -13,6 +14,8 @@ return Application::configure(basePath: dirname(__DIR__))
     )
     ->withMiddleware(function (Middleware $middleware): void {
         $middleware->trustProxies(at: '*');
+
+        $middleware->web(append: [EnsureCurrentChurch::class]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.4",
+        "bacon/bacon-qr-code": "^3.1",
         "laravel-notification-channels/webpush": "^10.5",
         "laravel/framework": "^13.0",
         "laravel/nightwatch": "^1.7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fb7aef345bef633b697424c27cd8c4e4",
+    "content-hash": "d795972dfd046070e055faf34cbe368e",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -156,6 +156,61 @@
                 "source": "https://github.com/aws/aws-sdk-php/tree/3.385.2"
             },
             "time": "2026-06-18T18:08:43+00:00"
+        },
+        {
+            "name": "bacon/bacon-qr-code",
+            "version": "v3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Bacon/BaconQrCode.git",
+                "reference": "4da2233e72eeecd9be3b62e0dc2cc9ed8e2e31c2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Bacon/BaconQrCode/zipball/4da2233e72eeecd9be3b62e0dc2cc9ed8e2e31c2",
+                "reference": "4da2233e72eeecd9be3b62e0dc2cc9ed8e2e31c2",
+                "shasum": ""
+            },
+            "require": {
+                "dasprid/enum": "^1.0.3",
+                "ext-iconv": "*",
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "phly/keep-a-changelog": "^2.12",
+                "phpunit/phpunit": "^10.5.11 || ^11.0.4",
+                "spatie/phpunit-snapshot-assertions": "^5.1.5",
+                "spatie/pixelmatch-php": "^1.2.0",
+                "squizlabs/php_codesniffer": "^3.9"
+            },
+            "suggest": {
+                "ext-imagick": "to generate QR code images"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "BaconQrCode\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Ben Scholzen 'DASPRiD'",
+                    "email": "mail@dasprids.de",
+                    "homepage": "https://dasprids.de/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "BaconQrCode is a QR code generator for PHP.",
+            "homepage": "https://github.com/Bacon/BaconQrCode",
+            "support": {
+                "issues": "https://github.com/Bacon/BaconQrCode/issues",
+                "source": "https://github.com/Bacon/BaconQrCode/tree/v3.1.1"
+            },
+            "time": "2026-04-05T21:06:35+00:00"
         },
         {
             "name": "brick/math",
@@ -414,6 +469,56 @@
                 }
             ],
             "time": "2025-01-03T16:18:33+00:00"
+        },
+        {
+            "name": "dasprid/enum",
+            "version": "1.0.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DASPRiD/Enum.git",
+                "reference": "b5874fa9ed0043116c72162ec7f4fb50e02e7cce"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DASPRiD/Enum/zipball/b5874fa9ed0043116c72162ec7f4fb50e02e7cce",
+                "reference": "b5874fa9ed0043116c72162ec7f4fb50e02e7cce",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1 <9.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7 || ^8 || ^9 || ^10 || ^11",
+                "squizlabs/php_codesniffer": "*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DASPRiD\\Enum\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Ben Scholzen 'DASPRiD'",
+                    "email": "mail@dasprids.de",
+                    "homepage": "https://dasprids.de/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP 7.1 enum implementation",
+            "keywords": [
+                "enum",
+                "map"
+            ],
+            "support": {
+                "issues": "https://github.com/DASPRiD/Enum/issues",
+                "source": "https://github.com/DASPRiD/Enum/tree/1.0.7"
+            },
+            "time": "2025-09-16T12:23:56+00:00"
         },
         {
             "name": "dflydev/dot-access-data",

--- a/config/app.php
+++ b/config/app.php
@@ -123,4 +123,7 @@ return [
         'store' => env('APP_MAINTENANCE_STORE', 'database'),
     ],
 
+    'first_church_name' => env('STAVE_FIRST_CHURCH_NAME', 'First Church'),
+    'first_church_timezone' => env('STAVE_FIRST_CHURCH_TIMEZONE', 'America/New_York'),
+
 ];

--- a/database/factories/ChurchFactory.php
+++ b/database/factories/ChurchFactory.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Church;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<Church>
+ */
+class ChurchFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $name = fake()->unique()->city().' Community Church';
+
+        return [
+            'name' => $name,
+            'slug' => Str::slug($name).'-'.Str::lower(Str::random(6)),
+            'timezone' => 'America/New_York',
+        ];
+    }
+
+    public function withJoinToken(): static
+    {
+        return $this->state(fn (array $attributes): array => [
+            'join_token' => Str::random(64),
+            'join_token_rotated_at' => now(),
+        ]);
+    }
+}

--- a/database/factories/ChurchInvitationFactory.php
+++ b/database/factories/ChurchInvitationFactory.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Church;
+use App\Models\ChurchInvitation;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<ChurchInvitation>
+ */
+class ChurchInvitationFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'church_id' => Church::factory(),
+            'email' => fake()->unique()->safeEmail(),
+            'roles' => [],
+            'invited_by' => User::factory(),
+            'token' => Str::random(64),
+            'expires_at' => now()->addDays(14),
+        ];
+    }
+
+    public function expired(): static
+    {
+        return $this->state(['expires_at' => now()->subDay()]);
+    }
+
+    public function accepted(): static
+    {
+        return $this->state(['accepted_at' => now()]);
+    }
+}

--- a/database/factories/Concerns/HasChurchAffinity.php
+++ b/database/factories/Concerns/HasChurchAffinity.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Factories\Concerns;
+
+use App\Models\Church;
+use App\Support\CurrentChurch;
+
+trait HasChurchAffinity
+{
+    /**
+     * Default church for factory-created rows: the current church when one
+     * resolves, else the first existing church, creating one only when none
+     * exists. "First church wins" keeps everything in a single-church test
+     * inside one church; multi-church tests pass church_id explicitly.
+     */
+    protected function defaultChurchId(): int
+    {
+        return app(CurrentChurch::class)->id()
+            ?? Church::query()->value('id')
+            ?? Church::factory()->create()->id;
+    }
+}

--- a/database/factories/GroupFactory.php
+++ b/database/factories/GroupFactory.php
@@ -9,6 +9,7 @@ use App\Enums\GroupVisibility;
 use App\Models\Conversation;
 use App\Models\Group;
 use App\Models\User;
+use Database\Factories\Concerns\HasChurchAffinity;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -16,12 +17,15 @@ use Illuminate\Database\Eloquent\Factories\Factory;
  */
 class GroupFactory extends Factory
 {
+    use HasChurchAffinity;
+
     /**
      * @return array<string, mixed>
      */
     public function definition(): array
     {
         return [
+            'church_id' => fn (): int => $this->defaultChurchId(),
             'name' => $this->faker->words(3, true),
             'description' => '<p>'.$this->faker->paragraph().'</p>',
             'visibility' => $this->faker->randomElement(GroupVisibility::cases()),

--- a/database/factories/HouseholdFactory.php
+++ b/database/factories/HouseholdFactory.php
@@ -3,6 +3,7 @@
 namespace Database\Factories;
 
 use App\Models\Household;
+use Database\Factories\Concerns\HasChurchAffinity;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -10,6 +11,8 @@ use Illuminate\Database\Eloquent\Factories\Factory;
  */
 class HouseholdFactory extends Factory
 {
+    use HasChurchAffinity;
+
     /**
      * Define the model's default state.
      *
@@ -18,6 +21,7 @@ class HouseholdFactory extends Factory
     public function definition(): array
     {
         return [
+            'church_id' => fn (): int => $this->defaultChurchId(),
             'name' => 'The '.fake()->lastName().' Household',
             'address' => fake()->optional(0.7)->streetAddress(),
         ];

--- a/database/factories/LiturgyElementFactory.php
+++ b/database/factories/LiturgyElementFactory.php
@@ -6,6 +6,7 @@ use App\Enums\LiturgyElementType;
 use App\Models\LiturgyElement;
 use App\Models\User;
 use App\Support\SectionTone;
+use Database\Factories\Concerns\HasChurchAffinity;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -13,6 +14,8 @@ use Illuminate\Database\Eloquent\Factories\Factory;
  */
 class LiturgyElementFactory extends Factory
 {
+    use HasChurchAffinity;
+
     /**
      * Define the model's default state.
      *
@@ -21,6 +24,7 @@ class LiturgyElementFactory extends Factory
     public function definition(): array
     {
         return [
+            'church_id' => fn (): int => $this->defaultChurchId(),
             'type' => $this->faker->randomElement(LiturgyElementType::cases()),
             'order' => $this->faker->numberBetween(1, 10),
             'name' => $this->faker->word(),

--- a/database/factories/PastoralNoteFactory.php
+++ b/database/factories/PastoralNoteFactory.php
@@ -5,6 +5,7 @@ namespace Database\Factories;
 use App\Models\PastoralNote;
 use App\Models\Person;
 use App\Models\User;
+use Database\Factories\Concerns\HasChurchAffinity;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -12,12 +13,15 @@ use Illuminate\Database\Eloquent\Factories\Factory;
  */
 class PastoralNoteFactory extends Factory
 {
+    use HasChurchAffinity;
+
     /**
      * @return array<string, mixed>
      */
     public function definition(): array
     {
         return [
+            'church_id' => fn (): int => $this->defaultChurchId(),
             'person_id' => Person::factory(),
             'author_id' => User::factory(),
             'body' => fake()->paragraph(),

--- a/database/factories/PersonFactory.php
+++ b/database/factories/PersonFactory.php
@@ -7,6 +7,7 @@ use App\Enums\HouseholdRole;
 use App\Enums\MembershipStatus;
 use App\Models\Household;
 use App\Models\Person;
+use Database\Factories\Concerns\HasChurchAffinity;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -14,12 +15,15 @@ use Illuminate\Database\Eloquent\Factories\Factory;
  */
 class PersonFactory extends Factory
 {
+    use HasChurchAffinity;
+
     /**
      * @return array<string, mixed>
      */
     public function definition(): array
     {
         return [
+            'church_id' => fn (): int => $this->defaultChurchId(),
             'first_name' => fake()->firstName(),
             'last_name' => fake()->lastName(),
             'email' => fake()->unique()->safeEmail(),

--- a/database/factories/PrayerRequestFactory.php
+++ b/database/factories/PrayerRequestFactory.php
@@ -6,6 +6,7 @@ use App\Enums\PrayerRequestVisibility;
 use App\Models\Person;
 use App\Models\PrayerRequest;
 use App\Models\User;
+use Database\Factories\Concerns\HasChurchAffinity;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Carbon;
 
@@ -14,12 +15,15 @@ use Illuminate\Support\Carbon;
  */
 class PrayerRequestFactory extends Factory
 {
+    use HasChurchAffinity;
+
     /**
      * @return array<string, mixed>
      */
     public function definition(): array
     {
         return [
+            'church_id' => fn (): int => $this->defaultChurchId(),
             'person_id' => Person::factory(),
             'body' => fake()->sentence(),
             'visibility' => fake()->randomElement(PrayerRequestVisibility::cases()),

--- a/database/factories/ReadingFactory.php
+++ b/database/factories/ReadingFactory.php
@@ -4,6 +4,7 @@ namespace Database\Factories;
 
 use App\Enums\ReadingType;
 use App\Models\Reading;
+use Database\Factories\Concerns\HasChurchAffinity;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -11,6 +12,8 @@ use Illuminate\Database\Eloquent\Factories\Factory;
  */
 class ReadingFactory extends Factory
 {
+    use HasChurchAffinity;
+
     /**
      * Define the model's default state.
      *
@@ -19,6 +22,7 @@ class ReadingFactory extends Factory
     public function definition(): array
     {
         return [
+            'church_id' => fn (): int => $this->defaultChurchId(),
             'title' => $this->faker->sentence(3),
             'type' => $this->faker->randomElement(ReadingType::cases()),
             'text' => '<p>'.$this->faker->paragraph().'</p>',

--- a/database/factories/SeriesFactory.php
+++ b/database/factories/SeriesFactory.php
@@ -3,6 +3,7 @@
 namespace Database\Factories;
 
 use App\Models\Series;
+use Database\Factories\Concerns\HasChurchAffinity;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -10,6 +11,8 @@ use Illuminate\Database\Eloquent\Factories\Factory;
  */
 class SeriesFactory extends Factory
 {
+    use HasChurchAffinity;
+
     /**
      * Define the model's default state.
      *
@@ -18,6 +21,7 @@ class SeriesFactory extends Factory
     public function definition(): array
     {
         return [
+            'church_id' => fn (): int => $this->defaultChurchId(),
             'name' => $this->faker->sentence(3),
             'description' => '<p>'.$this->faker->paragraph().'</p>',
         ];

--- a/database/factories/ServiceFactory.php
+++ b/database/factories/ServiceFactory.php
@@ -3,6 +3,7 @@
 namespace Database\Factories;
 
 use App\Models\Service;
+use Database\Factories\Concerns\HasChurchAffinity;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -10,6 +11,8 @@ use Illuminate\Database\Eloquent\Factories\Factory;
  */
 class ServiceFactory extends Factory
 {
+    use HasChurchAffinity;
+
     /**
      * Define the model's default state.
      *
@@ -18,6 +21,7 @@ class ServiceFactory extends Factory
     public function definition(): array
     {
         return [
+            'church_id' => fn (): int => $this->defaultChurchId(),
             'title' => $this->faker->sentence(3),
             'date' => $this->faker->dateTimeBetween('-1 year', '+1 month'),
             'template_id' => null,

--- a/database/factories/SongFactory.php
+++ b/database/factories/SongFactory.php
@@ -3,6 +3,7 @@
 namespace Database\Factories;
 
 use App\Models\Song;
+use Database\Factories\Concerns\HasChurchAffinity;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -10,6 +11,8 @@ use Illuminate\Database\Eloquent\Factories\Factory;
  */
 class SongFactory extends Factory
 {
+    use HasChurchAffinity;
+
     /**
      * Define the model's default state.
      *
@@ -18,6 +21,7 @@ class SongFactory extends Factory
     public function definition(): array
     {
         return [
+            'church_id' => fn (): int => $this->defaultChurchId(),
             'name' => $this->faker->sentence(3),
             'authors' => $this->faker->optional()->name(),
             'ccli_number' => $this->faker->optional()->numerify('#######'),

--- a/database/factories/TemplateFactory.php
+++ b/database/factories/TemplateFactory.php
@@ -3,6 +3,7 @@
 namespace Database\Factories;
 
 use App\Models\Template;
+use Database\Factories\Concerns\HasChurchAffinity;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -10,6 +11,8 @@ use Illuminate\Database\Eloquent\Factories\Factory;
  */
 class TemplateFactory extends Factory
 {
+    use HasChurchAffinity;
+
     /**
      * Define the model's default state.
      *
@@ -18,6 +21,7 @@ class TemplateFactory extends Factory
     public function definition(): array
     {
         return [
+            'church_id' => fn (): int => $this->defaultChurchId(),
             'name' => fake()->sentence(2),
             'default' => fake()->boolean(),
         ];

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -51,11 +51,7 @@ class UserFactory extends Factory
                 ? Church::query()->findOrFail($user->current_church_id)
                 : (Church::query()->orderBy('id')->first() ?? Church::factory()->create());
 
-            $church->users()->syncWithoutDetaching([$user->id]);
-
-            if ($user->current_church_id === null) {
-                $user->forceFill(['current_church_id' => $church->id])->save();
-            }
+            $church->addMember($user);
         });
     }
 

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Models\Church;
 use App\Models\Person;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
@@ -35,6 +36,32 @@ class UserFactory extends Factory
             'password' => (static::$password ??= Hash::make('password')),
             'remember_token' => Str::random(10),
         ];
+    }
+
+    /**
+     * Attach every created user to a church and make it current. Respects an
+     * explicit current_church_id (see forChurch()); otherwise the first
+     * existing church wins so single-church tests share one church.
+     */
+    #[\Override]
+    public function configure(): static
+    {
+        return $this->afterCreating(function (User $user): void {
+            $church = $user->current_church_id !== null
+                ? Church::query()->findOrFail($user->current_church_id)
+                : (Church::query()->orderBy('id')->first() ?? Church::factory()->create());
+
+            $church->users()->syncWithoutDetaching([$user->id]);
+
+            if ($user->current_church_id === null) {
+                $user->forceFill(['current_church_id' => $church->id])->save();
+            }
+        });
+    }
+
+    public function forChurch(Church $church): static
+    {
+        return $this->state(['current_church_id' => $church->id]);
     }
 
     /**

--- a/database/migrations/2026_06_19_004312_create_prayer_schedule_settings_table.php
+++ b/database/migrations/2026_06_19_004312_create_prayer_schedule_settings_table.php
@@ -2,8 +2,6 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Carbon;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class() extends Migration
@@ -19,15 +17,8 @@ return new class() extends Migration
             $table->timestamps();
         });
 
-        // Seed the single settings row so the rotation always has defaults to read.
-        DB::table('prayer_schedule_settings')->insert([
-            'cycle_weeks' => 8,
-            'group_by' => 'alpha',
-            'include_statuses' => json_encode(['member', 'catechumen']),
-            'anchor_date' => Carbon::now()->startOfWeek(Carbon::MONDAY)->toDateString(),
-            'created_at' => Carbon::now(),
-            'updated_at' => Carbon::now(),
-        ]);
+        // Settings rows are created lazily per church by
+        // PrayerScheduleSettings::current(); nothing to seed here.
     }
 
     public function down(): void

--- a/database/migrations/2026_07_15_013904_create_churches_table.php
+++ b/database/migrations/2026_07_15_013904_create_churches_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('churches', function (Blueprint $table): void {
+            $table->id();
+            $table->string('name');
+            $table->string('slug')->unique();
+            $table->string('timezone')->default('America/New_York');
+            $table->string('email')->nullable();
+            $table->string('phone')->nullable();
+            $table->text('address')->nullable();
+            $table->string('website')->nullable();
+            $table->string('logo_path')->nullable();
+            $table->string('join_token', 64)->nullable()->unique();
+            $table->timestamp('join_token_rotated_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('churches');
+    }
+};

--- a/database/migrations/2026_07_15_013905_create_church_user_table.php
+++ b/database/migrations/2026_07_15_013905_create_church_user_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('church_user', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('church_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+
+            $table->unique(['church_id', 'user_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('church_user');
+    }
+};

--- a/database/migrations/2026_07_15_013906_add_current_church_id_to_users_table.php
+++ b/database/migrations/2026_07_15_013906_add_current_church_id_to_users_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->foreignId('current_church_id')->nullable()->constrained('churches')->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->dropConstrainedForeignId('current_church_id');
+        });
+    }
+};

--- a/database/migrations/2026_07_15_013907_add_church_id_to_church_scoped_tables.php
+++ b/database/migrations/2026_07_15_013907_add_church_id_to_church_scoped_tables.php
@@ -1,0 +1,72 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    /**
+     * Tables whose models are the root of top-level queries and therefore
+     * carry their own church_id; strictly parent-accessed children (sheets,
+     * recordings, conversations, ...) inherit their church via the parent.
+     *
+     * @var array<int, string>
+     */
+    private array $tables = [
+        'people',
+        'households',
+        'services',
+        'templates',
+        'songs',
+        'readings',
+        'series',
+        'groups',
+        'prayer_requests',
+        'pastoral_notes',
+        'liturgy_elements',
+        'prayer_schedule_settings',
+    ];
+
+    public function up(): void
+    {
+        foreach ($this->tables as $tableName) {
+            Schema::table($tableName, function (Blueprint $table): void {
+                $table->foreignId('church_id')->nullable()->index()->constrained()->cascadeOnDelete();
+            });
+        }
+
+        Schema::table('services', function (Blueprint $table): void {
+            $table->index(['church_id', 'date']);
+        });
+
+        Schema::table('liturgy_elements', function (Blueprint $table): void {
+            $table->index(['church_id', 'assignee_id']);
+        });
+
+        Schema::table('prayer_schedule_settings', function (Blueprint $table): void {
+            $table->unique('church_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('prayer_schedule_settings', function (Blueprint $table): void {
+            $table->dropUnique(['church_id']);
+        });
+
+        Schema::table('services', function (Blueprint $table): void {
+            $table->dropIndex(['church_id', 'date']);
+        });
+
+        Schema::table('liturgy_elements', function (Blueprint $table): void {
+            $table->dropIndex(['church_id', 'assignee_id']);
+        });
+
+        foreach ($this->tables as $tableName) {
+            Schema::table($tableName, function (Blueprint $table): void {
+                $table->dropConstrainedForeignId('church_id');
+            });
+        }
+    }
+};

--- a/database/migrations/2026_07_15_013908_add_church_id_to_user_access_roles_table.php
+++ b/database/migrations/2026_07_15_013908_add_church_id_to_user_access_roles_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('user_access_roles', function (Blueprint $table): void {
+            $table->foreignId('church_id')->nullable()->constrained()->cascadeOnDelete();
+        });
+
+        // The new unique index must exist before the old one is dropped:
+        // InnoDB refuses to drop an index that backs the user_id foreign key.
+        Schema::table('user_access_roles', function (Blueprint $table): void {
+            $table->unique(['user_id', 'church_id', 'role']);
+        });
+
+        Schema::table('user_access_roles', function (Blueprint $table): void {
+            $table->dropUnique(['user_id', 'role']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('user_access_roles', function (Blueprint $table): void {
+            $table->unique(['user_id', 'role']);
+        });
+
+        Schema::table('user_access_roles', function (Blueprint $table): void {
+            $table->dropUnique(['user_id', 'church_id', 'role']);
+        });
+
+        Schema::table('user_access_roles', function (Blueprint $table): void {
+            $table->dropConstrainedForeignId('church_id');
+        });
+    }
+};

--- a/database/migrations/2026_07_15_013909_backfill_first_church.php
+++ b/database/migrations/2026_07_15_013909_backfill_first_church.php
@@ -1,0 +1,68 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+return new class() extends Migration
+{
+    /**
+     * Assign all pre-tenancy data to a first church. Idempotent: only rows
+     * still missing a church_id are touched, so re-running is safe.
+     *
+     * @var array<int, string>
+     */
+    private array $tables = [
+        'people',
+        'households',
+        'services',
+        'templates',
+        'songs',
+        'readings',
+        'series',
+        'groups',
+        'prayer_requests',
+        'pastoral_notes',
+        'liturgy_elements',
+        'prayer_schedule_settings',
+        'user_access_roles',
+    ];
+
+    public function up(): void
+    {
+        if (DB::table('users')->doesntExist()) {
+            return;
+        }
+
+        $name = env('STAVE_FIRST_CHURCH_NAME', 'First Church');
+
+        $churchId = DB::table('churches')->insertGetId([
+            'name' => $name,
+            'slug' => Str::slug($name),
+            'timezone' => env('STAVE_FIRST_CHURCH_TIMEZONE', 'America/New_York'),
+            'created_at' => Carbon::now(),
+            'updated_at' => Carbon::now(),
+        ]);
+
+        foreach ($this->tables as $table) {
+            DB::table($table)->whereNull('church_id')->update(['church_id' => $churchId]);
+        }
+
+        DB::table('users')->orderBy('id')->pluck('id')->each(function (int $userId) use ($churchId): void {
+            DB::table('church_user')->insertOrIgnore([
+                'church_id' => $churchId,
+                'user_id' => $userId,
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now(),
+            ]);
+        });
+
+        DB::table('users')->whereNull('current_church_id')->update(['current_church_id' => $churchId]);
+    }
+
+    public function down(): void
+    {
+        // Data backfill; intentionally irreversible.
+    }
+};

--- a/database/migrations/2026_07_15_013909_backfill_first_church.php
+++ b/database/migrations/2026_07_15_013909_backfill_first_church.php
@@ -35,12 +35,12 @@ return new class() extends Migration
             return;
         }
 
-        $name = env('STAVE_FIRST_CHURCH_NAME', 'First Church');
+        $name = config('app.first_church_name', 'First Church');
 
         $churchId = DB::table('churches')->insertGetId([
             'name' => $name,
             'slug' => Str::slug($name),
-            'timezone' => env('STAVE_FIRST_CHURCH_TIMEZONE', 'America/New_York'),
+            'timezone' => config('app.first_church_timezone', 'America/New_York'),
             'created_at' => Carbon::now(),
             'updated_at' => Carbon::now(),
         ]);
@@ -49,13 +49,17 @@ return new class() extends Migration
             DB::table($table)->whereNull('church_id')->update(['church_id' => $churchId]);
         }
 
-        DB::table('users')->orderBy('id')->pluck('id')->each(function (int $userId) use ($churchId): void {
-            DB::table('church_user')->insertOrIgnore([
-                'church_id' => $churchId,
-                'user_id' => $userId,
-                'created_at' => Carbon::now(),
-                'updated_at' => Carbon::now(),
-            ]);
+        $now = Carbon::now();
+
+        DB::table('users')->orderBy('id')->chunkById(1000, function ($users) use ($churchId, $now): void {
+            DB::table('church_user')->insertOrIgnore(
+                $users->map(fn (object $user): array => [
+                    'church_id' => $churchId,
+                    'user_id' => $user->id,
+                    'created_at' => $now,
+                    'updated_at' => $now,
+                ])->toArray(),
+            );
         });
 
         DB::table('users')->whereNull('current_church_id')->update(['current_church_id' => $churchId]);

--- a/database/migrations/2026_07_15_020609_make_group_direct_key_unique_per_church.php
+++ b/database/migrations/2026_07_15_020609_make_group_direct_key_unique_per_church.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('groups', function (Blueprint $table): void {
+            $table->unique(['church_id', 'direct_key']);
+        });
+
+        Schema::table('groups', function (Blueprint $table): void {
+            $table->dropUnique(['direct_key']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('groups', function (Blueprint $table): void {
+            $table->unique('direct_key');
+        });
+
+        Schema::table('groups', function (Blueprint $table): void {
+            $table->dropUnique(['church_id', 'direct_key']);
+        });
+    }
+};

--- a/database/migrations/2026_07_15_020944_add_person_id_to_church_user_table.php
+++ b/database/migrations/2026_07_15_020944_add_person_id_to_church_user_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    /**
+     * A user who belongs to several churches has a distinct Person record in
+     * each; the pivot tracks which Person represents the user per church.
+     * users.person_id remains as the single-church fallback.
+     */
+    public function up(): void
+    {
+        Schema::table('church_user', function (Blueprint $table): void {
+            $table->foreignId('person_id')->nullable()->constrained()->nullOnDelete();
+        });
+
+        DB::table('users')
+            ->whereNotNull('person_id')
+            ->orderBy('id')
+            ->each(function (object $user): void {
+                DB::table('church_user')
+                    ->where('user_id', $user->id)
+                    ->whereNull('person_id')
+                    ->update(['person_id' => $user->person_id]);
+            });
+    }
+
+    public function down(): void
+    {
+        Schema::table('church_user', function (Blueprint $table): void {
+            $table->dropConstrainedForeignId('person_id');
+        });
+    }
+};

--- a/database/migrations/2026_07_15_020944_create_church_invitations_table.php
+++ b/database/migrations/2026_07_15_020944_create_church_invitations_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('church_invitations', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('church_id')->constrained()->cascadeOnDelete();
+            $table->string('email');
+            $table->json('roles')->default('[]');
+            $table->foreignId('invited_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->string('token', 64)->unique();
+            $table->timestamp('expires_at');
+            $table->timestamp('accepted_at')->nullable();
+            $table->timestamps();
+
+            $table->unique(['church_id', 'email']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('church_invitations');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,15 +2,44 @@
 
 namespace Database\Seeders;
 
+use App\Models\Church;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
 
 class DatabaseSeeder extends Seeder
 {
+    /**
+     * Tables assigned to the seeded church after the raw-insert seeders run
+     * (they bypass Eloquent, so church_id cannot be filled automatically).
+     *
+     * @var array<int, string>
+     */
+    private array $churchScopedTables = [
+        'people',
+        'households',
+        'services',
+        'templates',
+        'songs',
+        'readings',
+        'series',
+        'groups',
+        'prayer_requests',
+        'pastoral_notes',
+        'liturgy_elements',
+        'prayer_schedule_settings',
+        'user_access_roles',
+    ];
+
     /**
      * Seed the application's database.
      */
     public function run(): void
     {
+        $church = Church::query()->firstOrCreate(
+            ['slug' => 'first-church'],
+            ['name' => 'First Church', 'timezone' => 'America/New_York'],
+        );
+
         $this->call([
             PeopleTableSeeder::class,
             UsersTableSeeder::class,
@@ -22,5 +51,20 @@ class DatabaseSeeder extends Seeder
             GroupSeeder::class,
             PrayerRequestSeeder::class,
         ]);
+
+        foreach ($this->churchScopedTables as $table) {
+            DB::table($table)->whereNull('church_id')->update(['church_id' => $church->id]);
+        }
+
+        DB::table('users')->orderBy('id')->pluck('id')->each(function (int $userId) use ($church): void {
+            DB::table('church_user')->insertOrIgnore([
+                'church_id' => $church->id,
+                'user_id' => $userId,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        });
+
+        DB::table('users')->whereNull('current_church_id')->update(['current_church_id' => $church->id]);
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -56,10 +56,11 @@ class DatabaseSeeder extends Seeder
             DB::table($table)->whereNull('church_id')->update(['church_id' => $church->id]);
         }
 
-        DB::table('users')->orderBy('id')->pluck('id')->each(function (int $userId) use ($church): void {
+        DB::table('users')->orderBy('id')->each(function (object $user) use ($church): void {
             DB::table('church_user')->insertOrIgnore([
                 'church_id' => $church->id,
-                'user_id' => $userId,
+                'user_id' => $user->id,
+                'person_id' => $user->person_id,
                 'created_at' => now(),
                 'updated_at' => now(),
             ]);

--- a/resources/views/components/layouts/app/sidebar.blade.php
+++ b/resources/views/components/layouts/app/sidebar.blade.php
@@ -14,6 +14,8 @@
                 <flux:sidebar.collapse />
             </flux:sidebar.header>
 
+            <livewire:sidebar.church-switcher />
+
             <flux:sidebar.nav>
                 <flux:sidebar.item icon="home" :href="route('dashboard')" :current="request()->routeIs('dashboard')" wire:navigate>{{ __('Dashboard') }}</flux:sidebar.item>
 

--- a/resources/views/components/settings/layout.blade.php
+++ b/resources/views/components/settings/layout.blade.php
@@ -5,6 +5,10 @@
             <flux:navlist.item :href="route('settings.password')" :current="request()->routeIs('settings.password')" wire:navigate>{{ __('Password') }}</flux:navlist.item>
             <flux:navlist.item :href="route('settings.appearance')" :current="request()->routeIs('settings.appearance')" wire:navigate>{{ __('Appearance') }}</flux:navlist.item>
             <flux:navlist.item :href="route('settings.notifications')" :current="request()->routeIs('settings.notifications')" wire:navigate>{{ __('Notifications') }}</flux:navlist.item>
+            @can('update', auth()->user()->currentChurch)
+                <flux:navlist.item :href="route('settings.church')" :current="request()->routeIs('settings.church')" wire:navigate>{{ __('Church') }}</flux:navlist.item>
+                <flux:navlist.item :href="route('settings.church-invitations')" :current="request()->routeIs('settings.church-invitations')" wire:navigate>{{ __('Invitations') }}</flux:navlist.item>
+            @endcan
         </flux:navlist>
     </div>
 

--- a/resources/views/livewire/people/drawer.blade.php
+++ b/resources/views/livewire/people/drawer.blade.php
@@ -5,11 +5,14 @@ use App\Enums\Gender;
 use App\Enums\HouseholdRole;
 use App\Enums\MembershipStatus;
 use App\Enums\Office;
+use App\Support\CurrentChurch;
 use App\Livewire\Forms\PersonForm;
 use App\Models\Household;
 use App\Models\Person;
 use App\Models\PersonOffice;
+use App\Models\User;
 use Flux\Flux;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Database\Eloquent\Collection;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Locked;
@@ -189,11 +192,22 @@ new class extends Component
             return;
         }
 
-        foreach (AccessRole::cases() as $role) {
-            $desired = (bool) ($this->accessRoles[$role->value] ?? false);
-            $original = (bool) ($this->originalAccessRoles[$role->value] ?? false);
+        $changed = collect(AccessRole::cases())
+            ->filter(fn (AccessRole $role): bool => (bool) ($this->accessRoles[$role->value] ?? false)
+                !== (bool) ($this->originalAccessRoles[$role->value] ?? false));
 
-            if ($desired === $original) {
+        if ($changed->isEmpty()) {
+            return;
+        }
+
+        abort_unless(auth()->user()->hasAccessRole(AccessRole::ADMIN), 403);
+
+        foreach ($changed as $role) {
+            $desired = (bool) ($this->accessRoles[$role->value] ?? false);
+
+            if (! $desired && $role === AccessRole::ADMIN && $this->isLastAdmin($user)) {
+                Flux::toast(variant: 'danger', text: 'A church needs at least one administrator.');
+
                 continue;
             }
 
@@ -201,6 +215,19 @@ new class extends Component
                 ? $user->grantAccessRole($role)
                 : $user->revokeAccessRole($role);
         }
+    }
+
+    /**
+     * Whether removing the administrator role from this user would leave the
+     * current church without any administrator.
+     */
+    private function isLastAdmin(User $user): bool
+    {
+        return $user->hasAccessRole(AccessRole::ADMIN)
+            && DB::table('user_access_roles')
+                ->where('church_id', app(CurrentChurch::class)->id())
+                ->where('role', AccessRole::ADMIN->value)
+                ->count() <= 1;
     }
 
     public function delete(): void
@@ -636,7 +663,7 @@ new class extends Component
                                                 <p class="text-xs text-zinc-500">{{ $role->description() }}</p>
                                             </div>
                                             <flux:spacer />
-                                            <flux:checkbox wire:model="accessRoles.{{ $role->value }}" />
+                                            <flux:checkbox wire:model="accessRoles.{{ $role->value }}" :disabled="! auth()->user()->hasAccessRole(AccessRole::ADMIN)" />
                                         </div>
                                     @endforeach
                                 </div>

--- a/resources/views/livewire/services/elements.blade.php
+++ b/resources/views/livewire/services/elements.blade.php
@@ -29,7 +29,7 @@ new class extends Component {
     #[Computed]
     public function users()
     {
-        return User::orderBy('name')->get();
+        return User::query()->inCurrentChurch()->orderBy('name')->get();
     }
 
     #[Computed]

--- a/resources/views/livewire/sidebar/church-switcher.blade.php
+++ b/resources/views/livewire/sidebar/church-switcher.blade.php
@@ -38,7 +38,7 @@ new class extends Component {
             <flux:profile
                 :name="$this->current?->name"
                 :avatar="$this->current?->logo_url"
-                :initials="$this->current?->name[0] ?? '?'"
+                :initials="mb_substr($this->current?->name ?? '?', 0, 1)"
                 icon-trailing="chevrons-up-down"
             />
 

--- a/resources/views/livewire/sidebar/church-switcher.blade.php
+++ b/resources/views/livewire/sidebar/church-switcher.blade.php
@@ -1,0 +1,63 @@
+<?php
+
+use App\Models\Church;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\Auth;
+use Livewire\Attributes\Computed;
+use Livewire\Component;
+
+new class extends Component {
+    /** @return Collection<int, Church> */
+    #[Computed]
+    public function churches(): Collection
+    {
+        return Auth::user()->churches()->orderBy('name')->get();
+    }
+
+    #[Computed]
+    public function current(): ?Church
+    {
+        return Auth::user()->currentChurch;
+    }
+
+    public function switch(int $churchId): void
+    {
+        $church = Auth::user()->churches()->findOrFail($churchId);
+
+        Auth::user()->switchChurch($church);
+
+        // Full page load (no wire:navigate): every mounted component holds
+        // state scoped to the previous church.
+        $this->redirect(route('dashboard'), navigate: false);
+    }
+}; ?>
+
+<div class="px-2 pb-2">
+    @if ($this->churches->count() > 1)
+        <flux:dropdown position="bottom" align="start">
+            <flux:profile
+                :name="$this->current?->name"
+                :avatar="$this->current?->logo_url"
+                :initials="$this->current?->name[0] ?? '?'"
+                icon-trailing="chevrons-up-down"
+            />
+
+            <flux:menu class="w-[240px]">
+                <flux:menu.radio.group>
+                    @foreach ($this->churches as $church)
+                        <flux:menu.radio
+                            wire:key="church-{{ $church->id }}"
+                            :checked="$church->id === $this->current?->id"
+                            wire:click="switch({{ $church->id }})"
+                        >{{ $church->name }}</flux:menu.radio>
+                    @endforeach
+                </flux:menu.radio.group>
+            </flux:menu>
+        </flux:dropdown>
+    @elseif ($this->current)
+        <div class="flex items-center gap-2 px-3 py-1.5">
+            <flux:avatar size="xs" :name="$this->current->name" :src="$this->current->logo_url" />
+            <span class="truncate text-sm font-medium text-zinc-700 dark:text-zinc-200">{{ $this->current->name }}</span>
+        </div>
+    @endif
+</div>

--- a/resources/views/livewire/templates/elements.blade.php
+++ b/resources/views/livewire/templates/elements.blade.php
@@ -34,7 +34,7 @@ new class extends Component {
     #[Computed]
     public function users()
     {
-        return User::orderBy("name")->get();
+        return User::query()->inCurrentChurch()->orderBy("name")->get();
     }
 
     /**

--- a/resources/views/mail/church-invitation.blade.php
+++ b/resources/views/mail/church-invitation.blade.php
@@ -1,0 +1,16 @@
+<x-mail::message>
+# You're invited to {{ $invitation->church->name }}
+
+{{ $invitation->invitedBy?->name ?? 'A church administrator' }} has invited you to join
+**{{ $invitation->church->name }}** on Stave, the worship service planning app.
+
+<x-mail::button :url="$invitation->acceptUrl()">
+Accept Invitation
+</x-mail::button>
+
+This invitation expires {{ $invitation->expires_at->toFormattedDateString() }}.
+If you weren't expecting it, you can safely ignore this email.
+
+Thanks,<br>
+{{ config('app.name') }}
+</x-mail::message>

--- a/resources/views/pages/auth/register.blade.php
+++ b/resources/views/pages/auth/register.blade.php
@@ -1,33 +1,61 @@
 <?php
 
+use App\Enums\AccessRole;
+use App\Models\Church;
 use App\Models\Person;
 use App\Models\User;
+use App\Support\CurrentChurch;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\Rules;
 use Livewire\Attributes\Layout;
+use Livewire\Attributes\Locked;
 use Livewire\Component;
 
 new #[Layout('components.layouts.auth')] class extends Component {
+    public string $church_name = '';
     public string $name = '';
     public string $email = '';
     public string $password = '';
     public string $password_confirmation = '';
 
+    /** Join-link token: registering through it joins that church instead of creating one. */
+    #[Locked]
+    public string $join = '';
+
+    public function mount(): void
+    {
+        $this->join = (string) request()->query('join', '');
+    }
+
     /**
-     * Handle an incoming registration request.
+     * Handle an incoming registration request: creates a new church with the
+     * registrant as its administrator, or — when arriving through a church's
+     * join link — joins that church as a plain member.
      */
     public function register(): void
     {
-        $validated = $this->validate([
+        $joinChurch = $this->joinChurch();
+
+        $validated = $this->validate(array_filter([
+            'church_name' => $joinChurch instanceof Church ? null : ['required', 'string', 'max:255'],
             'name' => ['required', 'string', 'max:255'],
             'email' => ['required', 'string', 'lowercase', 'email', 'max:255', Rule::unique(User::class)],
             'password' => ['required', 'string', 'confirmed', Rules\Password::defaults()],
-        ]);
+        ]));
 
-        $user = DB::transaction(function () use ($validated) {
+        $user = DB::transaction(function () use ($validated, $joinChurch) {
+            $church = $joinChurch ?? Church::create([
+                'name' => $validated['church_name'],
+                'slug' => Church::uniqueSlugFor($validated['church_name']),
+            ]);
+
+            // Make the church current so created records (the Person below)
+            // are stamped with it.
+            app(CurrentChurch::class)->set($church);
+
             [$first, $last] = array_pad(preg_split('/\s+/', trim($validated['name']), 2), 2, '');
 
             $person = Person::firstOrCreate([
@@ -37,10 +65,22 @@ new #[Layout('components.layouts.auth')] class extends Component {
                 'last_name'  => $last,
             ]);
 
-            $data = $validated;
-            $data['person_id'] = $person->id;
+            $user = User::create([
+                'name' => $validated['name'],
+                'email' => $validated['email'],
+                'password' => $validated['password'],
+                'person_id' => $person->id,
+            ]);
 
-            return User::create($data);
+            $church->users()->syncWithoutDetaching([$user->id => ['person_id' => $person->id]]);
+            $user->forceFill(['current_church_id' => $church->id])->save();
+
+            // Join-link members get no staff roles; church creators are admins.
+            if (! $joinChurch instanceof Church) {
+                $user->grantAccessRole(AccessRole::ADMIN, $church);
+            }
+
+            return $user;
         });
 
         event(new Registered($user));
@@ -48,6 +88,13 @@ new #[Layout('components.layouts.auth')] class extends Component {
         Auth::login($user);
 
         $this->redirectIntended(route('dashboard', absolute: false), navigate: true);
+    }
+
+    public function joinChurch(): ?Church
+    {
+        return $this->join !== ''
+            ? Church::query()->where('join_token', $this->join)->first()
+            : null;
     }
 }; ?>
 
@@ -58,13 +105,31 @@ new #[Layout('components.layouts.auth')] class extends Component {
     <x-auth-session-status class="text-center" :status="session('status')" />
 
     <form wire:submit="register" class="flex flex-col gap-6">
+        @if ($this->joinChurch())
+            <flux:callout icon="church" variant="secondary">
+                <flux:callout.text>
+                    {{ __('You are joining :church.', ['church' => $this->joinChurch()->name]) }}
+                </flux:callout.text>
+            </flux:callout>
+        @else
+            <!-- Church Name -->
+            <flux:input
+                wire:model="church_name"
+                :label="__('Church name')"
+                type="text"
+                required
+                autofocus
+                :placeholder="__('Your church\'s name')"
+                :description="__('This creates a new church workspace with you as its administrator.')"
+            />
+        @endif
+
         <!-- Name -->
         <flux:input
             wire:model="name"
             :label="__('Name')"
             type="text"
             required
-            autofocus
             autocomplete="name"
             :placeholder="__('Full name')"
         />

--- a/resources/views/pages/bulletin/show.blade.php
+++ b/resources/views/pages/bulletin/show.blade.php
@@ -1,16 +1,27 @@
 <?php
 
 use App\Enums\LiturgyElementType;
+use App\Models\Church;
 use App\Models\Service;
+use App\Support\CurrentChurch;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Layout;
 use Livewire\Component;
 
 new #[Layout('components.layouts.public')] class extends Component {
+    public ?Church $church = null;
+
     public ?Service $service = null;
 
-    public function mount(?Service $service = null): void
+    public function mount(Church $church, ?Service $service = null): void
     {
+        $this->church = $church;
+
+        // {service} is implicitly scoped through {church:slug}, so a service
+        // id from another church already 404s. Setting the current church
+        // here scopes the Service::current() fallback for guests.
+        app(CurrentChurch::class)->set($church);
+
         $this->service = $service ?? Service::current();
         $this->service?->load(['liturgyElements.content', 'liturgyElements.assignee']);
     }
@@ -78,7 +89,7 @@ new #[Layout('components.layouts.public')] class extends Component {
 ?>
 
 @php
-    $churchName = 'Reforming Truth Church';
+    $churchName = $church->name;
     $panels = $this->bulletin['panels'];
     $sections = $this->bulletin['sections'];
 @endphp

--- a/resources/views/pages/churches/create.blade.php
+++ b/resources/views/pages/churches/create.blade.php
@@ -1,0 +1,59 @@
+<?php
+
+use App\Enums\AccessRole;
+use App\Models\Church;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+
+new #[Layout('components.layouts.auth')] class extends Component {
+    public string $name = '';
+
+    /**
+     * Create a church for a user who has none (e.g. removed from their last
+     * church) and make them its administrator.
+     */
+    public function create(): void
+    {
+        $this->validate([
+            'name' => ['required', 'string', 'max:255'],
+        ]);
+
+        $user = Auth::user();
+
+        DB::transaction(function () use ($user): void {
+            $church = Church::create([
+                'name' => $this->name,
+                'slug' => Church::uniqueSlugFor($this->name),
+            ]);
+
+            $church->addMember($user, [AccessRole::ADMIN]);
+            $user->switchChurch($church);
+        });
+
+        $this->redirect(route('dashboard'), navigate: false);
+    }
+}; ?>
+
+<div class="flex flex-col gap-6">
+    <x-auth-header
+        :title="__('Set up your church')"
+        :description="__('You are not a member of any church yet. Create one to get started, or ask a church administrator for an invitation.')"
+    />
+
+    <form wire:submit="create" class="flex flex-col gap-6">
+        <flux:input
+            wire:model="name"
+            :label="__('Church name')"
+            type="text"
+            required
+            autofocus
+            :placeholder="__('Your church\'s name')"
+        />
+
+        <flux:button type="submit" variant="primary" class="w-full">
+            {{ __('Create church') }}
+        </flux:button>
+    </form>
+</div>

--- a/resources/views/pages/churches/join.blade.php
+++ b/resources/views/pages/churches/join.blade.php
@@ -1,0 +1,88 @@
+<?php
+
+use App\Models\Church;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Redirect;
+use Livewire\Attributes\Layout;
+use Livewire\Attributes\Locked;
+use Livewire\Component;
+
+new #[Layout('components.layouts.auth')] class extends Component {
+    #[Locked]
+    public string $token = '';
+
+    public function mount(string $token): void
+    {
+        $this->token = $token;
+
+        $this->church();
+    }
+
+    /**
+     * Join as the logged-in user. Join-link members get no access roles —
+     * a congregation-wide QR code must not grant staff capabilities.
+     */
+    public function join(): void
+    {
+        $church = $this->church();
+        $user = Auth::user();
+
+        DB::transaction(function () use ($church, $user): void {
+            $church->addMember($user);
+            $user->switchChurch($church);
+        });
+
+        $this->redirect(route('dashboard'), navigate: false);
+    }
+
+    public function goToLogin(): void
+    {
+        Redirect::setIntendedUrl(route('churches.join', $this->token));
+
+        $this->redirect(route('login'), navigate: false);
+    }
+
+    public function goToRegister(): void
+    {
+        $this->redirect(route('register', ['join' => $this->token]), navigate: false);
+    }
+
+    public function church(): Church
+    {
+        return Church::query()->where('join_token', $this->token)->firstOrFail();
+    }
+}; ?>
+
+@php
+    $church = $this->church();
+@endphp
+
+<div class="flex flex-col gap-6">
+    <x-auth-header
+        :title="__('Join :church', ['church' => $church->name])"
+        :description="__(':church uses Stave to plan worship services and stay connected.', ['church' => $church->name])"
+    />
+
+    @auth
+        @if ($church->hasMember(auth()->user()))
+            <flux:text class="text-center">{{ __('You are already a member of this church.') }}</flux:text>
+
+            <flux:button variant="primary" class="w-full" :href="route('dashboard')">{{ __('Go to dashboard') }}</flux:button>
+        @else
+            <flux:button variant="primary" class="w-full" wire:click="join">
+                {{ __('Join :church', ['church' => $church->name]) }}
+            </flux:button>
+        @endif
+    @endauth
+
+    @guest
+        <flux:button variant="primary" class="w-full" wire:click="goToRegister">
+            {{ __('Create an account') }}
+        </flux:button>
+
+        <flux:button variant="ghost" class="w-full" wire:click="goToLogin">
+            {{ __('I already have an account') }}
+        </flux:button>
+    @endguest
+</div>

--- a/resources/views/pages/churches/join.blade.php
+++ b/resources/views/pages/churches/join.blade.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\Church;
+use App\Models\User;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Redirect;
@@ -27,6 +28,8 @@ new #[Layout('components.layouts.auth')] class extends Component {
     {
         $church = $this->church();
         $user = Auth::user();
+
+        abort_unless($user instanceof User, 403);
 
         DB::transaction(function () use ($church, $user): void {
             $church->addMember($user);

--- a/resources/views/pages/groups/show.blade.php
+++ b/resources/views/pages/groups/show.blade.php
@@ -167,6 +167,7 @@ new class extends Component {
             ->pluck('users.id');
 
         return User::query()
+            ->inCurrentChurch()
             ->where(function ($q): void {
                 $q->where('name', 'like', "%{$this->memberSearch}%")
                     ->orWhere('email', 'like', "%{$this->memberSearch}%");
@@ -185,7 +186,7 @@ new class extends Component {
             return new Collection;
         }
 
-        return User::query()->whereIn('id', $this->pickedUserIds)->get();
+        return User::query()->inCurrentChurch()->whereIn('id', $this->pickedUserIds)->get();
     }
 
     public function openAddMember(): void
@@ -371,7 +372,7 @@ new class extends Component {
             ->pluck('users.id')
             ->all();
 
-        $users = User::query()->whereIn('id', $userIds)->get();
+        $users = User::query()->inCurrentChurch()->whereIn('id', $userIds)->get();
 
         DB::transaction(function () use ($users, $existingIds): void {
             foreach ($users as $user) {

--- a/resources/views/pages/invitations/accept.blade.php
+++ b/resources/views/pages/invitations/accept.blade.php
@@ -42,6 +42,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
 
         $user = Auth::user();
 
+        abort_unless($user instanceof User, 403);
         abort_unless(Str::lower($user->email) === Str::lower($invitation->email), 403);
 
         DB::transaction(function () use ($invitation, $user): void {

--- a/resources/views/pages/invitations/accept.blade.php
+++ b/resources/views/pages/invitations/accept.blade.php
@@ -1,0 +1,200 @@
+<?php
+
+use App\Models\ChurchInvitation;
+use App\Models\Person;
+use App\Models\User;
+use App\Support\CurrentChurch;
+use Illuminate\Auth\Events\Registered;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Redirect;
+use Illuminate\Support\Str;
+use Illuminate\Validation\Rules;
+use Livewire\Attributes\Layout;
+use Livewire\Attributes\Locked;
+use Livewire\Component;
+
+new #[Layout('components.layouts.auth')] class extends Component {
+    #[Locked]
+    public string $token = '';
+
+    public string $name = '';
+    public string $password = '';
+    public string $password_confirmation = '';
+
+    public function mount(string $token): void
+    {
+        $this->token = $token;
+
+        $invitation = $this->invitation();
+
+        abort_unless($invitation->isPending(), 404);
+    }
+
+    /**
+     * Accept as the logged-in user whose email matches the invitation.
+     */
+    public function join(): void
+    {
+        $invitation = $this->invitation();
+
+        abort_unless($invitation->isPending(), 404);
+
+        $user = Auth::user();
+
+        abort_unless(Str::lower($user->email) === Str::lower($invitation->email), 403);
+
+        DB::transaction(function () use ($invitation, $user): void {
+            $invitation->church->addMember($user, $invitation->accessRoles());
+            $user->switchChurch($invitation->church);
+            $invitation->forceFill(['accepted_at' => now()])->save();
+        });
+
+        $this->redirect(route('dashboard'), navigate: false);
+    }
+
+    /**
+     * Accept as a brand-new user: clicking the emailed link proves mailbox
+     * ownership, so the account is created already verified.
+     */
+    public function register(): void
+    {
+        $invitation = $this->invitation();
+
+        abort_unless($invitation->isPending(), 404);
+        abort_if(Auth::check(), 403);
+        abort_if(User::query()->where('email', $invitation->email)->exists(), 403);
+
+        $validated = $this->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'password' => ['required', 'string', 'confirmed', Rules\Password::defaults()],
+        ]);
+
+        $user = DB::transaction(function () use ($invitation, $validated): User {
+            $person = app(CurrentChurch::class)->runAs($invitation->church, function () use ($invitation, $validated): Person {
+                [$first, $last] = array_pad(preg_split('/\s+/', trim($validated['name']), 2), 2, '');
+
+                return Person::firstOrCreate([
+                    'email' => Str::lower($invitation->email),
+                ], [
+                    'first_name' => $first,
+                    'last_name' => $last,
+                ]);
+            });
+
+            $user = User::create([
+                'name' => $validated['name'],
+                'email' => $invitation->email,
+                'password' => $validated['password'],
+                'person_id' => $person->id,
+            ]);
+            $user->forceFill(['email_verified_at' => now()])->save();
+
+            $invitation->church->addMember($user, $invitation->accessRoles());
+            $user->forceFill(['current_church_id' => $invitation->church_id])->save();
+
+            $invitation->forceFill(['accepted_at' => now()])->save();
+
+            return $user;
+        });
+
+        event(new Registered($user));
+
+        Auth::login($user);
+
+        $this->redirect(route('dashboard'), navigate: false);
+    }
+
+    public function goToLogin(): void
+    {
+        Redirect::setIntendedUrl(route('invitations.accept', $this->token));
+
+        $this->redirect(route('login'), navigate: false);
+    }
+
+    public function invitation(): ChurchInvitation
+    {
+        return ChurchInvitation::query()
+            ->where('token', $this->token)
+            ->with('church')
+            ->firstOrFail();
+    }
+}; ?>
+
+@php
+    $invitation = $this->invitation();
+    $church = $invitation->church;
+    $existingUser = App\Models\User::query()->where('email', $invitation->email)->exists();
+    $emailMatches = auth()->check() && Illuminate\Support\Str::lower(auth()->user()->email) === Illuminate\Support\Str::lower($invitation->email);
+@endphp
+
+<div class="flex flex-col gap-6">
+    <x-auth-header
+        :title="__('Join :church', ['church' => $church->name])"
+        :description="__('You have been invited to join :church on Stave.', ['church' => $church->name])"
+    />
+
+    @auth
+        @if ($emailMatches)
+            <flux:button variant="primary" class="w-full" wire:click="join">
+                {{ __('Accept invitation') }}
+            </flux:button>
+        @else
+            <flux:callout icon="exclamation-triangle" variant="warning">
+                <flux:callout.text>
+                    {{ __('This invitation was sent to :email, but you are signed in as :current. Log out first to accept it.', ['email' => $invitation->email, 'current' => auth()->user()->email]) }}
+                </flux:callout.text>
+            </flux:callout>
+        @endif
+    @endauth
+
+    @guest
+        @if ($existingUser)
+            <flux:text class="text-center">
+                {{ __('This invitation was sent to :email. Log in with that account to accept it.', ['email' => $invitation->email]) }}
+            </flux:text>
+
+            <flux:button variant="primary" class="w-full" wire:click="goToLogin">
+                {{ __('Log in to accept') }}
+            </flux:button>
+        @else
+            <form wire:submit="register" class="flex flex-col gap-6">
+                <flux:input :label="__('Email address')" type="email" :value="$invitation->email" disabled />
+
+                <flux:input
+                    wire:model="name"
+                    :label="__('Name')"
+                    type="text"
+                    required
+                    autofocus
+                    autocomplete="name"
+                    :placeholder="__('Full name')"
+                />
+
+                <flux:input
+                    wire:model="password"
+                    :label="__('Password')"
+                    type="password"
+                    required
+                    autocomplete="new-password"
+                    :placeholder="__('Password')"
+                    viewable
+                />
+
+                <flux:input
+                    wire:model="password_confirmation"
+                    :label="__('Confirm password')"
+                    type="password"
+                    required
+                    autocomplete="new-password"
+                    :placeholder="__('Confirm password')"
+                    viewable
+                />
+
+                <flux:button type="submit" variant="primary" class="w-full">
+                    {{ __('Create account & join') }}
+                </flux:button>
+            </form>
+        @endif
+    @endguest
+</div>

--- a/resources/views/pages/messages/index.blade.php
+++ b/resources/views/pages/messages/index.blade.php
@@ -227,6 +227,7 @@ new class extends Component {
 
         /** @var EloquentCollection<int, User> */
         return User::query()
+            ->inCurrentChurch()
             ->where('id', '!=', $this->user()->id)
             ->whereNotIn('id', $this->composeRecipients)
             ->when($query !== '', fn ($builder) => $builder->where(fn ($inner) => $inner
@@ -249,6 +250,7 @@ new class extends Component {
         $order = array_flip($this->composeRecipients);
 
         return User::query()
+            ->inCurrentChurch()
             ->whereIn('id', $this->composeRecipients)
             ->get()
             ->sortBy(fn (User $user): int => $order[$user->id] ?? 0)
@@ -264,7 +266,7 @@ new class extends Component {
 
         if ($count === 1) {
             $existing = $this->existingOneToOne($recipients[0]);
-            $recipient = User::find($recipients[0]);
+            $recipient = User::query()->inCurrentChurch()->find($recipients[0]);
             $name = $recipient instanceof User ? $recipient->name : 'this person';
 
             if ($existing && $this->addPersonFrom !== null) {

--- a/resources/views/pages/services/show.blade.php
+++ b/resources/views/pages/services/show.blade.php
@@ -39,7 +39,10 @@ new class extends Component {
 
     public function viewBulletin(): void
     {
-        $this->redirectRoute('bulletin.show', ['service' => $this->form->service], navigate: true);
+        $this->redirectRoute('bulletin.show', [
+            'church' => $this->form->service->church,
+            'service' => $this->form->service,
+        ], navigate: true);
     }
 
     public function duplicate(): void

--- a/resources/views/pages/settings/church-invitations.blade.php
+++ b/resources/views/pages/settings/church-invitations.blade.php
@@ -1,0 +1,234 @@
+<?php
+
+use App\Enums\AccessRole;
+use App\Mail\ChurchInvitationMail;
+use App\Models\Church;
+use App\Models\ChurchInvitation;
+use App\Support\QrCode;
+use Flux\Flux;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Str;
+use Livewire\Attributes\Computed;
+use Livewire\Component;
+
+new class extends Component {
+    public string $email = '';
+
+    /** @var array<int, string> */
+    public array $roles = [];
+
+    public function mount(): void
+    {
+        abort_unless(Auth::user()->can('manageMembers', $this->church()), 403);
+    }
+
+    public function invite(): void
+    {
+        $church = $this->church();
+
+        $this->authorize('manageMembers', $church);
+
+        $this->validate([
+            'email' => ['required', 'string', 'lowercase', 'email', 'max:255'],
+            'roles' => ['array'],
+            'roles.*' => ['string', Illuminate\Validation\Rule::enum(AccessRole::class)],
+        ]);
+
+        $email = Str::lower($this->email);
+
+        $alreadyMember = $church->users()->where('email', $email)->exists();
+
+        if ($alreadyMember) {
+            $this->addError('email', __('That person is already a member of this church.'));
+
+            return;
+        }
+
+        $invitation = ChurchInvitation::createFor(
+            $church,
+            $email,
+            array_map(fn (string $value): AccessRole => AccessRole::from($value), $this->roles),
+            Auth::user(),
+        );
+
+        Mail::to($email)->send(new ChurchInvitationMail($invitation));
+
+        $this->reset('email', 'roles');
+        unset($this->invitations);
+
+        Flux::toast(variant: 'success', text: __('Invitation sent.'));
+    }
+
+    public function resend(int $invitationId): void
+    {
+        $church = $this->church();
+
+        $this->authorize('manageMembers', $church);
+
+        $invitation = $church->invitations()->whereKey($invitationId)->firstOrFail();
+
+        // Refresh the token and expiry, then re-send.
+        $invitation = ChurchInvitation::createFor(
+            $church,
+            $invitation->email,
+            $invitation->accessRoles(),
+            Auth::user(),
+        );
+
+        Mail::to($invitation->email)->send(new ChurchInvitationMail($invitation));
+
+        unset($this->invitations);
+
+        Flux::toast(variant: 'success', text: __('Invitation re-sent.'));
+    }
+
+    public function revoke(int $invitationId): void
+    {
+        $church = $this->church();
+
+        $this->authorize('manageMembers', $church);
+
+        $church->invitations()->whereKey($invitationId)->delete();
+
+        unset($this->invitations);
+
+        Flux::toast(variant: 'success', text: __('Invitation revoked.'));
+    }
+
+    public function regenerateJoinLink(): void
+    {
+        $church = $this->church();
+
+        $this->authorize('manageMembers', $church);
+
+        $church->regenerateJoinToken();
+
+        Flux::toast(variant: 'success', text: __('Join link regenerated. Previously shared links and QR codes no longer work.'));
+    }
+
+    public function disableJoinLink(): void
+    {
+        $church = $this->church();
+
+        $this->authorize('manageMembers', $church);
+
+        $church->disableJoinToken();
+
+        Flux::toast(variant: 'success', text: __('Join link disabled.'));
+    }
+
+    /** @return Collection<int, ChurchInvitation> */
+    #[Computed]
+    public function invitations(): Collection
+    {
+        return $this->church()->invitations()
+            ->whereNull('accepted_at')
+            ->orderByDesc('created_at')
+            ->get();
+    }
+
+    #[Computed]
+    public function joinUrl(): ?string
+    {
+        $token = $this->church()->join_token;
+
+        return $token !== null ? route('churches.join', $token) : null;
+    }
+
+    private function church(): Church
+    {
+        return Auth::user()->currentChurch;
+    }
+}; ?>
+
+<section class="w-full">
+    @include('partials.settings-heading')
+
+    <x-settings.layout :heading="__('Invitations')" :subheading="__('Invite people to join your church')">
+        <form wire:submit="invite" class="my-6 w-full space-y-6">
+            <flux:input wire:model="email" :label="__('Email address')" type="email" required placeholder="name@example.com" />
+
+            <flux:checkbox.group wire:model="roles" :label="__('Access roles')" :description="__('Optional. Members without roles can still view groups and messages.')">
+                @foreach (AccessRole::cases() as $role)
+                    <flux:checkbox :value="$role->value" :label="$role->label()" :description="$role->description()" />
+                @endforeach
+            </flux:checkbox.group>
+
+            <flux:button type="submit" variant="primary">{{ __('Send invitation') }}</flux:button>
+        </form>
+
+        <flux:separator class="my-8" />
+
+        <flux:heading class="mb-4 font-semibold">{{ __('Pending invitations') }}</flux:heading>
+
+        @if ($this->invitations->isEmpty())
+            <flux:text>{{ __('No pending invitations.') }}</flux:text>
+        @else
+            <div class="space-y-3">
+                @foreach ($this->invitations as $invitation)
+                    <div wire:key="invitation-{{ $invitation->id }}" class="flex items-center justify-between gap-3 rounded-lg border border-zinc-200 px-4 py-3 dark:border-zinc-700">
+                        <div class="min-w-0">
+                            <div class="truncate text-sm font-medium">{{ $invitation->email }}</div>
+                            <div class="text-xs text-zinc-500">
+                                @if ($invitation->isExpired())
+                                    {{ __('Expired :date', ['date' => $invitation->expires_at->toFormattedDateString()]) }}
+                                @else
+                                    {{ __('Expires :date', ['date' => $invitation->expires_at->toFormattedDateString()]) }}
+                                @endif
+                                @if ($invitation->accessRoles() !== [])
+                                    · {{ collect($invitation->accessRoles())->map(fn ($role) => $role->shortLabel())->implode(', ') }}
+                                @endif
+                            </div>
+                        </div>
+                        <div class="flex shrink-0 items-center gap-2">
+                            <flux:button size="sm" variant="subtle" wire:click="resend({{ $invitation->id }})">{{ __('Resend') }}</flux:button>
+                            <flux:button size="sm" variant="danger" wire:click="revoke({{ $invitation->id }})">{{ __('Revoke') }}</flux:button>
+                        </div>
+                    </div>
+                @endforeach
+            </div>
+        @endif
+
+        <flux:separator class="my-8" />
+
+        <flux:heading class="mb-1 font-semibold">{{ __('Join link') }}</flux:heading>
+        <flux:text class="mb-4">{{ __('Anyone with this link (or QR code) can join your church as a member with no staff roles. Share it in a bulletin or post it in the foyer.') }}</flux:text>
+
+        @if ($this->joinUrl)
+            <div class="space-y-4">
+                <div class="flex items-center gap-2" x-data="{ copied: false }">
+                    <flux:input :value="$this->joinUrl" readonly class="flex-1" />
+                    <flux:button
+                        icon="clipboard"
+                        x-on:click="navigator.clipboard?.writeText(@js($this->joinUrl)); copied = true; setTimeout(() => copied = false, 1600)"
+                    >
+                        <span x-show="! copied">{{ __('Copy') }}</span>
+                        <span x-show="copied" style="display: none">{{ __('Copied!') }}</span>
+                    </flux:button>
+                </div>
+
+                <div class="inline-block rounded-xl border border-zinc-200 bg-white p-4 dark:border-zinc-700">
+                    {!! App\Support\QrCode::svg($this->joinUrl) !!}
+                </div>
+
+                <div class="flex items-center gap-2">
+                    <flux:button
+                        variant="subtle"
+                        wire:click="regenerateJoinLink"
+                        wire:confirm="{{ __('Regenerate the join link? Previously shared links and printed QR codes will stop working.') }}"
+                    >{{ __('Regenerate link') }}</flux:button>
+
+                    <flux:button
+                        variant="danger"
+                        wire:click="disableJoinLink"
+                        wire:confirm="{{ __('Disable the join link? No one will be able to join with it until you create a new one.') }}"
+                    >{{ __('Disable link') }}</flux:button>
+                </div>
+            </div>
+        @else
+            <flux:button variant="primary" wire:click="regenerateJoinLink">{{ __('Create join link') }}</flux:button>
+        @endif
+    </x-settings.layout>
+</section>

--- a/resources/views/pages/settings/church.blade.php
+++ b/resources/views/pages/settings/church.blade.php
@@ -49,18 +49,20 @@ new class extends Component {
             'logo' => ['nullable', 'image', 'max:2048'],
         ]);
 
+        $oldLogoPath = null;
+
         if ($this->logo instanceof TemporaryUploadedFile) {
             $path = $this->logo->store("churches/{$church->id}", 'digital-ocean');
-
-            if ($church->logo_path) {
-                Storage::disk('digital-ocean')->delete($church->logo_path);
-            }
-
+            $oldLogoPath = $church->logo_path;
             $church->logo_path = $path;
             $this->logo = null;
         }
 
         $church->fill(collect($validated)->except('logo')->all())->save();
+
+        if ($oldLogoPath) {
+            Storage::disk('digital-ocean')->delete($oldLogoPath);
+        }
 
         $this->dispatch('church-updated');
     }
@@ -72,8 +74,9 @@ new class extends Component {
         $this->authorize('update', $church);
 
         if ($church->logo_path) {
-            Storage::disk('digital-ocean')->delete($church->logo_path);
+            $oldPath = $church->logo_path;
             $church->forceFill(['logo_path' => null])->save();
+            Storage::disk('digital-ocean')->delete($oldPath);
         }
     }
 

--- a/resources/views/pages/settings/church.blade.php
+++ b/resources/views/pages/settings/church.blade.php
@@ -1,0 +1,130 @@
+<?php
+
+use App\Models\Church;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Storage;
+use Livewire\Component;
+use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
+use Livewire\WithFileUploads;
+
+new class extends Component {
+    use WithFileUploads;
+
+    public string $name = '';
+    public string $timezone = '';
+    public ?string $email = '';
+    public ?string $phone = '';
+    public ?string $address = '';
+    public ?string $website = '';
+
+    public ?TemporaryUploadedFile $logo = null;
+
+    public function mount(): void
+    {
+        $church = $this->church();
+
+        abort_unless(Auth::user()->can('update', $church), 403);
+
+        $this->name = $church->name;
+        $this->timezone = $church->timezone;
+        $this->email = $church->email;
+        $this->phone = $church->phone;
+        $this->address = $church->address;
+        $this->website = $church->website;
+    }
+
+    public function updateChurch(): void
+    {
+        $church = $this->church();
+
+        $this->authorize('update', $church);
+
+        $validated = $this->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'timezone' => ['required', 'string', 'timezone:all'],
+            'email' => ['nullable', 'string', 'lowercase', 'email', 'max:255'],
+            'phone' => ['nullable', 'string', 'max:50'],
+            'address' => ['nullable', 'string', 'max:500'],
+            'website' => ['nullable', 'string', 'url', 'max:255'],
+            'logo' => ['nullable', 'image', 'max:2048'],
+        ]);
+
+        if ($this->logo instanceof TemporaryUploadedFile) {
+            $path = $this->logo->store("churches/{$church->id}", 'digital-ocean');
+
+            if ($church->logo_path) {
+                Storage::disk('digital-ocean')->delete($church->logo_path);
+            }
+
+            $church->logo_path = $path;
+            $this->logo = null;
+        }
+
+        $church->fill(collect($validated)->except('logo')->all())->save();
+
+        $this->dispatch('church-updated');
+    }
+
+    public function removeLogo(): void
+    {
+        $church = $this->church();
+
+        $this->authorize('update', $church);
+
+        if ($church->logo_path) {
+            Storage::disk('digital-ocean')->delete($church->logo_path);
+            $church->forceFill(['logo_path' => null])->save();
+        }
+    }
+
+    private function church(): Church
+    {
+        return Auth::user()->currentChurch;
+    }
+}; ?>
+
+<section class="w-full">
+    @include('partials.settings-heading')
+
+    <x-settings.layout :heading="__('Church')" :subheading="__('Update your church\'s profile and contact information')">
+        <form wire:submit="updateChurch" class="my-6 w-full space-y-6">
+            <flux:input wire:model="name" :label="__('Church name')" type="text" required />
+
+            <flux:select wire:model="timezone" :label="__('Timezone')">
+                @foreach (timezone_identifiers_list() as $tz)
+                    <flux:select.option value="{{ $tz }}">{{ $tz }}</flux:select.option>
+                @endforeach
+            </flux:select>
+
+            <flux:input wire:model="email" :label="__('Contact email')" type="email" />
+
+            <flux:input wire:model="phone" :label="__('Phone')" type="text" />
+
+            <flux:textarea wire:model="address" :label="__('Address')" rows="3" />
+
+            <flux:input wire:model="website" :label="__('Website')" type="url" placeholder="https://example.org" />
+
+            <flux:field>
+                <flux:label>{{ __('Logo') }}</flux:label>
+
+                @if (auth()->user()->currentChurch->logo_path)
+                    <div class="mb-2 flex items-center gap-3">
+                        <flux:avatar size="lg" :src="auth()->user()->currentChurch->logo_url" :name="auth()->user()->currentChurch->name" />
+                        <flux:button size="sm" variant="subtle" wire:click="removeLogo">{{ __('Remove logo') }}</flux:button>
+                    </div>
+                @endif
+
+                <flux:input type="file" wire:model="logo" accept="image/*" />
+                <flux:error name="logo" />
+            </flux:field>
+
+            <div class="flex items-center gap-4">
+                <flux:button variant="primary" type="submit">{{ __('Save') }}</flux:button>
+
+                <x-action-message class="me-3" on="church-updated">
+                    {{ __('Saved.') }}
+                </x-action-message>
+            </div>
+        </form>
+    </x-settings.layout>
+</section>

--- a/resources/views/pages/templates/edit.blade.php
+++ b/resources/views/pages/templates/edit.blade.php
@@ -25,7 +25,7 @@ new class extends Component {
     #[Computed]
     public function users()
     {
-        return User::all();
+        return User::query()->inCurrentChurch()->orderBy('name')->get();
     }
 
     #[On("service-element-changed")]

--- a/resources/views/pages/templates/edit.blade.php
+++ b/resources/views/pages/templates/edit.blade.php
@@ -1,14 +1,15 @@
 <?php
 
 use App\Livewire\Forms\LiturgyElementForm;
-use Flux\Flux;
+use App\Livewire\Forms\TemplateForm;
 use App\Models\Template;
 use App\Models\User;
+use Flux\Flux;
+use Illuminate\Database\Eloquent\Collection;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\On;
 use Livewire\Attributes\Url;
 use Livewire\Component;
-use App\Livewire\Forms\TemplateForm;
 
 new class extends Component {
     public TemplateForm $form;
@@ -22,8 +23,9 @@ new class extends Component {
         $this->form->setTemplate($template);
     }
 
+    /** @return Collection<int, User> */
     #[Computed]
-    public function users()
+    public function users(): Collection
     {
         return User::query()->inCurrentChurch()->orderBy('name')->get();
     }

--- a/routes/web.php
+++ b/routes/web.php
@@ -14,7 +14,7 @@ Route::get('/bulletin', function () {
 })->name('bulletin.index');
 
 Route::livewire('/bulletin/{church:slug}', 'pages::bulletin.show')->name('bulletin.current');
-Route::livewire('/bulletin/{church:slug}/{service}', 'pages::bulletin.show')->name('bulletin.show');
+Route::livewire('/bulletin/{church:slug}/{service}', 'pages::bulletin.show')->name('bulletin.show')->scopeBindings();
 
 Route::livewire('/invitations/{token}/accept', 'pages::invitations.accept')->name('invitations.accept');
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,17 +1,32 @@
 <?php
 
+use App\Models\Church;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', fn () => view('welcome'))->name('home');
 
-Route::livewire('/bulletin', 'pages::bulletin.show')->name('bulletin.current');
-Route::livewire('/bulletin/{service}', 'pages::bulletin.show')->name('bulletin.show');
+Route::get('/bulletin', function () {
+    $church = auth()->user()?->currentChurch;
+
+    return $church instanceof Church
+        ? redirect()->route('bulletin.current', $church)
+        : redirect()->route('home');
+})->name('bulletin.index');
+
+Route::livewire('/bulletin/{church:slug}', 'pages::bulletin.show')->name('bulletin.current');
+Route::livewire('/bulletin/{church:slug}/{service}', 'pages::bulletin.show')->name('bulletin.show');
+
+Route::livewire('/invitations/{token}/accept', 'pages::invitations.accept')->name('invitations.accept');
+
+Route::livewire('/join/{token}', 'pages::churches.join')->name('churches.join');
 
 Route::livewire('dashboard', 'pages::dashboard.index')
     ->middleware(['auth', 'verified'])
     ->name('dashboard');
 
 Route::middleware(['auth'])->group(function (): void {
+    Route::livewire('churches/create', 'pages::churches.create')->name('churches.create');
+
     Route::redirect('settings', 'settings/profile');
 
     Route::name('settings.')
@@ -21,6 +36,8 @@ Route::middleware(['auth'])->group(function (): void {
             Route::livewire('password', 'pages::settings.password')->name('password');
             Route::livewire('appearance', 'pages::settings.appearance')->name('appearance');
             Route::livewire('notifications', 'pages::settings.notifications')->name('notifications');
+            Route::livewire('church', 'pages::settings.church')->name('church');
+            Route::livewire('church/invitations', 'pages::settings.church-invitations')->name('church-invitations');
         });
 
     Route::name('songs.')

--- a/tests/Browser/PublicBulletinSmokeTest.php
+++ b/tests/Browser/PublicBulletinSmokeTest.php
@@ -26,7 +26,7 @@ it('renders the public bulletin for guests without smoke', function (): void {
         ['type' => LiturgyElementType::SERMON, 'name' => 'The God Who Provides', 'order' => 4, 'assignee_id' => $preacher->id],
     ]);
 
-    $page = visit(route('bulletin.show', $service));
+    $page = visit(route('bulletin.show', [$service->church, $service]));
 
     $page->assertSee('Reforming Truth Church')
         ->assertSee('Doxology')
@@ -44,7 +44,7 @@ it('advances to the next element with the arrow key', function (): void {
         ['type' => LiturgyElementType::SERMON, 'name' => 'The God Who Provides', 'order' => 2],
     ]);
 
-    $page = visit(route('bulletin.show', $service));
+    $page = visit(route('bulletin.show', [$service->church, $service]));
 
     $page->assertSee('Call to Worship')
         ->keys('#follow-along', 'ArrowRight')

--- a/tests/Feature/Auth/RegistrationTest.php
+++ b/tests/Feature/Auth/RegistrationTest.php
@@ -1,5 +1,8 @@
 <?php
 
+use App\Enums\AccessRole;
+use App\Models\Church;
+use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Livewire\Livewire;
 
@@ -13,6 +16,7 @@ test('registration screen can be rendered', function (): void {
 
 test('new users can register', function (): void {
     $response = Livewire::test('pages::auth.register')
+        ->set('church_name', 'Test Community Church')
         ->set('name', 'Test User')
         ->set('email', 'test@example.com')
         ->set('password', 'password')
@@ -24,4 +28,34 @@ test('new users can register', function (): void {
         ->assertRedirect(route('dashboard', absolute: false));
 
     $this->assertAuthenticated();
+});
+
+test('a church name is required to register', function (): void {
+    Livewire::test('pages::auth.register')
+        ->set('name', 'Test User')
+        ->set('email', 'test@example.com')
+        ->set('password', 'password')
+        ->set('password_confirmation', 'password')
+        ->call('register')
+        ->assertHasErrors(['church_name' => 'required']);
+});
+
+test('registering creates a church with the registrant as its admin', function (): void {
+    Livewire::test('pages::auth.register')
+        ->set('church_name', 'Grace Fellowship')
+        ->set('name', 'Test User')
+        ->set('email', 'test@example.com')
+        ->set('password', 'password')
+        ->set('password_confirmation', 'password')
+        ->call('register')
+        ->assertHasNoErrors();
+
+    $church = Church::query()->where('name', 'Grace Fellowship')->sole();
+    $user = User::query()->where('email', 'test@example.com')->sole();
+
+    expect($church->slug)->toBe('grace-fellowship')
+        ->and($user->current_church_id)->toBe($church->id)
+        ->and($church->hasMember($user))->toBeTrue()
+        ->and($user->hasAccessRole(AccessRole::ADMIN, $church))->toBeTrue()
+        ->and($user->person->church_id)->toBe($church->id);
 });

--- a/tests/Feature/Churches/AccessRoleScopingTest.php
+++ b/tests/Feature/Churches/AccessRoleScopingTest.php
@@ -1,0 +1,83 @@
+<?php
+
+use App\Enums\AccessRole;
+use App\Models\Church;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+test('roles are scoped to the church they were granted in', function (): void {
+    $a = Church::factory()->create();
+    $b = Church::factory()->create();
+
+    $user = User::factory()->forChurch($a)->create();
+    $user->churches()->attach($b);
+
+    $user->grantAccessRole(AccessRole::ADMIN, $a);
+
+    expect($user->hasAccessRole(AccessRole::ADMIN, $a))->toBeTrue()
+        ->and($user->hasAccessRole(AccessRole::ADMIN, $b))->toBeFalse();
+
+    $this->assertDatabaseHas('user_access_roles', [
+        'user_id' => $user->id,
+        'church_id' => $a->id,
+        'role' => AccessRole::ADMIN->value,
+    ]);
+});
+
+test('an admin of one church has no capabilities in another', function (): void {
+    $a = Church::factory()->create();
+    $b = Church::factory()->create();
+
+    $user = User::factory()->forChurch($a)->create();
+    $user->churches()->attach($b);
+    $user->grantAccessRole(AccessRole::ADMIN, $a);
+
+    $this->actingAs($user);
+    expect($user->canManageLiturgy())->toBeTrue()
+        ->and($user->canAccessPastoralCare())->toBeTrue();
+
+    $user->switchChurch($b);
+    $fresh = $user->fresh();
+    $this->actingAs($fresh);
+
+    expect($fresh->canManageLiturgy())->toBeFalse()
+        ->and($fresh->canAccessPastoralCare())->toBeFalse();
+
+    $this->actingAs($fresh)->get('/pastoral-care')->assertForbidden();
+});
+
+test('granting without explicit church defaults to the current church', function (): void {
+    $a = Church::factory()->create();
+    $user = User::factory()->forChurch($a)->create();
+
+    $user->grantAccessRole(AccessRole::LITURGY_ADMIN);
+
+    $this->assertDatabaseHas('user_access_roles', [
+        'user_id' => $user->id,
+        'church_id' => $a->id,
+        'role' => AccessRole::LITURGY_ADMIN->value,
+    ]);
+
+    $user->revokeAccessRole(AccessRole::LITURGY_ADMIN);
+
+    $this->assertDatabaseMissing('user_access_roles', [
+        'user_id' => $user->id,
+        'church_id' => $a->id,
+        'role' => AccessRole::LITURGY_ADMIN->value,
+    ]);
+});
+
+test('the prayer schedule digest command stays inside each church', function (): void {
+    $a = Church::factory()->create();
+    $b = Church::factory()->create();
+
+    $userA = User::factory()->forChurch($a)->create();
+    $userB = User::factory()->forChurch($b)->create();
+
+    $this->artisan('stave:send-prayer-schedule')
+        ->expectsOutputToContain($a->name)
+        ->expectsOutputToContain($b->name)
+        ->assertSuccessful();
+});

--- a/tests/Feature/Churches/AccessRoleScopingTest.php
+++ b/tests/Feature/Churches/AccessRoleScopingTest.php
@@ -4,6 +4,7 @@ use App\Enums\AccessRole;
 use App\Models\Church;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Mail;
 
 uses(RefreshDatabase::class);
 
@@ -70,6 +71,8 @@ test('granting without explicit church defaults to the current church', function
 });
 
 test('the prayer schedule digest command stays inside each church', function (): void {
+    Mail::fake();
+
     $a = Church::factory()->create();
     $b = Church::factory()->create();
 

--- a/tests/Feature/Churches/ChurchSettingsTest.php
+++ b/tests/Feature/Churches/ChurchSettingsTest.php
@@ -1,0 +1,99 @@
+<?php
+
+use App\Enums\AccessRole;
+use App\Models\Church;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+test('guests are redirected from church settings', function (): void {
+    $this->get('/settings/church')->assertRedirect('/login');
+});
+
+test('only church admins can view church settings', function (?AccessRole $role, bool $allowed): void {
+    $church = Church::factory()->create();
+    $user = User::factory()->forChurch($church)->create();
+
+    if ($role instanceof AccessRole) {
+        $user->grantAccessRole($role, $church);
+    }
+
+    $this->actingAs($user)
+        ->get('/settings/church')
+        ->assertStatus($allowed ? 200 : 403);
+})->with([
+    'no roles' => [null, false],
+    'liturgy user' => [AccessRole::LITURGY_USER, false],
+    'liturgy admin' => [AccessRole::LITURGY_ADMIN, false],
+    'pastoral care admin' => [AccessRole::PASTORAL_CARE_ADMIN, false],
+    'admin' => [AccessRole::ADMIN, true],
+]);
+
+test('an admin can update the church profile', function (): void {
+    $church = Church::factory()->create();
+    $user = User::factory()->forChurch($church)->create();
+    $user->grantAccessRole(AccessRole::ADMIN, $church);
+
+    Livewire::actingAs($user)
+        ->test('pages::settings.church')
+        ->set('name', 'Renamed Church')
+        ->set('timezone', 'America/Chicago')
+        ->set('email', 'office@renamed.org')
+        ->set('phone', '555-0100')
+        ->set('address', '1 Main Street')
+        ->set('website', 'https://renamed.org')
+        ->call('updateChurch')
+        ->assertHasNoErrors();
+
+    $church->refresh();
+
+    expect($church->name)->toBe('Renamed Church')
+        ->and($church->timezone)->toBe('America/Chicago')
+        ->and($church->email)->toBe('office@renamed.org')
+        ->and($church->phone)->toBe('555-0100')
+        ->and($church->address)->toBe('1 Main Street')
+        ->and($church->website)->toBe('https://renamed.org');
+});
+
+test('an admin can upload and remove a church logo', function (): void {
+    Storage::fake('digital-ocean');
+
+    $church = Church::factory()->create();
+    $user = User::factory()->forChurch($church)->create();
+    $user->grantAccessRole(AccessRole::ADMIN, $church);
+
+    Livewire::actingAs($user)
+        ->test('pages::settings.church')
+        ->set('logo', UploadedFile::fake()->image('logo.png', 200, 200))
+        ->call('updateChurch')
+        ->assertHasNoErrors();
+
+    $church->refresh();
+    expect($church->logo_path)->not->toBeNull();
+    Storage::disk('digital-ocean')->assertExists($church->logo_path);
+
+    $path = $church->logo_path;
+
+    Livewire::actingAs($user)
+        ->test('pages::settings.church')
+        ->call('removeLogo');
+
+    expect($church->fresh()->logo_path)->toBeNull();
+    Storage::disk('digital-ocean')->assertMissing($path);
+});
+
+test('an admin of another church cannot edit this church', function (): void {
+    $a = Church::factory()->create();
+    $b = Church::factory()->create();
+
+    $user = User::factory()->forChurch($b)->create();
+    $user->churches()->attach($a);
+    $user->grantAccessRole(AccessRole::ADMIN, $a);
+
+    // Current church is B, where the user holds no roles.
+    $this->actingAs($user)->get('/settings/church')->assertForbidden();
+});

--- a/tests/Feature/Churches/InvitationTest.php
+++ b/tests/Feature/Churches/InvitationTest.php
@@ -1,0 +1,167 @@
+<?php
+
+use App\Enums\AccessRole;
+use App\Mail\ChurchInvitationMail;
+use App\Models\Church;
+use App\Models\ChurchInvitation;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Mail;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+test('only church admins can view the invitations page', function (): void {
+    $church = Church::factory()->create();
+    $member = User::factory()->forChurch($church)->create();
+    $admin = User::factory()->forChurch($church)->create();
+    $admin->grantAccessRole(AccessRole::ADMIN, $church);
+
+    $this->actingAs($member)->get('/settings/church/invitations')->assertForbidden();
+    $this->actingAs($admin)->get('/settings/church/invitations')->assertOk();
+});
+
+test('an admin can send an invitation with roles', function (): void {
+    Mail::fake();
+
+    $church = Church::factory()->create();
+    $admin = User::factory()->forChurch($church)->create();
+    $admin->grantAccessRole(AccessRole::ADMIN, $church);
+
+    Livewire::actingAs($admin)
+        ->test('pages::settings.church-invitations')
+        ->set('email', 'invitee@example.com')
+        ->set('roles', [AccessRole::LITURGY_ADMIN->value, AccessRole::PASTORAL_CARE_USER->value])
+        ->call('invite')
+        ->assertHasNoErrors();
+
+    $invitation = ChurchInvitation::query()->sole();
+
+    expect($invitation->church_id)->toBe($church->id)
+        ->and($invitation->email)->toBe('invitee@example.com')
+        ->and($invitation->roles)->toBe([AccessRole::LITURGY_ADMIN->value, AccessRole::PASTORAL_CARE_USER->value]);
+
+    Mail::assertQueued(ChurchInvitationMail::class, fn (ChurchInvitationMail $mail): bool => $mail->hasTo('invitee@example.com'));
+});
+
+test('existing members cannot be invited again', function (): void {
+    Mail::fake();
+
+    $church = Church::factory()->create();
+    $admin = User::factory()->forChurch($church)->create();
+    $admin->grantAccessRole(AccessRole::ADMIN, $church);
+    $member = User::factory()->forChurch($church)->create();
+
+    Livewire::actingAs($admin)
+        ->test('pages::settings.church-invitations')
+        ->set('email', $member->email)
+        ->call('invite')
+        ->assertHasErrors('email');
+
+    Mail::assertNothingQueued();
+});
+
+test('a logged-in user with a matching email can accept', function (): void {
+    $church = Church::factory()->create();
+    $invitee = User::factory()->create();
+
+    $invitation = ChurchInvitation::factory()->create([
+        'church_id' => $church->id,
+        'email' => $invitee->email,
+        'roles' => [AccessRole::LITURGY_USER->value],
+    ]);
+
+    Livewire::actingAs($invitee)
+        ->test('pages::invitations.accept', ['token' => $invitation->token])
+        ->call('join')
+        ->assertRedirect(route('dashboard'));
+
+    $invitee->refresh();
+
+    expect($church->hasMember($invitee))->toBeTrue()
+        ->and($invitee->current_church_id)->toBe($church->id)
+        ->and($invitee->hasAccessRole(AccessRole::LITURGY_USER, $church))->toBeTrue()
+        ->and($invitation->fresh()->accepted_at)->not->toBeNull();
+});
+
+test('a logged-in user with a different email cannot accept', function (): void {
+    $church = Church::factory()->create();
+    $otherChurch = Church::factory()->create();
+    $bystander = User::factory()->forChurch($otherChurch)->create();
+
+    $invitation = ChurchInvitation::factory()->create([
+        'church_id' => $church->id,
+        'email' => 'someone-else@example.com',
+    ]);
+
+    Livewire::actingAs($bystander)
+        ->test('pages::invitations.accept', ['token' => $invitation->token])
+        ->call('join')
+        ->assertForbidden();
+
+    expect($church->hasMember($bystander))->toBeFalse();
+});
+
+test('a new user can register through an invitation and skips email verification', function (): void {
+    $church = Church::factory()->create();
+
+    $invitation = ChurchInvitation::factory()->create([
+        'church_id' => $church->id,
+        'email' => 'fresh@example.com',
+        'roles' => [AccessRole::PASTORAL_CARE_ADMIN->value],
+    ]);
+
+    Livewire::test('pages::invitations.accept', ['token' => $invitation->token])
+        ->set('name', 'Fresh Face')
+        ->set('password', 'password')
+        ->set('password_confirmation', 'password')
+        ->call('register')
+        ->assertHasNoErrors()
+        ->assertRedirect(route('dashboard'));
+
+    $user = User::query()->where('email', 'fresh@example.com')->sole();
+
+    expect($user->email_verified_at)->not->toBeNull()
+        ->and($church->hasMember($user))->toBeTrue()
+        ->and($user->current_church_id)->toBe($church->id)
+        ->and($user->hasAccessRole(AccessRole::PASTORAL_CARE_ADMIN, $church))->toBeTrue()
+        ->and($user->personFor($church))->not->toBeNull();
+
+    $this->assertAuthenticated();
+});
+
+test('expired and accepted invitations 404', function (): void {
+    $expired = ChurchInvitation::factory()->expired()->create();
+    $accepted = ChurchInvitation::factory()->accepted()->create();
+
+    $this->get(route('invitations.accept', $expired->token))->assertNotFound();
+    $this->get(route('invitations.accept', $accepted->token))->assertNotFound();
+    $this->get(route('invitations.accept', 'nonsense-token'))->assertNotFound();
+});
+
+test('an admin can revoke and resend invitations', function (): void {
+    Mail::fake();
+
+    $church = Church::factory()->create();
+    $admin = User::factory()->forChurch($church)->create();
+    $admin->grantAccessRole(AccessRole::ADMIN, $church);
+
+    $invitation = ChurchInvitation::factory()->create([
+        'church_id' => $church->id,
+        'invited_by' => $admin->id,
+    ]);
+    $originalToken = $invitation->token;
+
+    Livewire::actingAs($admin)
+        ->test('pages::settings.church-invitations')
+        ->call('resend', $invitation->id);
+
+    expect($invitation->fresh()->token)->not->toBe($originalToken);
+    Mail::assertQueued(ChurchInvitationMail::class);
+
+    Livewire::actingAs($admin)
+        ->test('pages::settings.church-invitations')
+        ->call('revoke', $invitation->id);
+
+    $this->assertDatabaseMissing('church_invitations', ['id' => $invitation->id]);
+});

--- a/tests/Feature/Churches/JoinLinkTest.php
+++ b/tests/Feature/Churches/JoinLinkTest.php
@@ -1,0 +1,103 @@
+<?php
+
+use App\Enums\AccessRole;
+use App\Models\Church;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+test('the join page renders for a valid token and 404s otherwise', function (): void {
+    $church = Church::factory()->withJoinToken()->create(['name' => 'Open Door Chapel']);
+
+    $this->get(route('churches.join', $church->join_token))
+        ->assertOk()
+        ->assertSee('Open Door Chapel');
+
+    $this->get(route('churches.join', 'bogus-token'))->assertNotFound();
+});
+
+test('a rotated token invalidates old links', function (): void {
+    $church = Church::factory()->withJoinToken()->create();
+    $oldToken = $church->join_token;
+
+    $church->regenerateJoinToken();
+
+    $this->get(route('churches.join', $oldToken))->assertNotFound();
+    $this->get(route('churches.join', $church->fresh()->join_token))->assertOk();
+});
+
+test('a logged-in user can join through the link with zero roles', function (): void {
+    $home = Church::factory()->create();
+    $target = Church::factory()->withJoinToken()->create();
+
+    $user = User::factory()->forChurch($home)->create();
+
+    Livewire::actingAs($user)
+        ->test('pages::churches.join', ['token' => $target->join_token])
+        ->call('join')
+        ->assertRedirect(route('dashboard'));
+
+    $user->refresh();
+
+    expect($target->hasMember($user))->toBeTrue()
+        ->and($user->current_church_id)->toBe($target->id)
+        ->and($user->accessRoles($target))->toBeEmpty();
+});
+
+test('a guest can register through the join link and becomes a plain member', function (): void {
+    $church = Church::factory()->withJoinToken()->create();
+
+    Livewire::withQueryParams(['join' => $church->join_token])
+        ->test('pages::auth.register')
+        ->set('name', 'New Member')
+        ->set('email', 'member@example.com')
+        ->set('password', 'password')
+        ->set('password_confirmation', 'password')
+        ->call('register')
+        ->assertHasNoErrors()
+        ->assertRedirect(route('dashboard', absolute: false));
+
+    $user = User::query()->where('email', 'member@example.com')->sole();
+
+    expect($church->hasMember($user))->toBeTrue()
+        ->and($user->current_church_id)->toBe($church->id)
+        ->and($user->accessRoles($church))->toBeEmpty()
+        ->and(Church::query()->count())->toBe(1);
+
+    $this->assertAuthenticated();
+});
+
+test('registering through the join link does not require a church name', function (): void {
+    $church = Church::factory()->withJoinToken()->create();
+
+    Livewire::withQueryParams(['join' => $church->join_token])
+        ->test('pages::auth.register')
+        ->set('name', 'New Member')
+        ->set('email', 'member@example.com')
+        ->set('password', 'password')
+        ->set('password_confirmation', 'password')
+        ->call('register')
+        ->assertHasNoErrors();
+});
+
+test('admins can regenerate and disable the join link', function (): void {
+    $church = Church::factory()->withJoinToken()->create();
+    $admin = User::factory()->forChurch($church)->create();
+    $admin->grantAccessRole(AccessRole::ADMIN, $church);
+
+    $original = $church->join_token;
+
+    Livewire::actingAs($admin)
+        ->test('pages::settings.church-invitations')
+        ->call('regenerateJoinLink');
+
+    expect($church->fresh()->join_token)->not->toBe($original);
+
+    Livewire::actingAs($admin)
+        ->test('pages::settings.church-invitations')
+        ->call('disableJoinLink');
+
+    expect($church->fresh()->join_token)->toBeNull();
+});

--- a/tests/Feature/Churches/RoleEditingGuardTest.php
+++ b/tests/Feature/Churches/RoleEditingGuardTest.php
@@ -1,0 +1,53 @@
+<?php
+
+use App\Enums\AccessRole;
+use App\Models\Church;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+test('non-admins cannot change access roles from the people drawer', function (): void {
+    $church = Church::factory()->create();
+    $editor = User::factory()->forChurch($church)->create();
+    $target = User::factory()->forChurch($church)->create();
+
+    Livewire::actingAs($editor)
+        ->test('people.drawer')
+        ->call('openPerson', $target->person->id)
+        ->set('accessRoles.'.AccessRole::LITURGY_ADMIN->value, true)
+        ->call('save')
+        ->assertForbidden();
+
+    expect($target->fresh()->hasAccessRole(AccessRole::LITURGY_ADMIN, $church))->toBeFalse();
+});
+
+test('admins can change access roles from the people drawer', function (): void {
+    $church = Church::factory()->create();
+    $editor = User::factory()->forChurch($church)->create();
+    $editor->grantAccessRole(AccessRole::ADMIN, $church);
+    $target = User::factory()->forChurch($church)->create();
+
+    Livewire::actingAs($editor)
+        ->test('people.drawer')
+        ->call('openPerson', $target->person->id)
+        ->set('accessRoles.'.AccessRole::LITURGY_ADMIN->value, true)
+        ->call('save');
+
+    expect($target->fresh()->hasAccessRole(AccessRole::LITURGY_ADMIN, $church))->toBeTrue();
+});
+
+test('the last admin of a church cannot be demoted', function (): void {
+    $church = Church::factory()->create();
+    $admin = User::factory()->forChurch($church)->create();
+    $admin->grantAccessRole(AccessRole::ADMIN, $church);
+
+    Livewire::actingAs($admin)
+        ->test('people.drawer')
+        ->call('openPerson', $admin->person->id)
+        ->set('accessRoles.'.AccessRole::ADMIN->value, false)
+        ->call('save');
+
+    expect($admin->fresh()->hasAccessRole(AccessRole::ADMIN, $church))->toBeTrue();
+});

--- a/tests/Feature/Churches/ScopingTest.php
+++ b/tests/Feature/Churches/ScopingTest.php
@@ -1,0 +1,133 @@
+<?php
+
+use App\Enums\LiturgyElementType;
+use App\Models\Church;
+use App\Models\Group;
+use App\Models\Person;
+use App\Models\Service;
+use App\Models\Song;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+test('index pages only show records from the current church', function (): void {
+    $a = Church::factory()->create();
+    $b = Church::factory()->create();
+
+    Song::factory()->create(['church_id' => $a->id, 'name' => 'Alpha Anthem']);
+    Song::factory()->create(['church_id' => $b->id, 'name' => 'Beta Ballad']);
+    Service::factory()->create(['church_id' => $a->id, 'title' => 'Alpha Service', 'date' => now()->addDay()]);
+    Service::factory()->create(['church_id' => $b->id, 'title' => 'Beta Service', 'date' => now()->addDay()]);
+    Person::factory()->create(['church_id' => $a->id, 'first_name' => 'Alpha', 'last_name' => 'Member']);
+    Person::factory()->create(['church_id' => $b->id, 'first_name' => 'Beta', 'last_name' => 'Stranger']);
+    Group::factory()->public()->create(['church_id' => $a->id, 'name' => 'Alpha Fellowship']);
+    Group::factory()->public()->create(['church_id' => $b->id, 'name' => 'Beta Fellowship']);
+
+    $user = User::factory()->forChurch($a)->create();
+
+    $this->actingAs($user)->get('/songs')->assertOk()
+        ->assertSee('Alpha Anthem')->assertDontSee('Beta Ballad');
+
+    $this->actingAs($user)->get('/services')->assertOk()
+        ->assertSee('Alpha Service')->assertDontSee('Beta Service');
+
+    $this->actingAs($user)->get('/people')->assertOk()
+        ->assertSee('Alpha')->assertDontSee('Stranger');
+
+    $this->actingAs($user)->get('/groups')->assertOk()
+        ->assertSee('Alpha Fellowship')->assertDontSee('Beta Fellowship');
+});
+
+test('route model binding 404s for records of another church', function (): void {
+    $a = Church::factory()->create();
+    $b = Church::factory()->create();
+
+    $foreignSong = Song::factory()->create(['church_id' => $b->id]);
+    $foreignService = Service::factory()->create(['church_id' => $b->id]);
+
+    $user = User::factory()->forChurch($a)->create();
+
+    $this->actingAs($user)->get("/songs/{$foreignSong->id}")->assertNotFound();
+    $this->actingAs($user)->get("/songs/{$foreignSong->id}/edit")->assertNotFound();
+    $this->actingAs($user)->get("/services/{$foreignService->id}")->assertNotFound();
+});
+
+test('factory-created records default to a single shared church', function (): void {
+    $song = Song::factory()->create();
+    $service = Service::factory()->create();
+    $user = User::factory()->create();
+
+    expect($song->church_id)->not->toBeNull()
+        ->and($service->church_id)->toBe($song->church_id)
+        ->and($user->current_church_id)->toBe($song->church_id);
+});
+
+test('last used date ignores usage recorded in another church', function (): void {
+    $a = Church::factory()->create();
+    $b = Church::factory()->create();
+
+    $song = Song::factory()->create(['church_id' => $a->id, 'name' => 'Shared Name']);
+
+    // Church B (incorrectly or coincidentally) references church A's song id.
+    $foreignService = Service::factory()->create(['church_id' => $b->id, 'date' => now()->subWeek()]);
+    $foreignService->liturgyElements()->create([
+        'type' => LiturgyElementType::SONG,
+        'content_type' => Song::class,
+        'content_id' => $song->id,
+        'order' => 1,
+        'name' => 'Song',
+        'church_id' => $b->id,
+    ]);
+
+    $user = User::factory()->forChurch($a)->create();
+    $this->actingAs($user);
+
+    expect(Song::withLastUsedDate()->find($song->id)->last_used_date)->toBeNull();
+});
+
+test('upcoming assignments only include the current church', function (): void {
+    $a = Church::factory()->create();
+    $b = Church::factory()->create();
+
+    $user = User::factory()->forChurch($a)->create();
+    $user->churches()->attach($b);
+
+    $serviceA = Service::factory()->create(['church_id' => $a->id, 'date' => now()->addDays(2)]);
+    $serviceA->liturgyElements()->create([
+        'type' => LiturgyElementType::READING,
+        'order' => 1,
+        'name' => 'Reading A',
+        'assignee_id' => $user->id,
+        'church_id' => $a->id,
+    ]);
+
+    $serviceB = Service::factory()->create(['church_id' => $b->id, 'date' => now()->addDays(3)]);
+    $serviceB->liturgyElements()->create([
+        'type' => LiturgyElementType::READING,
+        'order' => 1,
+        'name' => 'Reading B',
+        'assignee_id' => $user->id,
+        'church_id' => $b->id,
+    ]);
+
+    $this->actingAs($user);
+
+    expect($user->upcomingAssignments()->pluck('name')->all())->toBe(['Reading A']);
+
+    $user->switchChurch($b);
+    $this->actingAs($user->fresh());
+
+    expect($user->fresh()->upcomingAssignments()->pluck('name')->all())->toBe(['Reading B']);
+});
+
+test('creating records stamps the current church automatically', function (): void {
+    $a = Church::factory()->create();
+    $user = User::factory()->forChurch($a)->create();
+
+    $this->actingAs($user);
+
+    $song = Song::create(['name' => 'Stamped Song']);
+
+    expect($song->church_id)->toBe($a->id);
+});

--- a/tests/Feature/Churches/SwitcherTest.php
+++ b/tests/Feature/Churches/SwitcherTest.php
@@ -1,0 +1,93 @@
+<?php
+
+use App\Models\Church;
+use App\Models\User;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+test('single-church users see their church without a switcher dropdown', function (): void {
+    $church = Church::factory()->create(['name' => 'Solo Chapel']);
+    $user = User::factory()->forChurch($church)->create();
+
+    Livewire::actingAs($user)
+        ->test('sidebar.church-switcher')
+        ->assertSee('Solo Chapel')
+        ->assertDontSee('chevrons-up-down');
+});
+
+test('multi-church users can switch churches', function (): void {
+    $a = Church::factory()->create(['name' => 'Alpha Chapel']);
+    $b = Church::factory()->create(['name' => 'Beta Chapel']);
+
+    $user = User::factory()->forChurch($a)->create();
+    $user->churches()->attach($b);
+
+    Livewire::actingAs($user)
+        ->test('sidebar.church-switcher')
+        ->assertSee('Alpha Chapel')
+        ->assertSee('Beta Chapel')
+        ->call('switch', $b->id)
+        ->assertRedirect(route('dashboard'));
+
+    expect($user->fresh()->current_church_id)->toBe($b->id);
+});
+
+test('users cannot switch to a church they are not a member of', function (): void {
+    $a = Church::factory()->create();
+    $b = Church::factory()->create();
+
+    $user = User::factory()->forChurch($a)->create();
+
+    $component = Livewire::actingAs($user)->test('sidebar.church-switcher');
+
+    expect(fn () => $component->call('switch', $b->id))
+        ->toThrow(ModelNotFoundException::class);
+
+    expect($user->fresh()->current_church_id)->toBe($a->id);
+});
+
+test('users without a church are redirected to onboarding', function (): void {
+    $user = User::factory()->create();
+    $user->churches()->detach();
+    $user->forceFill(['current_church_id' => null])->save();
+
+    $this->actingAs($user)
+        ->get('/songs')
+        ->assertRedirect(route('churches.create'));
+});
+
+test('a churchless user can create a church from onboarding', function (): void {
+    $user = User::factory()->create();
+    $user->churches()->detach();
+    $user->forceFill(['current_church_id' => null])->save();
+
+    Livewire::actingAs($user)
+        ->test('pages::churches.create')
+        ->set('name', 'Fresh Start Church')
+        ->call('create')
+        ->assertHasNoErrors()
+        ->assertRedirect(route('dashboard'));
+
+    $church = Church::query()->where('name', 'Fresh Start Church')->sole();
+
+    expect($user->fresh()->current_church_id)->toBe($church->id)
+        ->and($church->hasMember($user))->toBeTrue();
+});
+
+test('a stale current church self-heals to an existing membership', function (): void {
+    $a = Church::factory()->create();
+    $b = Church::factory()->create();
+
+    $user = User::factory()->forChurch($a)->create();
+    $user->churches()->attach($b);
+
+    // Simulate removal from the current church.
+    $user->churches()->detach($a);
+
+    $this->actingAs($user)->get('/songs')->assertOk();
+
+    expect($user->fresh()->current_church_id)->toBe($b->id);
+});

--- a/tests/Feature/People/DrawerTest.php
+++ b/tests/Feature/People/DrawerTest.php
@@ -108,6 +108,8 @@ test('ends a current office', function (): void {
 });
 
 test('access role changes are staged and persisted on save', function (): void {
+    auth()->user()->grantAccessRole(AccessRole::ADMIN);
+
     $person = Person::factory()->member()->create();
     User::factory()->create(['person_id' => $person->id]);
 

--- a/tests/Feature/PrayerSchedule/MondayEmailTest.php
+++ b/tests/Feature/PrayerSchedule/MondayEmailTest.php
@@ -2,6 +2,7 @@
 
 use App\Enums\MembershipStatus;
 use App\Mail\PrayerScheduleDigestMail;
+use App\Models\Church;
 use App\Models\PastoralNote;
 use App\Models\Person;
 use App\Models\PersonOffice;
@@ -9,6 +10,7 @@ use App\Models\PrayerRequest;
 use App\Models\PrayerScheduleSettings;
 use App\Models\User;
 use App\Services\PrayerScheduleService;
+use App\Support\CurrentChurch;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Mail;
@@ -19,9 +21,19 @@ uses(RefreshDatabase::class);
  * Collapse the cycle to a single week so everyone is scheduled in the current
  * week, making the command's output deterministic.
  */
+function updateSchedule(array $attributes): void
+{
+    $church = Church::query()->orderBy('id')->first() ?? Church::factory()->create();
+
+    app(CurrentChurch::class)->runAs(
+        $church,
+        fn () => PrayerScheduleSettings::current()->update($attributes),
+    );
+}
+
 function singleWeekSchedule(): void
 {
-    PrayerScheduleSettings::current()->update([
+    updateSchedule([
         'cycle_weeks' => 1,
         'anchor_date' => Carbon::now()->startOfWeek(Carbon::MONDAY),
         'include_statuses' => [MembershipStatus::MEMBER->value, MembershipStatus::CATECHUMEN->value],
@@ -118,7 +130,7 @@ test('nothing is sent when no one is scheduled for the week', function (): void 
     makeElder();
 
     // Exclude every status so the rotation is empty.
-    PrayerScheduleSettings::current()->update(['include_statuses' => []]);
+    updateSchedule(['include_statuses' => []]);
 
     $this->artisan('stave:send-prayer-schedule')
         ->expectsOutputToContain('nothing to send')

--- a/tests/Feature/PublicBulletinTest.php
+++ b/tests/Feature/PublicBulletinTest.php
@@ -77,6 +77,13 @@ it('returns 404 for an unknown service id', function (): void {
     $this->get('/bulletin/999999')->assertNotFound();
 });
 
+it('returns 404 for a service belonging to another church', function (): void {
+    $otherChurch = Church::factory()->create();
+    $foreignService = Service::factory()->create(['church_id' => $otherChurch->id]);
+
+    $this->get(route('bulletin.show', [$this->church, $foreignService]))->assertNotFound();
+});
+
 it('shows song lyrics and CCLI details', function (): void {
     $song = Song::factory()->create([
         'name' => 'Doxology',

--- a/tests/Feature/PublicBulletinTest.php
+++ b/tests/Feature/PublicBulletinTest.php
@@ -2,6 +2,7 @@
 
 use App\Enums\LiturgyElementType;
 use App\Enums\ReadingType;
+use App\Models\Church;
 use App\Models\Reading;
 use App\Models\Service;
 use App\Models\Song;
@@ -9,6 +10,10 @@ use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
 uses(RefreshDatabase::class);
+
+beforeEach(function (): void {
+    $this->church = Church::factory()->create();
+});
 
 it('lets guests view a service bulletin by id', function (): void {
     $service = Service::factory()->create([
@@ -22,7 +27,7 @@ it('lets guests view a service bulletin by id', function (): void {
         'order' => 1,
     ]);
 
-    $this->get(route('bulletin.show', $service))
+    $this->get(route('bulletin.show', [$this->church, $service]))
         ->assertSuccessful()
         ->assertSee('Prayer of Confession')
         ->assertSee('Sun, May 3, 2026');
@@ -38,7 +43,7 @@ it('resolves the soonest upcoming service on /bulletin', function (): void {
     Service::factory()->create(['date' => now()->addWeek()])
         ->liturgyElements()->create(['type' => LiturgyElementType::SERMON, 'name' => 'Future Sermon', 'order' => 1]);
 
-    $this->get(route('bulletin.current'))
+    $this->get(route('bulletin.current', $this->church))
         ->assertSuccessful()
         ->assertSee('Todays Sermon')
         ->assertDontSee('Past Sermon')
@@ -56,14 +61,14 @@ it('shows the empty state when only past services exist', function (): void {
     Service::factory()->create(['date' => now()->subWeek()])
         ->liturgyElements()->create(['type' => LiturgyElementType::SERMON, 'name' => 'Past Sermon', 'order' => 1]);
 
-    $this->get(route('bulletin.current'))
+    $this->get(route('bulletin.current', $this->church))
         ->assertSuccessful()
         ->assertSee('No upcoming service is scheduled')
         ->assertDontSee('Past Sermon');
 });
 
 it('shows the empty state when no services exist', function (): void {
-    $this->get(route('bulletin.current'))
+    $this->get(route('bulletin.current', $this->church))
         ->assertSuccessful()
         ->assertSee('No upcoming service is scheduled');
 });
@@ -91,7 +96,7 @@ it('shows song lyrics and CCLI details', function (): void {
         'content_id' => $song->id,
     ]);
 
-    $this->get(route('bulletin.show', $service))
+    $this->get(route('bulletin.show', [$this->church, $service]))
         ->assertSuccessful()
         ->assertSee('Praise God, from whom all blessings flow')
         ->assertSee('Thomas Ken')
@@ -115,7 +120,7 @@ it('shows reading text with the reading type as the kind label', function (): vo
         'content_id' => $reading->id,
     ]);
 
-    $this->get(route('bulletin.show', $service))
+    $this->get(route('bulletin.show', [$this->church, $service]))
         ->assertSuccessful()
         ->assertSee('Sing to the LORD with thanksgiving')
         ->assertSee('Opening Reading')
@@ -139,7 +144,7 @@ it('strips dangerous html from song lyrics before the public page renders it', f
         'content_id' => $song->id,
     ]);
 
-    $this->get(route('bulletin.show', $service))
+    $this->get(route('bulletin.show', [$this->church, $service]))
         ->assertSuccessful()
         ->assertSee('Praise God')
         ->assertDontSee('alert(1)');
@@ -162,7 +167,7 @@ it('strips dangerous html from reading text before the public page renders it', 
         'content_id' => $reading->id,
     ]);
 
-    $this->get(route('bulletin.show', $service))
+    $this->get(route('bulletin.show', [$this->church, $service]))
         ->assertSuccessful()
         ->assertSee('Sing praises')
         ->assertDontSee('alert(1)');
@@ -179,7 +184,7 @@ it('hides assignees on non-sermon elements', function (): void {
         'assignee_id' => $user->id,
     ]);
 
-    $this->get(route('bulletin.show', $service))
+    $this->get(route('bulletin.show', [$this->church, $service]))
         ->assertSuccessful()
         ->assertDontSee('Hidden Assignee Name');
 });
@@ -195,7 +200,7 @@ it('shows the preacher on the sermon element', function (): void {
         'assignee_id' => $user->id,
     ]);
 
-    $this->get(route('bulletin.show', $service))
+    $this->get(route('bulletin.show', [$this->church, $service]))
         ->assertSuccessful()
         ->assertSee('Preaching')
         ->assertSee('Rev. Joshua Pangborn');
@@ -208,7 +213,7 @@ it('never renders internal service notes', function (): void {
     ]);
     $service->liturgyElements()->create(['type' => LiturgyElementType::SERMON, 'name' => 'Sermon', 'order' => 1]);
 
-    $this->get(route('bulletin.show', $service))
+    $this->get(route('bulletin.show', [$this->church, $service]))
         ->assertSuccessful()
         ->assertDontSee('Internal planning notes for staff only');
 });
@@ -224,7 +229,7 @@ it('excludes sections from the element count', function (): void {
         ['type' => LiturgyElementType::SERMON, 'name' => 'Sermon', 'order' => 5],
     ]);
 
-    $this->get(route('bulletin.show', $service))
+    $this->get(route('bulletin.show', [$this->church, $service]))
         ->assertSuccessful()
         ->assertSee('of 3');
 });
@@ -238,7 +243,7 @@ it('shows a no-content card for a contentless song', function (): void {
         'order' => 1,
     ]);
 
-    $this->get(route('bulletin.show', $service))
+    $this->get(route('bulletin.show', [$this->church, $service]))
         ->assertSuccessful()
         ->assertSee('No content was attached to this element yet.');
 });
@@ -251,7 +256,7 @@ it('shows the entering card on the first element of a movement', function (): vo
         ['type' => LiturgyElementType::READING, 'name' => 'Call to Worship', 'order' => 2],
     ]);
 
-    $this->get(route('bulletin.show', $service))
+    $this->get(route('bulletin.show', [$this->church, $service]))
         ->assertSuccessful()
         ->assertSee('Entering · God')
         ->assertSee('We start with a proclamation of God.');
@@ -266,7 +271,7 @@ it('keeps a trailing section with no following element in the stepper', function
         ['type' => LiturgyElementType::SECTION, 'name' => 'Sending', 'order' => 3],
     ]);
 
-    $this->get(route('bulletin.show', $service))
+    $this->get(route('bulletin.show', [$this->church, $service]))
         ->assertSuccessful()
         ->assertSee('God')
         ->assertSee('Sending');
@@ -281,7 +286,7 @@ it('keeps consecutive sections in the stepper', function (): void {
         ['type' => LiturgyElementType::SERMON, 'name' => 'The Sermon', 'order' => 3],
     ]);
 
-    $this->get(route('bulletin.show', $service))
+    $this->get(route('bulletin.show', [$this->church, $service]))
         ->assertSuccessful()
         ->assertSee('Adoration')
         ->assertSee('Confession');
@@ -290,7 +295,7 @@ it('keeps consecutive sections in the stepper', function (): void {
 it('renders a service with no elements without a counter', function (): void {
     $service = Service::factory()->create(['date' => now()]);
 
-    $this->get(route('bulletin.show', $service))
+    $this->get(route('bulletin.show', [$this->church, $service]))
         ->assertSuccessful()
         ->assertSee("This service doesn't have any elements yet.", false);
 });

--- a/tests/Feature/ReadingsTest.php
+++ b/tests/Feature/ReadingsTest.php
@@ -140,6 +140,8 @@ test('guests are redirected from the reading show page', function (): void {
 
 test('authenticated users can view the reading show page', function (): void {
     $user = User::factory()->create();
+    $this->actingAs($user);
+
     $reading = Reading::create([
         'title' => 'Test Reading',
         'type' => ReadingType::CREED->value,
@@ -164,6 +166,8 @@ test('guests are redirected from the reading edit page', function (): void {
 
 test('authenticated users can view the reading edit page', function (): void {
     $user = User::factory()->create();
+    $this->actingAs($user);
+
     $reading = Reading::create([
         'title' => 'Edit Me',
         'type' => ReadingType::LAW->value,
@@ -179,6 +183,8 @@ test('authenticated users can view the reading edit page', function (): void {
 
 test('authenticated users can update a reading', function (): void {
     $user = User::factory()->create();
+    $this->actingAs($user);
+
     $reading = Reading::create([
         'title' => 'Old Title',
         'type' => ReadingType::PRAYER->value,
@@ -199,6 +205,8 @@ test('authenticated users can update a reading', function (): void {
 
 test('authenticated users can delete a reading', function (): void {
     $user = User::factory()->create();
+    $this->actingAs($user);
+
     $reading = Reading::create([
         'title' => 'Delete Me',
         'type' => ReadingType::PRAISE->value,

--- a/tests/Feature/SeriesTest.php
+++ b/tests/Feature/SeriesTest.php
@@ -69,6 +69,8 @@ test('guests are redirected from the series show page', function (): void {
 
 test('authenticated users can view the series show page', function (): void {
     $user = User::factory()->create();
+    $this->actingAs($user);
+
     $series = Series::create([
         'name' => 'Test Series',
         'description' => '<p>Description</p>',
@@ -91,6 +93,8 @@ test('guests are redirected from the series edit page', function (): void {
 
 test('authenticated users can view the series edit page', function (): void {
     $user = User::factory()->create();
+    $this->actingAs($user);
+
     $series = Series::create([
         'name' => 'Edit Me',
         'description' => '<p>Description</p>',
@@ -105,6 +109,8 @@ test('authenticated users can view the series edit page', function (): void {
 
 test('authenticated users can update a series', function (): void {
     $user = User::factory()->create();
+    $this->actingAs($user);
+
     $series = Series::create([
         'name' => 'Old Name',
         'description' => '<p>Old description</p>',
@@ -124,6 +130,8 @@ test('authenticated users can update a series', function (): void {
 
 test('authenticated users can delete a series', function (): void {
     $user = User::factory()->create();
+    $this->actingAs($user);
+
     $series = Series::create([
         'name' => 'Delete Me',
         'description' => '<p>Description</p>',

--- a/tests/Feature/ServiceShowRedesignTest.php
+++ b/tests/Feature/ServiceShowRedesignTest.php
@@ -116,7 +116,7 @@ it('redirects to the bulletin view when View Bulletin is clicked', function (): 
 
     Livewire::test('pages::services.show', ['service' => $service])
         ->call('viewBulletin')
-        ->assertRedirect(route('bulletin.show', $service));
+        ->assertRedirect(route('bulletin.show', [$service->church, $service]));
 });
 
 it('inserts a new element after the anchor', function (): void {

--- a/tests/Feature/SongsTest.php
+++ b/tests/Feature/SongsTest.php
@@ -74,6 +74,8 @@ test('guests are redirected from the song show page', function (): void {
 
 test('authenticated users can view the song show page', function (): void {
     $user = User::factory()->create();
+    $this->actingAs($user);
+
     $song = Song::create([
         'name' => 'Test Song',
         'ccli_number' => null,
@@ -100,6 +102,8 @@ test('guests are redirected from the song edit page', function (): void {
 
 test('authenticated users can view the song edit page', function (): void {
     $user = User::factory()->create();
+    $this->actingAs($user);
+
     $song = Song::create([
         'name' => 'Edit Me',
         'ccli_number' => null,
@@ -116,6 +120,8 @@ test('authenticated users can view the song edit page', function (): void {
 
 test('authenticated users can update a song', function (): void {
     $user = User::factory()->create();
+    $this->actingAs($user);
+
     $song = Song::create([
         'name' => 'Old Title',
         'ccli_number' => '11111',
@@ -137,6 +143,8 @@ test('authenticated users can update a song', function (): void {
 
 test('authenticated users can delete a song', function (): void {
     $user = User::factory()->create();
+    $this->actingAs($user);
+
     $song = Song::create([
         'name' => 'Delete Me',
         'ccli_number' => null,
@@ -175,6 +183,8 @@ test('authenticated users can create a song with authors', function (): void {
 
 test('authenticated users can update a song with authors', function (): void {
     $user = User::factory()->create();
+    $this->actingAs($user);
+
     $song = Song::create([
         'name' => 'Old Title',
         'authors' => null,
@@ -214,6 +224,8 @@ test('song authors field is optional', function (): void {
 
 test('song show page displays authors when present', function (): void {
     $user = User::factory()->create();
+    $this->actingAs($user);
+
     $song = Song::create([
         'name' => 'Test Song',
         'authors' => 'John Newton, William Cowper',

--- a/tests/Feature/TemplatesTest.php
+++ b/tests/Feature/TemplatesTest.php
@@ -67,6 +67,8 @@ test('guests are redirected from the template show page', function (): void {
 
 test('authenticated users can view the template show page', function (): void {
     $user = User::factory()->create();
+    $this->actingAs($user);
+
     $template = Template::create([
         'name' => 'Test Template',
         'default' => false,
@@ -89,6 +91,8 @@ test('guests are redirected from the template edit page', function (): void {
 
 test('authenticated users can view the template edit page', function (): void {
     $user = User::factory()->create();
+    $this->actingAs($user);
+
     $template = Template::create([
         'name' => 'Edit Me',
         'default' => true,
@@ -103,6 +107,8 @@ test('authenticated users can view the template edit page', function (): void {
 
 test('authenticated users can update a template', function (): void {
     $user = User::factory()->create();
+    $this->actingAs($user);
+
     $template = Template::create([
         'name' => 'Old Name',
         'default' => false,
@@ -121,6 +127,8 @@ test('authenticated users can update a template', function (): void {
 
 test('authenticated users can delete a template', function (): void {
     $user = User::factory()->create();
+    $this->actingAs($user);
+
     $template = Template::create([
         'name' => 'Delete Me',
         'default' => false,


### PR DESCRIPTION
## Summary

- Introduces a `Church` model as the tenancy boundary; all domain models (people, services, songs, groups, etc.) gain a `church_id` via a `BelongsToChurch` trait that auto-stamps on creation and applies a global query scope.
- Access roles are now per-church — a user can be an admin in one church and a plain member in another. The `User` model gains church switching, per-church person linkage, and a cached role resolver.
- New member onboarding via three flows: email invitations (with role grants), shareable join links with QR codes, and registration with automatic church creation.
- `EnsureCurrentChurch` middleware self-heals stale church state and routes churchless users to onboarding. Backfill migration assigns all existing data to a first church.
- Comprehensive test suite covering data scoping, role isolation, invitations, join links, church switching, role editing guards, and church settings.

## Test plan
- [ ] Run `php artisan test` — all new `tests/Feature/Churches/` tests pass
- [ ] Register a new account and verify a church is created with the user as admin
- [ ] Use the join link flow (generate link in settings, open in incognito, register through it)
- [ ] Send an email invitation and accept it as both an existing and new user
- [ ] Switch between churches in the sidebar and verify data isolation
- [ ] Verify the backfill migration correctly assigns existing data on a fresh `php artisan migrate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multi-church support with an in-app church switcher, plus onboarding to create or join a church.
  * Added church invitations (email + accept links), join-link/QR code support, and church settings management (including logo).
* **Bug Fixes**
  * Enforced active-church scoping across pages, data, and permissions (including bulletin routing and message/member selection).
  * Improved “stave:send-prayer-schedule” digest output to be church-specific.
  * Prevented removing the last church administrator.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->