### PR TITLE
Move church settings and invitations to sidebar navigation

### DIFF
--- a/resources/views/components/layouts/app/sidebar.blade.php
+++ b/resources/views/components/layouts/app/sidebar.blade.php
@@ -39,6 +39,13 @@
                         <flux:sidebar.item icon="calendar-date-range" :href="route('prayer-schedule.index')" :current="request()->routeIs('prayer-schedule.*')" wire:navigate>{{ __('Prayer Schedule') }}</flux:sidebar.item>
                     @endif
                 </flux:sidebar.group>
+
+                @can('update', auth()->user()?->currentChurch)
+                    <flux:sidebar.item icon="cog-6-tooth" :href="route('church.settings')" :current="request()->routeIs('church.settings')" wire:navigate>{{ __('Church Settings') }}</flux:sidebar.item>
+                @endcan
+                @can('manageMembers', auth()->user()?->currentChurch)
+                    <flux:sidebar.item icon="envelope" :href="route('church.invitations')" :current="request()->routeIs('church.invitations')" wire:navigate>{{ __('Invitations') }}</flux:sidebar.item>
+                @endcan
             </flux:sidebar.nav>
 
             <flux:spacer />

--- a/resources/views/components/settings/layout.blade.php
+++ b/resources/views/components/settings/layout.blade.php
@@ -5,10 +5,6 @@
             <flux:navlist.item :href="route('settings.password')" :current="request()->routeIs('settings.password')" wire:navigate>{{ __('Password') }}</flux:navlist.item>
             <flux:navlist.item :href="route('settings.appearance')" :current="request()->routeIs('settings.appearance')" wire:navigate>{{ __('Appearance') }}</flux:navlist.item>
             <flux:navlist.item :href="route('settings.notifications')" :current="request()->routeIs('settings.notifications')" wire:navigate>{{ __('Notifications') }}</flux:navlist.item>
-            @can('update', auth()->user()->currentChurch)
-                <flux:navlist.item :href="route('settings.church')" :current="request()->routeIs('settings.church')" wire:navigate>{{ __('Church') }}</flux:navlist.item>
-                <flux:navlist.item :href="route('settings.church-invitations')" :current="request()->routeIs('settings.church-invitations')" wire:navigate>{{ __('Invitations') }}</flux:navlist.item>
-            @endcan
         </flux:navlist>
     </div>
 

--- a/resources/views/pages/church/invitations.blade.php
+++ b/resources/views/pages/church/invitations.blade.php
@@ -144,9 +144,13 @@ new class extends Component {
 }; ?>
 
 <section class="w-full">
-    @include('partials.settings-heading')
+    <div class="relative mb-6 w-full">
+        <flux:heading size="xl" level="1">{{ __('Invitations') }}</flux:heading>
+        <flux:subheading size="lg">{{ __('Invite people to join your church') }}</flux:subheading>
+        <flux:separator variant="subtle" />
+    </div>
 
-    <x-settings.layout :heading="__('Invitations')" :subheading="__('Invite people to join your church')">
+    <div class="w-full max-w-lg">
         <form wire:submit="invite" class="my-6 w-full space-y-6">
             <flux:input wire:model="email" :label="__('Email address')" type="email" required placeholder="name@example.com" />
 
@@ -230,5 +234,5 @@ new class extends Component {
         @else
             <flux:button variant="primary" wire:click="regenerateJoinLink">{{ __('Create join link') }}</flux:button>
         @endif
-    </x-settings.layout>
+    </div>
 </section>

--- a/resources/views/pages/church/settings.blade.php
+++ b/resources/views/pages/church/settings.blade.php
@@ -87,9 +87,13 @@ new class extends Component {
 }; ?>
 
 <section class="w-full">
-    @include('partials.settings-heading')
+    <div class="relative mb-6 w-full">
+        <flux:heading size="xl" level="1">{{ __('Church Settings') }}</flux:heading>
+        <flux:subheading size="lg">{{ __('Update your church\'s profile and contact information') }}</flux:subheading>
+        <flux:separator variant="subtle" />
+    </div>
 
-    <x-settings.layout :heading="__('Church')" :subheading="__('Update your church\'s profile and contact information')">
+    <div class="w-full max-w-lg">
         <form wire:submit="updateChurch" class="my-6 w-full space-y-6">
             <flux:input wire:model="name" :label="__('Church name')" type="text" required />
 
@@ -129,5 +133,5 @@ new class extends Component {
                 </x-action-message>
             </div>
         </form>
-    </x-settings.layout>
+    </div>
 </section>

--- a/routes/web.php
+++ b/routes/web.php
@@ -36,8 +36,13 @@ Route::middleware(['auth'])->group(function (): void {
             Route::livewire('password', 'pages::settings.password')->name('password');
             Route::livewire('appearance', 'pages::settings.appearance')->name('appearance');
             Route::livewire('notifications', 'pages::settings.notifications')->name('notifications');
-            Route::livewire('church', 'pages::settings.church')->name('church');
-            Route::livewire('church/invitations', 'pages::settings.church-invitations')->name('church-invitations');
+        });
+
+    Route::name('church.')
+        ->prefix('church')
+        ->group(function (): void {
+            Route::livewire('settings', 'pages::church.settings')->name('settings');
+            Route::livewire('invitations', 'pages::church.invitations')->name('invitations');
         });
 
     Route::name('songs.')

--- a/tests/Feature/Churches/ChurchSettingsTest.php
+++ b/tests/Feature/Churches/ChurchSettingsTest.php
@@ -11,7 +11,7 @@ use Livewire\Livewire;
 uses(RefreshDatabase::class);
 
 test('guests are redirected from church settings', function (): void {
-    $this->get('/settings/church')->assertRedirect('/login');
+    $this->get('/church/settings')->assertRedirect('/login');
 });
 
 test('only church admins can view church settings', function (?AccessRole $role, bool $allowed): void {
@@ -23,7 +23,7 @@ test('only church admins can view church settings', function (?AccessRole $role,
     }
 
     $this->actingAs($user)
-        ->get('/settings/church')
+        ->get('/church/settings')
         ->assertStatus($allowed ? 200 : 403);
 })->with([
     'no roles' => [null, false],
@@ -39,7 +39,7 @@ test('an admin can update the church profile', function (): void {
     $user->grantAccessRole(AccessRole::ADMIN, $church);
 
     Livewire::actingAs($user)
-        ->test('pages::settings.church')
+        ->test('pages::church.settings')
         ->set('name', 'Renamed Church')
         ->set('timezone', 'America/Chicago')
         ->set('email', 'office@renamed.org')
@@ -67,7 +67,7 @@ test('an admin can upload and remove a church logo', function (): void {
     $user->grantAccessRole(AccessRole::ADMIN, $church);
 
     Livewire::actingAs($user)
-        ->test('pages::settings.church')
+        ->test('pages::church.settings')
         ->set('logo', UploadedFile::fake()->image('logo.png', 200, 200))
         ->call('updateChurch')
         ->assertHasNoErrors();
@@ -79,7 +79,7 @@ test('an admin can upload and remove a church logo', function (): void {
     $path = $church->logo_path;
 
     Livewire::actingAs($user)
-        ->test('pages::settings.church')
+        ->test('pages::church.settings')
         ->call('removeLogo');
 
     expect($church->fresh()->logo_path)->toBeNull();
@@ -95,5 +95,5 @@ test('an admin of another church cannot edit this church', function (): void {
     $user->grantAccessRole(AccessRole::ADMIN, $a);
 
     // Current church is B, where the user holds no roles.
-    $this->actingAs($user)->get('/settings/church')->assertForbidden();
+    $this->actingAs($user)->get('/church/settings')->assertForbidden();
 });

--- a/tests/Feature/Churches/InvitationTest.php
+++ b/tests/Feature/Churches/InvitationTest.php
@@ -17,8 +17,8 @@ test('only church admins can view the invitations page', function (): void {
     $admin = User::factory()->forChurch($church)->create();
     $admin->grantAccessRole(AccessRole::ADMIN, $church);
 
-    $this->actingAs($member)->get('/settings/church/invitations')->assertForbidden();
-    $this->actingAs($admin)->get('/settings/church/invitations')->assertOk();
+    $this->actingAs($member)->get('/church/invitations')->assertForbidden();
+    $this->actingAs($admin)->get('/church/invitations')->assertOk();
 });
 
 test('an admin can send an invitation with roles', function (): void {
@@ -29,7 +29,7 @@ test('an admin can send an invitation with roles', function (): void {
     $admin->grantAccessRole(AccessRole::ADMIN, $church);
 
     Livewire::actingAs($admin)
-        ->test('pages::settings.church-invitations')
+        ->test('pages::church.invitations')
         ->set('email', 'invitee@example.com')
         ->set('roles', [AccessRole::LITURGY_ADMIN->value, AccessRole::PASTORAL_CARE_USER->value])
         ->call('invite')
@@ -53,7 +53,7 @@ test('existing members cannot be invited again', function (): void {
     $member = User::factory()->forChurch($church)->create();
 
     Livewire::actingAs($admin)
-        ->test('pages::settings.church-invitations')
+        ->test('pages::church.invitations')
         ->set('email', $member->email)
         ->call('invite')
         ->assertHasErrors('email');
@@ -153,14 +153,14 @@ test('an admin can revoke and resend invitations', function (): void {
     $originalToken = $invitation->token;
 
     Livewire::actingAs($admin)
-        ->test('pages::settings.church-invitations')
+        ->test('pages::church.invitations')
         ->call('resend', $invitation->id);
 
     expect($invitation->fresh()->token)->not->toBe($originalToken);
     Mail::assertQueued(ChurchInvitationMail::class);
 
     Livewire::actingAs($admin)
-        ->test('pages::settings.church-invitations')
+        ->test('pages::church.invitations')
         ->call('revoke', $invitation->id);
 
     $this->assertDatabaseMissing('church_invitations', ['id' => $invitation->id]);

--- a/tests/Feature/Churches/JoinLinkTest.php
+++ b/tests/Feature/Churches/JoinLinkTest.php
@@ -90,13 +90,13 @@ test('admins can regenerate and disable the join link', function (): void {
     $original = $church->join_token;
 
     Livewire::actingAs($admin)
-        ->test('pages::settings.church-invitations')
+        ->test('pages::church.invitations')
         ->call('regenerateJoinLink');
 
     expect($church->fresh()->join_token)->not->toBe($original);
 
     Livewire::actingAs($admin)
-        ->test('pages::settings.church-invitations')
+        ->test('pages::church.invitations')
         ->call('disableJoinLink');
 
     expect($church->fresh()->join_token)->toBeNull();


### PR DESCRIPTION
Church settings and invitations are organizational concerns, not personal account settings. This moves them from the user settings navlist into their own top-level route group (`/church/*`) with dedicated sidebar items gated by `update` and `manageMembers` policies respectively. Views are relocated to `pages/church/`, the settings layout wrapper is replaced with standalone page headings, and all tests are updated to match the new routes and component paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated Church navigation for Church Settings and Invitations.
  * Moved Church Settings and Invitations to the `/church/settings` and `/church/invitations` paths.
  * Navigation options now appear only for authorized users.
* **UI Improvements**
  * Updated Church Settings and Invitations pages with clearer headings and streamlined layouts.
  * Improved form sizing on the Church Settings page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->